### PR TITLE
WIP: Undo / Redo implementation

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -8,6 +8,8 @@
     <string name="link_text">Link</string>
     <string name="ordered_list_text">Ordered list</string>
     <string name="bulleted_list_text">Bulleted list</string>
+    <string name="undo_text">Undo</string>
+    <string name="redo_text">Redo</string>
     <string name="text_color_text">Text color</string>
     <string name="type_text">Type...</string>
     <string name="close_text">Close</string>

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -1,6 +1,8 @@
 package com.jjrodcast.textkit.editor.core
 
 import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.core.history.EditorHistoryManager
+import com.jjrodcast.textkit.editor.core.history.HistorySnapshot
 import com.jjrodcast.textkit.editor.core.models.TextEditorModel
 import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.parser.MentionType
@@ -20,9 +22,65 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
 
     internal val transaction by lazy { TextEditorTransaction(configuration) }
 
+    private val history = EditorHistoryManager()
+
     fun load(json: String, isViewer: Boolean) {
         transaction.loadWith(json, isViewer)
+        // The document was replaced; snapshots taken against the previous one are meaningless.
+        history.clear()
     }
+
+    /** Whether there is at least one edit that [undo] can revert. */
+    val canUndo: Boolean get() = history.canUndo
+
+    /** Whether there is at least one reverted edit that [redo] can reapply. */
+    val canRedo: Boolean get() = history.canRedo
+
+    /**
+     * Captures the current document state paired with [selection] as a restore point, **before** a
+     * mutation. Pair with [pushHistory] once the mutation is known to have changed the document, so
+     * no-op edits do not create empty undo steps. O(1).
+     */
+    internal fun captureHistoryPoint(selection: TextRange): HistorySnapshot =
+        HistorySnapshot(transaction.snapshot(), selection)
+
+    /**
+     * Commits a restore point captured with [captureHistoryPoint]. [coalesceKey] merges a run of
+     * same-kind edits into one undo step (see [EditorHistoryManager.record]); pass `null` for a
+     * discrete step.
+     */
+    internal fun pushHistory(point: HistorySnapshot, coalesceKey: Any? = null) =
+        history.record(point, coalesceKey)
+
+    /** Ends the current coalescing run so the next [pushHistory] starts a fresh undo step. */
+    internal fun breakHistoryCoalescing() = history.breakCoalescing()
+
+    /**
+     * Reverts the last recorded edit. [currentSelection] is the live caret/selection, stored so
+     * [redo] can restore it. Returns the selection to place the caret at, or `null` when there is
+     * nothing to undo.
+     */
+    fun undo(currentSelection: TextRange): TextRange? {
+        val restored = history.undo(HistorySnapshot(transaction.snapshot(), currentSelection))
+            ?: return null
+        transaction.restore(restored.document)
+        return restored.selection
+    }
+
+    /**
+     * Reapplies the last undone edit. [currentSelection] is the live caret/selection, stored so a
+     * following [undo] can restore it. Returns the selection to place the caret at, or `null` when
+     * there is nothing to redo.
+     */
+    fun redo(currentSelection: TextRange): TextRange? {
+        val restored = history.redo(HistorySnapshot(transaction.snapshot(), currentSelection))
+            ?: return null
+        transaction.restore(restored.document)
+        return restored.selection
+    }
+
+    /** Drops all undo/redo history. */
+    fun clearHistory() = history.clear()
 
     val text get() = transaction.text
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/history/EditorHistoryManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/history/EditorHistoryManager.kt
@@ -1,0 +1,113 @@
+package com.jjrodcast.textkit.editor.core.history
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.core.piecetable.PieceTableSnapshot
+
+/**
+ * A single undo/redo restore point: the document state ([document]) plus the [selection] to put the
+ * caret back to when this point is restored.
+ */
+internal class HistorySnapshot(
+    val document: PieceTableSnapshot,
+    val selection: TextRange,
+)
+
+/**
+ * The kind of edit, used only as a coalescing key so a run of same-kind edits (e.g. typing
+ * character by character) collapses into a single undo step. Discrete edits (formatting, list
+ * toggles, token insertions, …) pass `null` instead, which always starts a new, un-mergeable entry.
+ */
+internal enum class EditKind {
+    Typing,
+    Deleting,
+}
+
+/**
+ * Stack-based undo/redo history over immutable [PieceTableSnapshot]s.
+ *
+ * Because a snapshot is an O(1) capture of a persistent rope (see [PieceTableSnapshot]), a single
+ * snapshot type uniformly covers **every** kind of document mutation (typing, deleting, formatting,
+ * lists, tokens): recording is just pushing the pre-edit snapshot, and undo/redo is swapping it back.
+ *
+ * Coalescing: [record] merges consecutive edits that share a non-null [coalesceKey], so typing a
+ * word is one undo step rather than one per keystroke. [breakCoalescing] force-ends the current run
+ * (e.g. after a word boundary) so the next edit starts a fresh step.
+ *
+ * The undo stack is capped at [limit]; the oldest entries are dropped past it. Redo is invalidated by
+ * any new [record].
+ */
+internal class EditorHistoryManager(private val limit: Int = DEFAULT_LIMIT) {
+
+    private val undoStack = ArrayDeque<HistorySnapshot>()
+    private val redoStack = ArrayDeque<HistorySnapshot>()
+
+    /** Coalescing key of the most recently recorded edit, or `null` at a boundary. */
+    private var lastKey: Any? = null
+
+    val canUndo: Boolean get() = undoStack.isNotEmpty()
+    val canRedo: Boolean get() = redoStack.isNotEmpty()
+
+    /** Number of undo steps currently retained. Exposed for tests. */
+    internal val undoCount: Int get() = undoStack.size
+
+    /** Number of redo steps currently retained. Exposed for tests. */
+    internal val redoCount: Int get() = redoStack.size
+
+    /**
+     * Records [snapshot] as a restore point (the state **before** the edit it guards). Any new record
+     * invalidates the redo stack.
+     *
+     * When [coalesceKey] is non-null and equal to the previous record's key, the edits are merged:
+     * this snapshot is dropped so the earlier boundary remains the restore point — this is what turns
+     * a run of keystrokes into one undo step. A `null` key always starts a new, un-mergeable entry.
+     */
+    fun record(snapshot: HistorySnapshot, coalesceKey: Any? = null) {
+        redoStack.clear()
+        val mergeable = coalesceKey != null && coalesceKey == lastKey && undoStack.isNotEmpty()
+        lastKey = coalesceKey
+        if (mergeable) return
+        undoStack.addLast(snapshot)
+        while (undoStack.size > limit) undoStack.removeFirst()
+    }
+
+    /**
+     * Ends the current coalescing run so the next [record] starts a fresh undo step even if it shares
+     * the previous key. Called e.g. right after typing a word-boundary character.
+     */
+    fun breakCoalescing() {
+        lastKey = null
+    }
+
+    /**
+     * Pops the last restore point and returns it, pushing [current] (the live state) onto the redo
+     * stack so the move can be reversed. Returns `null` when there is nothing to undo.
+     */
+    fun undo(current: HistorySnapshot): HistorySnapshot? {
+        val previous = undoStack.removeLastOrNull() ?: return null
+        redoStack.addLast(current)
+        lastKey = null
+        return previous
+    }
+
+    /**
+     * Pops the last redone point and returns it, pushing [current] (the live state) back onto the
+     * undo stack. Returns `null` when there is nothing to redo.
+     */
+    fun redo(current: HistorySnapshot): HistorySnapshot? {
+        val next = redoStack.removeLastOrNull() ?: return null
+        undoStack.addLast(current)
+        lastKey = null
+        return next
+    }
+
+    /** Clears all history (both stacks). Called when the document is replaced (e.g. `load`). */
+    fun clear() {
+        undoStack.clear()
+        redoStack.clear()
+        lastKey = null
+    }
+
+    companion object {
+        const val DEFAULT_LIMIT = 100
+    }
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/PieceTableSnapshot.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/PieceTableSnapshot.kt
@@ -1,0 +1,23 @@
+package com.jjrodcast.textkit.editor.core.piecetable
+
+import com.jjrodcast.textkit.editor.core.piecetable.rope.RopeNode
+
+/**
+ * An immutable, O(1)-captured version of a [RichTextEditorBasePieceTable]'s document state, used as
+ * a restore point for undo/redo.
+ *
+ * It holds only two references, both immutable, so capturing and restoring a snapshot is O(1) in
+ * time and adds no per-snapshot memory beyond the retained (structurally shared) tree:
+ * - [root]: the piece-sequence tree. [RopeNode] uses path-copying, so different document versions
+ *   share almost all of their nodes.
+ * - [cachedText]: the plain-text cache for [root] (a [String], which is immutable). Restoring it
+ *   alongside [root] avoids an O(N) rebuild on undo/redo.
+ *
+ * The character buffers are intentionally **not** captured: `originalBuffer` never changes except on
+ * `build` (which clears history), and `addedBuffer` is append-only, so any offset referenced by an
+ * older [root] stays valid forever.
+ */
+internal class PieceTableSnapshot(
+    val root: RopeNode?,
+    val cachedText: String?,
+)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorBasePieceTable.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorBasePieceTable.kt
@@ -92,6 +92,23 @@ internal abstract class RichTextEditorBasePieceTable :
         invalidateCache()
     }
 
+    /**
+     * Captures the current document state as a [PieceTableSnapshot] restore point. **O(1)** — copies
+     * two immutable references (the rope root and the text cache). See [PieceTableSnapshot] for why
+     * the character buffers do not need to be captured.
+     */
+    internal fun snapshot(): PieceTableSnapshot = PieceTableSnapshot(rope.snapshot(), _cachedText)
+
+    /**
+     * Restores a document state previously captured with [snapshot]. **O(1)** — swaps the rope root
+     * and its matching text cache back in. The two are always restored together so the cache never
+     * belongs to a different version than the tree.
+     */
+    internal fun restore(snapshot: PieceTableSnapshot) {
+        rope.restore(snapshot.root)
+        _cachedText = snapshot.cachedText
+    }
+
     override fun getTextAt(offset: Int): TextEditorModel {
         val (index, _) = getPieceIndexAndOffset(offset)
         val piece = rope.get(index)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/rope/PieceRope.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/rope/PieceRope.kt
@@ -53,6 +53,20 @@ internal class PieceRope {
         root = merge(root, RopeNode.Leaf(piece))
     }
 
+    // ── Versioning (snapshot / restore) ──────────────────────────────────────
+
+    /**
+     * Captures the current tree as an opaque version token. **O(1)** — returns the [root]
+     * reference. Safe because [RopeNode] is immutable (path-copying): the captured tree shares
+     * structure with future versions and is never mutated, so it stays a valid restore point.
+     */
+    fun snapshot(): RopeNode? = root
+
+    /** Restores a tree previously captured with [snapshot]. **O(1)**. */
+    fun restore(snapshot: RopeNode?) {
+        root = snapshot
+    }
+
     // ── Point access ───────────────────────────────────────────────────────
 
     /** Returns the piece at 0-indexed [index]. O(log P). */

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
@@ -12,6 +12,7 @@ import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.parser.TEXT_EDITOR_JSON
 import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
+import com.jjrodcast.textkit.editor.core.piecetable.PieceTableSnapshot
 import com.jjrodcast.textkit.editor.core.piecetable.RichTextEditorBasePieceTable
 import com.jjrodcast.textkit.editor.core.piecetable.RichTextEditorPieceTable
 import com.jjrodcast.textkit.editor.core.piecetable.models.RichPieceTransaction
@@ -222,4 +223,10 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
     }
 
     internal fun getLastOffset(): Int = pieceTable.getLastOffset()
+
+    /** Captures the document state for undo/redo. O(1). See [RichTextEditorBasePieceTable.snapshot]. */
+    internal fun snapshot() = pieceTable.snapshot()
+
+    /** Restores a document state captured with [snapshot]. O(1). */
+    internal fun restore(snapshot: PieceTableSnapshot) = pieceTable.restore(snapshot)
 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
@@ -89,7 +89,11 @@ fun TextKitSample() {
             onHighlightClick = state::applyHighlight,
             onLinkClick = { state.applyLink() },
             onOrderedListClick = state::toggleOrderedList,
-            onBulletedListClick = state::toggleUnorderedList
+            onBulletedListClick = state::toggleUnorderedList,
+            onUndoClick = { state.undo() },
+            onRedoClick = { state.redo() },
+            canUndo = state.canUndo,
+            canRedo = state.canRedo
         )
         Spacer(Modifier.size(6.dp))
         // Wrap the editor in a Box so the popup overlays it (shares its coordinate space) and

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
@@ -18,6 +18,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
@@ -51,6 +60,7 @@ fun TextKitEditor(
             .verticalScroll(rememberScrollState())
             .fillMaxWidth()
             .focusRequester(focusRequester)
+            .onPreviewKeyEvent { handleUndoRedoShortcut(it, state) }
             .pointerInput(state) {
                 awaitPointerEventScope {
                     while (true) {
@@ -85,6 +95,23 @@ fun TextKitEditor(
     )
 }
 
+/**
+ * Handles the undo/redo keyboard shortcuts on a key-down event, consuming the event when it triggers
+ * one. Accepts Ctrl (desktop/web) or Cmd (macOS/iOS): Ctrl/Cmd+Z undoes, Ctrl/Cmd+Shift+Z and Ctrl+Y
+ * redo. Returns false for anything else so normal typing is unaffected.
+ */
+private fun handleUndoRedoShortcut(event: KeyEvent, state: TextKitState): Boolean {
+    if (event.type != KeyEventType.KeyDown) return false
+    val modifier = event.isCtrlPressed || event.isMetaPressed
+    if (!modifier) return false
+    return when {
+        event.key == Key.Z && !event.isShiftPressed -> state.undo()
+        event.key == Key.Z && event.isShiftPressed -> state.redo()
+        event.key == Key.Y -> state.redo()
+        else -> false
+    }
+}
+
 @Composable
 fun TextKitEditorOutlined(
     modifier: Modifier = Modifier,
@@ -108,6 +135,7 @@ fun TextKitEditorOutlined(
         modifier = modifier
             .fillMaxWidth()
             .focusRequester(focusRequester)
+            .onPreviewKeyEvent { handleUndoRedoShortcut(it, state) }
             .pointerInput(state) {
                 awaitPointerEventScope {
                     while (true) {

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitFormatting.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitFormatting.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.FormatListBulleted
+import androidx.compose.material.icons.automirrored.rounded.Redo
+import androidx.compose.material.icons.automirrored.rounded.Undo
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.rounded.FormatBold
 import androidx.compose.material.icons.rounded.FormatColorFill
@@ -56,9 +58,11 @@ import textkit.shared.generated.resources.highlight_text
 import textkit.shared.generated.resources.italic_text
 import textkit.shared.generated.resources.link_text
 import textkit.shared.generated.resources.ordered_list_text
+import textkit.shared.generated.resources.redo_text
 import textkit.shared.generated.resources.strikethrough_text
 import textkit.shared.generated.resources.text_color_text
 import textkit.shared.generated.resources.underline_text
+import textkit.shared.generated.resources.undo_text
 
 @Composable
 fun TextKitScreen(
@@ -88,9 +92,32 @@ fun TextKitFormattingBar(
     onLinkClick: (Boolean) -> Unit = {},
     onOrderedListClick: (Boolean) -> Unit = {},
     onBulletedListClick: (Boolean) -> Unit = {},
+    onUndoClick: () -> Unit = {},
+    onRedoClick: () -> Unit = {},
+    canUndo: Boolean = false,
+    canRedo: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     Row(modifier = modifier.height(IntrinsicSize.Min)) {
+        TextKitTooltipFormattingItem(
+            tooltipText = stringResource(Res.string.undo_text),
+            rememberVectorPainter(Icons.AutoMirrored.Rounded.Undo),
+            onClick = { onUndoClick() },
+            value = false,
+            backgroundColor = selectedColor,
+            enabled = canUndo
+        )
+        TextKitFormattingSeparator()
+        TextKitTooltipFormattingItem(
+            tooltipText = stringResource(Res.string.redo_text),
+            rememberVectorPainter(Icons.AutoMirrored.Rounded.Redo),
+            onClick = { onRedoClick() },
+            value = false,
+            backgroundColor = selectedColor,
+            enabled = canRedo
+        )
+        TextKitFormattingDivider()
+        TextKitFormattingSeparator()
         TextKitTooltipFormattingItem(
             tooltipText = stringResource(Res.string.bold_text),
             rememberVectorPainter(Icons.Rounded.FormatBold),
@@ -175,6 +202,7 @@ fun TextKitTooltipFormattingItem(
     onClick: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     backgroundColor: Color = Color.Unspecified,
+    enabled: Boolean = true,
 ) {
     TooltipBox(
         modifier = modifier,
@@ -192,7 +220,8 @@ fun TextKitTooltipFormattingItem(
             painter = painter,
             value = value,
             onValueChange = onClick,
-            backgroundColor = backgroundColor
+            backgroundColor = backgroundColor,
+            enabled = enabled
         )
     }
 
@@ -229,7 +258,7 @@ fun TextKitFormattingItem(
         Icon(
             painter = painter,
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.secondary
+            tint = MaterialTheme.colorScheme.secondary.copy(alpha = if (enabled) 1f else 0.38f)
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.em
 import com.jjrodcast.textkit.editor.components.TextEditorDecoratorItem
 import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import com.jjrodcast.textkit.editor.core.history.EditKind
 import com.jjrodcast.textkit.editor.core.parser.BoldMark
 import com.jjrodcast.textkit.editor.core.parser.HeadingLevels
 import com.jjrodcast.textkit.editor.core.parser.HeadingLevelsValues
@@ -114,6 +115,21 @@ class TextKitState(
 
     internal var selection by mutableStateOf(TextRange.Zero)
         private set
+
+    /** Whether an [undo] is available. Observable so the formatting bar's undo button can enable/disable. */
+    var canUndo by mutableStateOf(false)
+        private set
+
+    /** Whether a [redo] is available. Observable so the formatting bar's redo button can enable/disable. */
+    var canRedo by mutableStateOf(false)
+        private set
+
+    /**
+     * Re-entrancy guard for [recordBefore]. A compound action (e.g. a link text+URL edit that swaps
+     * text and then applies a link) calls other recording methods internally; only the outermost call
+     * should capture a restore point, so the whole action is a single undo step.
+     */
+    private var historyDepth = 0
 
     /**
      * Marks active at the collapsed caret, captured when the selection moves. Text typed next
@@ -221,6 +237,75 @@ class TextKitState(
         val text = manager.text
         textFieldValue = textFieldValue.copy(text = text, selection = TextRange.Zero)
         updateAnnotatedString(textFieldValue.selection)
+        syncHistoryAvailability()
+    }
+
+    /**
+     * Reverts the last edit (typing, deletion, formatting, list toggle, token insertion, …) and
+     * restores the caret to where it was before that edit. No-op — returns false — when there is
+     * nothing to undo. Wire it to a toolbar button ([canUndo]) or a keyboard shortcut (Ctrl/Cmd+Z).
+     */
+    fun undo(): Boolean {
+        val restored = manager.undo(selection) ?: return false
+        applyRestoredHistory(restored)
+        return true
+    }
+
+    /**
+     * Reapplies the last undone edit and restores its caret. No-op — returns false — when there is
+     * nothing to redo. Wire it to a toolbar button ([canRedo]) or a keyboard shortcut
+     * (Ctrl/Cmd+Shift+Z, or Ctrl+Y).
+     */
+    fun redo(): Boolean {
+        val restored = manager.redo(selection) ?: return false
+        applyRestoredHistory(restored)
+        return true
+    }
+
+    /** Re-renders the field after an undo/redo restore and re-syncs the caret-dependent UI state. */
+    private fun applyRestoredHistory(restoredSelection: TextRange) {
+        // A restore can shrink or grow the document; any query/token popup that was open no longer
+        // matches the restored text, and a remembered range is stale.
+        tokenState.dismiss()
+        lastRangeSelection = TextRange.Zero
+        selection = restoredSelection
+        updateAnnotatedString(restoredSelection)
+        readSelectionContext()
+        syncHistoryAvailability()
+    }
+
+    private fun syncHistoryAvailability() {
+        canUndo = manager.canUndo
+        canRedo = manager.canRedo
+    }
+
+    /**
+     * Runs a document-mutating [block] as one undo step. Captures a restore point (the pre-edit
+     * state + current [selection]) and, if [block] reports a change, commits it with [coalesceKey]
+     * (see [EditorHistoryManager][com.jjrodcast.textkit.editor.core.history.EditorHistoryManager]);
+     * [breakAfter] then ends the coalescing run so the next edit starts fresh.
+     *
+     * Nested calls (a compound action calling other recording methods) reuse the outermost restore
+     * point via [historyDepth], so the whole action is a single undo step.
+     */
+    private inline fun recordBefore(
+        coalesceKey: Any? = null,
+        breakAfter: Boolean = true,
+        block: () -> Boolean
+    ): Boolean {
+        val point = if (historyDepth == 0) manager.captureHistoryPoint(selection) else null
+        historyDepth++
+        val changed = try {
+            block()
+        } finally {
+            historyDepth--
+        }
+        if (changed && point != null) {
+            manager.pushHistory(point, coalesceKey)
+            if (breakAfter) manager.breakHistoryCoalescing()
+            syncHistoryAvailability()
+        }
+        return changed
     }
 
     /**
@@ -394,8 +479,8 @@ class TextKitState(
         previousMarks: TextEditorSelectedMark,
         currentMarks: TextEditorSelectedMark,
         transactionType: TextEditorTransactionType
-    ): Boolean {
-        val (updated, selection) = manager.updateDocument(
+    ): Boolean = recordBefore(coalesceKey = null) {
+        val (updated, resultSelection) = manager.updateDocument(
             selection,
             previousMarks,
             currentMarks,
@@ -403,12 +488,12 @@ class TextKitState(
         )
 
         if (updated) {
-            this.selection = selection
-            updateAnnotatedString(selection)
+            this.selection = resultSelection
+            updateAnnotatedString(resultSelection)
             // Refresh the caret context so formatting-bar toggles reflect the change just applied.
             readSelectionContext()
         }
-        return updated
+        updated
     }
 
     /**
@@ -451,7 +536,12 @@ class TextKitState(
      */
     fun updateLinkText(newText: String, url: String, range: TextRange): Boolean {
         if (newText.isEmpty()) return false
+        // Text swap + link apply is one logical action; wrap so it is a single undo step (the nested
+        // updateLink reuses this restore point).
+        return recordBefore { updateLinkTextInternal(newText, url, range) }
+    }
 
+    private fun updateLinkTextInternal(newText: String, url: String, range: TextRange): Boolean {
         val min = range.min.coerceIn(0, textFieldValue.text.length)
         val max = range.max.coerceIn(min, textFieldValue.text.length)
         val currentText = textFieldValue.text.substring(min, max)
@@ -677,28 +767,43 @@ class TextKitState(
 
     private fun handleAddingText(marks: Set<Mark> = lastMarks) {
         val action = createAddAction(marks)
-        val (result, range) = TextTransaction.onTextUpdated(action, manager)
-        if (result) {
-            selection = range
-            updateAnnotatedString(selection)
-            tokenState.refreshQuery(textFieldValue.text, selection)
-            // Editing shifts offsets, so a remembered selection is no longer valid.
-            lastRangeSelection = TextRange.Zero
+        val added = (action as? TextEditorAction.TextAdded)?.text.orEmpty()
+        // A single typed character coalesces into the current word; a word boundary (space/newline)
+        // still joins the run but ends it so the next word is a separate undo step. Anything else
+        // (a paste-like multi-char insert) is its own discrete step.
+        val singleChar = added.length == 1
+        val boundary = added.any { it == ' ' || it == '\n' }
+        recordBefore(
+            coalesceKey = if (singleChar) EditKind.Typing else null,
+            breakAfter = !singleChar || boundary
+        ) {
+            val (result, range) = TextTransaction.onTextUpdated(action, manager)
+            if (result) {
+                selection = range
+                updateAnnotatedString(selection)
+                tokenState.refreshQuery(textFieldValue.text, selection)
+                // Editing shifts offsets, so a remembered selection is no longer valid.
+                lastRangeSelection = TextRange.Zero
+            }
+            result
         }
     }
 
     private fun handleRemovingText() {
-        // A partial deletion of an atomic token (e.g. Backspace at its trailing edge) must remove the
-        // whole token instead of clipping a character off its label.
-        if (handleAtomicTokenDeletion()) return
-        val action = createRemoveAction()
-        val (result, range) = TextTransaction.onTextUpdated(action, manager)
-        if (result) {
-            selection = range
-            updateAnnotatedString(selection)
-            tokenState.refreshQuery(textFieldValue.text, selection)
-            // Editing shifts offsets, so a remembered selection is no longer valid.
-            lastRangeSelection = TextRange.Zero
+        recordBefore(coalesceKey = EditKind.Deleting, breakAfter = false) {
+            // A partial deletion of an atomic token (e.g. Backspace at its trailing edge) must remove
+            // the whole token instead of clipping a character off its label.
+            if (handleAtomicTokenDeletion()) return@recordBefore true
+            val action = createRemoveAction()
+            val (result, range) = TextTransaction.onTextUpdated(action, manager)
+            if (result) {
+                selection = range
+                updateAnnotatedString(selection)
+                tokenState.refreshQuery(textFieldValue.text, selection)
+                // Editing shifts offsets, so a remembered selection is no longer valid.
+                lastRangeSelection = TextRange.Zero
+            }
+            result
         }
     }
 
@@ -714,9 +819,13 @@ class TextKitState(
      * an ephemeral trigger (`/`) it inserts the label as plain text.
      */
     fun selectToken(id: String, label: String) {
-        val caret = tokenState.commitSelection(id, label, selection, lastMarks) ?: return
-        selection = caret
-        updateAnnotatedString(caret)
+        recordBefore {
+            val caret = tokenState.commitSelection(id, label, selection, lastMarks)
+                ?: return@recordBefore false
+            selection = caret
+            updateAnnotatedString(caret)
+            true
+        }
     }
 
     /**
@@ -740,10 +849,15 @@ class TextKitState(
      * command trigger is active. Use this from a slash-command popup (see `TextKitSlashCommandPopup`).
      */
     fun runCommand(command: TextKitCommand) {
-        val caret = tokenState.commitCommand(selection) ?: return
-        selection = caret
-        updateAnnotatedString(caret)
-        command.onSelect(this)
+        recordBefore {
+            val caret = tokenState.commitCommand(selection) ?: return@recordBefore false
+            selection = caret
+            updateAnnotatedString(caret)
+            // The command may mutate further (e.g. insertText / applyHeading); those calls nest under
+            // this restore point, so the whole command is a single undo step.
+            command.onSelect(this)
+            true
+        }
     }
 
     /**
@@ -753,15 +867,18 @@ class TextKitState(
      */
     fun insertText(text: String) {
         if (text.isEmpty()) return
-        val caret = manager.insertToken(
-            nodeType = null,
-            id = "",
-            label = text,
-            replaceRange = TextRange(selection.min, selection.max),
-            marks = lastMarks
-        )
-        selection = caret
-        updateAnnotatedString(caret)
+        recordBefore {
+            val caret = manager.insertToken(
+                nodeType = null,
+                id = "",
+                label = text,
+                replaceRange = TextRange(selection.min, selection.max),
+                marks = lastMarks
+            )
+            selection = caret
+            updateAnnotatedString(caret)
+            true
+        }
     }
 
     /**

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditorHistoryManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditorHistoryManagerTest.kt
@@ -1,0 +1,153 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.core.history.EditKind
+import com.jjrodcast.textkit.editor.core.history.EditorHistoryManager
+import com.jjrodcast.textkit.editor.core.history.HistorySnapshot
+import com.jjrodcast.textkit.editor.core.piecetable.PieceTableSnapshot
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Pure unit tests for the undo/redo stack + coalescing logic in [EditorHistoryManager], exercised
+ * with dummy [HistorySnapshot]s (the document payload is irrelevant to the stack behavior).
+ */
+class EditorHistoryManagerTest {
+
+    private fun snap(selection: Int = 0): HistorySnapshot =
+        HistorySnapshot(PieceTableSnapshot(root = null, cachedText = null), TextRange(selection))
+
+    @Test
+    fun starts_empty() {
+        val history = EditorHistoryManager()
+        assertFalse(history.canUndo)
+        assertFalse(history.canRedo)
+        assertEquals(0, history.undoCount)
+        assertEquals(0, history.redoCount)
+    }
+
+    @Test
+    fun recording_makes_undo_available() {
+        val history = EditorHistoryManager()
+        history.record(snap())
+        assertTrue(history.canUndo)
+        assertEquals(1, history.undoCount)
+    }
+
+    @Test
+    fun same_key_run_coalesces_into_one_step() {
+        val history = EditorHistoryManager()
+        history.record(snap(0), EditKind.Typing)
+        history.record(snap(1), EditKind.Typing)
+        history.record(snap(2), EditKind.Typing)
+        assertEquals(1, history.undoCount)
+    }
+
+    @Test
+    fun break_coalescing_starts_a_new_step() {
+        val history = EditorHistoryManager()
+        history.record(snap(0), EditKind.Typing)
+        history.record(snap(1), EditKind.Typing)
+        history.breakCoalescing()
+        history.record(snap(2), EditKind.Typing)
+        assertEquals(2, history.undoCount)
+    }
+
+    @Test
+    fun null_key_never_coalesces() {
+        val history = EditorHistoryManager()
+        history.record(snap(0), coalesceKey = null)
+        history.record(snap(1), coalesceKey = null)
+        assertEquals(2, history.undoCount)
+    }
+
+    @Test
+    fun different_keys_do_not_coalesce() {
+        val history = EditorHistoryManager()
+        history.record(snap(0), EditKind.Typing)
+        history.record(snap(1), EditKind.Deleting)
+        assertEquals(2, history.undoCount)
+    }
+
+    @Test
+    fun new_record_invalidates_redo() {
+        val history = EditorHistoryManager()
+        history.record(snap(0))
+        history.undo(snap(9))
+        assertTrue(history.canRedo)
+
+        history.record(snap(1))
+        assertFalse(history.canRedo)
+    }
+
+    @Test
+    fun undo_returns_the_recorded_point_and_stores_current_for_redo() {
+        val history = EditorHistoryManager()
+        val recorded = snap(0)
+        history.record(recorded)
+
+        val current = snap(5)
+        val restored = history.undo(current)
+
+        assertSame(recorded, restored)
+        assertFalse(history.canUndo)
+        assertTrue(history.canRedo)
+    }
+
+    @Test
+    fun redo_returns_the_state_that_was_current_at_undo() {
+        val history = EditorHistoryManager()
+        history.record(snap(0))
+        val current = snap(5)
+        history.undo(current)
+
+        val redone = history.redo(snap(7))
+
+        assertSame(current, redone)
+        assertTrue(history.canUndo)
+        assertFalse(history.canRedo)
+    }
+
+    @Test
+    fun undo_and_redo_are_null_when_empty() {
+        val history = EditorHistoryManager()
+        assertNull(history.undo(snap()))
+        assertNull(history.redo(snap()))
+    }
+
+    @Test
+    fun limit_drops_the_oldest_entries() {
+        val history = EditorHistoryManager(limit = 3)
+        repeat(5) { history.record(snap(it)) }
+        assertEquals(3, history.undoCount)
+    }
+
+    @Test
+    fun clear_empties_both_stacks() {
+        val history = EditorHistoryManager()
+        history.record(snap(0))
+        history.undo(snap(1))
+        assertTrue(history.canRedo)
+
+        history.clear()
+
+        assertFalse(history.canUndo)
+        assertFalse(history.canRedo)
+    }
+
+    @Test
+    fun undo_ends_the_coalescing_run() {
+        val history = EditorHistoryManager()
+        history.record(snap(0), EditKind.Typing)
+        history.undo(snap(9))
+        // After an undo, a following same-key record must not merge into the (now redone) run.
+        history.record(snap(1), EditKind.Typing)
+        history.record(snap(2), EditKind.Typing)
+        assertEquals(1, history.undoCount) // the two Typing records after undo coalesce together
+        assertFalse(history.canRedo)       // ...and the fresh record invalidated redo
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/UndoRedoTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/UndoRedoTest.kt
@@ -1,0 +1,218 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.components.TextEditorStyleItem
+import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import com.jjrodcast.textkit.editor.core.parser.BoldMark
+import com.jjrodcast.textkit.editor.utils.DocumentUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end undo/redo over the real engine: every mutation kind (typing, deletion, formatting, list
+ * toggles, paragraph split/merge) is captured as a snapshot and reverted/reapplied through
+ * [TextKitEditorManager.undo] / [TextKitEditorManager.redo].
+ *
+ * These drive the same `captureHistoryPoint` + `pushHistory` contract the UI ([TextKitState]) uses:
+ * capture a restore point *before* the edit, then commit it once the edit changed the document.
+ */
+class UndoRedoTest {
+
+    /** Records a restore point for the state *before* the next edit, as the UI does. */
+    private fun TextKitEditorManager.checkpoint(selection: TextRange = TextRange.Zero, key: Any? = null) =
+        pushHistory(captureHistoryPoint(selection), key)
+
+    @Test
+    fun no_history_initially() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        assertFalse(editor.canUndo)
+        assertFalse(editor.canRedo)
+        assertNull(editor.undo(TextRange.Zero))
+        assertNull(editor.redo(TextRange.Zero))
+    }
+
+    @Test
+    fun undo_reverts_typing_and_redo_reapplies_it() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        val original = editor.text
+
+        editor.checkpoint(TextRange(0))
+        editor.typeText(offset = 0, textToAdd = "Hi ")
+        assertEquals("Hi Hello world", editor.text)
+        assertTrue(editor.canUndo)
+
+        val undoSelection = editor.undo(TextRange(3))
+        assertEquals(original, editor.text)
+        assertEquals(TextRange(0), undoSelection) // caret restored to where it was before typing
+        assertTrue(editor.canRedo)
+
+        val redoSelection = editor.redo(TextRange(0))
+        assertEquals("Hi Hello world", editor.text)
+        assertEquals(TextRange(3), redoSelection) // caret restored to where it was before the undo
+    }
+
+    @Test
+    fun undo_reverts_deletion() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        val original = editor.text
+
+        editor.checkpoint(TextRange(0))
+        editor.deleteText(offset = 0, length = "Hello ".length)
+        assertEquals("world", editor.text)
+
+        editor.undo(TextRange(0))
+        assertEquals(original, editor.text)
+    }
+
+    @Test
+    fun undo_reverts_bold_formatting_including_serialization() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        val range = editor.rangeOf("Hello")
+        val jsonBefore = editor.toJson()
+
+        editor.checkpoint(range)
+        editor.applyStyle(range, TextEditorStyleItem.Bold)
+        assertTrue(editor.marksAt(range).has<BoldMark>())
+
+        editor.undo(range)
+        assertFalse(editor.marksAt(range).has<BoldMark>())
+        // Undo restores the exact document, so it round-trips to the original JSON.
+        assertEquals(jsonBefore, editor.toJson())
+
+        editor.redo(range)
+        assertTrue(editor.marksAt(range).has<BoldMark>())
+    }
+
+    @Test
+    fun undo_reverts_a_list_toggle() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        val range = editor.rangeOf("Hello")
+
+        editor.checkpoint(range)
+        editor.toListItem(range, from = TextEditorListItem.None, to = TextEditorListItem.BulletedList)
+        val afterToggle = editor.text
+        assertTrue(afterToggle != "Hello world") // a bullet decorator marker was inserted
+
+        editor.undo(range)
+        assertEquals("Hello world", editor.text)
+
+        editor.redo(range)
+        assertEquals(afterToggle, editor.text)
+    }
+
+    @Test
+    fun undo_merges_a_split_paragraph_back() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        editor.checkpoint(TextRange(editor.offsetOf("world")))
+        editor.typeText(offset = editor.offsetOf("world"), textToAdd = "\n")
+        assertEquals(2, editor.getParagraphs().size)
+
+        editor.undo(TextRange.Zero)
+        assertEquals("Hello world", editor.text)
+        assertEquals(1, editor.getParagraphs().size)
+    }
+
+    @Test
+    fun multiple_sequential_undos_walk_back_the_history() {
+        val editor = editorFrom(DocumentUtils.emptyDocument)
+
+        editor.checkpoint(TextRange(0))
+        editor.typeText(0, "one")
+        editor.checkpoint(TextRange(editor.text.length))
+        editor.typeText(editor.text.length, "two")
+        editor.checkpoint(TextRange(editor.text.length))
+        editor.typeText(editor.text.length, "three")
+        assertEquals("onetwothree", editor.text)
+
+        editor.undo(TextRange(editor.text.length))
+        assertEquals("onetwo", editor.text)
+        editor.undo(TextRange(editor.text.length))
+        assertEquals("one", editor.text)
+        editor.undo(TextRange(editor.text.length))
+        assertEquals("", editor.text)
+        assertFalse(editor.canUndo)
+    }
+
+    @Test
+    fun a_new_edit_after_undo_invalidates_redo() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        editor.checkpoint(TextRange(0))
+        editor.typeText(0, "A")
+        editor.undo(TextRange(1))
+        assertTrue(editor.canRedo)
+
+        editor.checkpoint(TextRange(0))
+        editor.typeText(0, "B")
+        assertFalse(editor.canRedo)
+        assertEquals("BHello world", editor.text)
+    }
+
+    @Test
+    fun redo_stack_survives_across_undo_redo_cycles() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        editor.checkpoint(TextRange(0))
+        editor.typeText(0, "X ")
+        assertEquals("X Hello world", editor.text)
+
+        editor.undo(TextRange(2))
+        assertEquals("Hello world", editor.text)
+        editor.redo(TextRange(0))
+        assertEquals("X Hello world", editor.text)
+        editor.undo(TextRange(2))
+        assertEquals("Hello world", editor.text)
+    }
+
+    @Test
+    fun load_clears_history() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        editor.checkpoint(TextRange(0))
+        editor.typeText(0, "junk")
+        assertTrue(editor.canUndo)
+
+        editor.load(SampleDocuments.TWO_PARAGRAPHS, isViewer = false)
+
+        assertFalse(editor.canUndo)
+        assertFalse(editor.canRedo)
+        assertNull(editor.undo(TextRange.Zero))
+    }
+
+    @Test
+    fun clearHistory_drops_all_steps() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        editor.checkpoint(TextRange(0))
+        editor.typeText(0, "a")
+
+        editor.clearHistory()
+
+        assertFalse(editor.canUndo)
+        assertFalse(editor.canRedo)
+    }
+
+    @Test
+    fun undo_then_edit_then_undo_restores_intermediate_and_original() {
+        val editor = editorFrom(DocumentUtils.emptyDocument)
+
+        editor.checkpoint(TextRange(0))
+        editor.typeText(0, "hello")
+        assertEquals("hello", editor.text)
+
+        // Revert once, then make a different edit; the old redo is gone but undo still reaches "".
+        editor.undo(TextRange(5))
+        assertEquals("", editor.text)
+
+        editor.checkpoint(TextRange(0))
+        editor.typeText(0, "world")
+        assertEquals("world", editor.text)
+
+        editor.undo(TextRange(5))
+        assertEquals("", editor.text)
+        assertFalse(editor.canUndo)
+    }
+}


### PR DESCRIPTION
- Text kit using Snapshots and Memento strategy, cost is O(1) for saving the tree and O(n) for getting the cached text.