### PR TITLE
Adding Text Color support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Observable properties you can read in composition:
 | `activeTrigger` | `TextKitTrigger?` | The trigger currently being composed (`@`/`#`/`/`…), or `null`. Drives which candidate set the popup shows. |
 | `tokenQuery` | `String?` | Text typed after the active trigger char, or `null` when no trigger is being composed. |
 | `activeEmbed` | `EmbedInfo?` | The embedded block under the caret/tap, or `null`. Observe it to show an embed popup. |
+| `activeColorAnchor` | `Rect?` | Window bounds the color picker is anchored to while open, or `null`. Observe it to show `TextKitColorsPopup`. |
+| `currentTextColor` | `Color?` | The selection's current text color, or `null` when it has none. Seeds the color picker's marked swatch. |
 | `canUndo` / `canRedo` | `Boolean` | Whether an undo / redo step is available (drives toolbar button enablement). |
 | `annotatedStringForViewer` | `Pair<AnnotatedString, Map<String, InlineTextContent>>` | Rendered content for read-only display. |
 
@@ -382,7 +384,9 @@ import com.jjrodcast.textkit.ui.TextKitFormattingBar
 import com.jjrodcast.textkit.ui.TextKitScreen
 import com.jjrodcast.textkit.ui.state.rememberTextKitFormattingBarState
 
-val barState = rememberTextKitFormattingBarState()
+// `colors` is the palette exposed as `barState.colors` for the text-color popup (see below);
+// it defaults to TextKitPickerPallete.DefaultPallete.
+val barState = rememberTextKitFormattingBarState(colors = TextKitPickerPallete.DefaultPallete)
 
 // Mirror the caret's active marks/list into the bar so toggles highlight correctly:
 LaunchedEffect(state.lastMarks, state.lastListItem) {
@@ -399,6 +403,7 @@ TextKitScreen { // MaterialTheme + Scaffold wrapper (optional)
         onStrikeThroughClick = state::applyStrikeThrough,
         onHighlightClick = state::applyHighlight,
         onLinkClick = { state.applyLink() },
+        onTextAndColorClick = { state.openColorPicker(it) },
         onOrderedListClick = state::toggleOrderedList,
         onBulletedListClick = state::toggleUnorderedList,
         onUndoClick = { state.undo() },
@@ -409,6 +414,7 @@ TextKitScreen { // MaterialTheme + Scaffold wrapper (optional)
     Box {
         TextKitEditor(state = state)
         TextKitLinkPopup(state = state, /* onEdit / onRemove */)
+        TextKitColorsPopup(state = state, colors = barState.colors)
         TextKitTokenPopup(state = state) { /* users / tags by active trigger */ users }
         TextKitSlashCommandPopup(state = state, commands = commands)
     }
@@ -418,6 +424,43 @@ TextKitScreen { // MaterialTheme + Scaffold wrapper (optional)
 Each `on…Click` receives a `Boolean` (the new toggle value). `TextKitFormattingBarState` exposes
 `isBold`, `isItalic`, `isUnderline`, `isStrikethrough`, `isHighlight`, `isLink`, `isNumberedList`,
 `isBulletedList`, `isCheckList`.
+
+### Text color popup
+
+The palette button is different: `onTextAndColorClick` is **not** a toggle — it hands you the button's
+bounds in window coordinates (`Rect`). Wire it to `state.openColorPicker(bounds)` and render
+`TextKitColorsPopup` next to the editor. It follows the same pattern as [Links](#links): the popup is
+driven by editor state (`state.activeColorAnchor`), applies the pick back to the document, and marks
+the selection's current color (`state.currentTextColor`) so it round-trips both ways.
+
+```kotlin
+import com.jjrodcast.textkit.ui.TextKitColorsPopup
+
+TextKitFormattingBar(
+    barState = barState,
+    selectedColor = Color.Yellow,
+    onTextAndColorClick = { bounds -> state.openColorPicker(bounds) }, // open the picker
+    // … other on…Click handlers
+)
+
+Box {
+    TextKitEditor(state = state)
+    // Palette to show; a leading "no color" swatch (emits null → reset to default) is always added.
+    TextKitColorsPopup(state = state, colors = barState.colors)
+}
+```
+
+`TextKitColorsPopup` positions itself relative to the button (below it, flipping above when it would
+overflow the bottom and clamping horizontally, so it always fits the screen) and closes automatically
+once a color is picked. By default it applies the pick with
+`state.applyTextColor(hex)` (or resets to the configured color on the "no color" swatch); override
+`onColorSelected` / `onClose` to customize. The palette also has a default
+(`TextKitPickerPallete.DefaultPallete`), so `colors` is optional.
+
+**Related state APIs:** `state.openColorPicker(bounds)` / `state.dismissColorPicker()` (show/hide),
+`state.activeColorAnchor` (observable anchor, non-null while open), `state.applyTextColor(hex)`
+(set only the color, keeping the current font size; `null` resets to the default color), and
+`state.currentTextColor` (`Color?`, the selection's current color or `null`).
 
 ## Configuration
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
@@ -18,6 +18,7 @@ import com.jjrodcast.textkit.editor.core.parser.EmbedTypes
 import com.jjrodcast.textkit.editor.models.TextKitTrigger
 import com.jjrodcast.textkit.editor.models.createTextKitConfiguration
 import com.jjrodcast.textkit.editor.utils.DocumentUtils
+import com.jjrodcast.textkit.ui.TextKitColorsPopup
 import com.jjrodcast.textkit.ui.TextKitEditor
 import com.jjrodcast.textkit.ui.TextKitEmbedPopup
 import com.jjrodcast.textkit.ui.TextKitFormattingBar
@@ -29,6 +30,7 @@ import com.jjrodcast.textkit.ui.model.TextKitCommand
 import com.jjrodcast.textkit.ui.model.TextKitTokenSuggestion
 import com.jjrodcast.textkit.ui.state.rememberTextKitFormattingBarState
 import com.jjrodcast.textkit.ui.state.rememberTextKitState
+import com.jjrodcast.textkit.ui.utils.TextKitPickerPallete
 
 // A demo table (ProseMirror shape) inserted by the "Insertar tabla" button. It is stored verbatim on
 // the placeholder piece and re-emitted on toJson(); the editor only shows the "📊 Tabla" chip.
@@ -89,9 +91,7 @@ private val sampleCommands = listOf(
 
 @Composable
 fun TextKitSample() {
-    val barState = rememberTextKitFormattingBarState()
-    // Enable the trigger flows: '@' mentions, '#' hashtags (atomic chips) and '/' slash commands
-    // (ephemeral text insertion).
+    val barState = rememberTextKitFormattingBarState(colors = TextKitPickerPallete.DefaultPallete)
     val configuration = remember {
         createTextKitConfiguration {
             addTrigger { TextKitTrigger.TextKitMentionTrigger() }
@@ -100,7 +100,7 @@ fun TextKitSample() {
         }
     }
     val state =
-        rememberTextKitState(json = DocumentUtils.complexJsonV2, configuration = configuration)
+        rememberTextKitState(json = DocumentUtils.complexJsonV1, configuration = configuration)
 
     LaunchedEffect(state.lastMarks, state.lastListItem) {
         barState.syncFrom(state.lastMarks, state.lastListItem)
@@ -117,6 +117,7 @@ fun TextKitSample() {
             onStrikeThroughClick = state::applyStrikeThrough,
             onHighlightClick = state::applyHighlight,
             onLinkClick = { state.applyLink() },
+            onTextAndColorClick = { state.openColorPicker(it) },
             onOrderedListClick = state::toggleOrderedList,
             onBulletedListClick = state::toggleUnorderedList,
             onUndoClick = { state.undo() },
@@ -131,10 +132,22 @@ fun TextKitSample() {
             modifier = Modifier.padding(horizontal = 10.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            OutlinedButton(onClick = { state.insertEmbed(EmbedTypes.Table, DEMO_TABLE_JSON, "📊 Tabla") }) {
+            OutlinedButton(onClick = {
+                state.insertEmbed(
+                    EmbedTypes.Table,
+                    DEMO_TABLE_JSON,
+                    "📊 Tabla"
+                )
+            }) {
                 Text("Insertar tabla")
             }
-            OutlinedButton(onClick = { state.insertEmbed(EmbedTypes.Image, DEMO_IMAGE_JSON, "🖼 Imagen") }) {
+            OutlinedButton(onClick = {
+                state.insertEmbed(
+                    EmbedTypes.Image,
+                    DEMO_IMAGE_JSON,
+                    "🖼 Imagen"
+                )
+            }) {
                 Text("Insertar imagen")
             }
         }
@@ -148,6 +161,10 @@ fun TextKitSample() {
             )
             // Popup for embedded blocks: renders the table and offers "Eliminar".
             TextKitEmbedPopup(state = state)
+            TextKitColorsPopup(
+                state = state,
+                colors = barState.colors
+            )
             TextKitLinkPopup(
                 state = state,
                 onEdit = { link ->

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitColorPickerGrid.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitColorPickerGrid.kt
@@ -1,0 +1,111 @@
+package com.jjrodcast.textkit.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.jjrodcast.textkit.ui.utils.TextKitPickerPallete
+
+@Composable
+fun TextKitColorPickerGrid(
+    colors: List<Color>,
+    selected: Color?,
+    onColorSelected: (Color?) -> Unit,
+    modifier: Modifier = Modifier,
+    columns: Int = 8,
+) {
+    val defaultModifier = Modifier.aspectRatio(1f).clip(CircleShape)
+
+    LazyVerticalGrid(
+        modifier = modifier,
+        columns = GridCells.Fixed(columns),
+        contentPadding = PaddingValues(6.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        if (colors.isNotEmpty()) {
+            // "No color" swatch: a white circle with a red diagonal line. Picking it emits null, which
+            // resets the text color. It is highlighted when the selection currently has no color.
+            item {
+                val isSelected = selected == null
+                Box(
+                    modifier = defaultModifier
+                        .background(Color.White)
+                        .border(
+                            width = if (isSelected) 2.dp else 1.dp,
+                            color = if (isSelected) Color.Black else Color.LightGray,
+                            shape = CircleShape
+                        )
+                        .clickable { onColorSelected(null) }
+                ) {
+                    Canvas(modifier = Modifier.fillMaxSize()) {
+                        drawLine(
+                            color = Color.Red,
+                            start = Offset(0f, size.height),
+                            end = Offset(size.width, 0f),
+                            strokeWidth = 2.dp.toPx(),
+                            cap = StrokeCap.Round
+                        )
+                    }
+                }
+            }
+        }
+        items(colors) { color ->
+            val isSelected = color == selected
+            Box(
+                modifier = defaultModifier
+                    .background(color)
+                    .border(
+                        width = if (isSelected) 2.dp else 1.dp,
+                        color = if (isSelected) Color.Black else Color.LightGray,
+                        shape = CircleShape
+                    )
+                    .clickable {
+                        onColorSelected(color)
+                    }
+            )
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFFEFEFEF,
+    widthDp = 340,
+    heightDp = 280
+)
+@Composable
+private fun ColorPickerGridPreview() {
+    var selected by remember { mutableStateOf<Color?>(Color.Red) }
+
+    TextKitColorPickerGrid(
+        modifier = Modifier.padding(8.dp),
+        colors = TextKitPickerPallete.DefaultPallete,
+        selected = selected,
+        onColorSelected = {
+            selected = it
+        }
+    )
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitColorsPopup.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitColorsPopup.kt
@@ -1,0 +1,83 @@
+package com.jjrodcast.textkit.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import com.jjrodcast.textkit.editor.utils.toHexWithAlpha
+import com.jjrodcast.textkit.ui.state.TextKitState
+import com.jjrodcast.textkit.ui.utils.TextKitPickerPallete
+import com.jjrodcast.textkit.ui.utils.TextKitPopupAnchorProvider
+
+/**
+ * Popup that shows the text-color palette, anchored to wherever the color picker was opened
+ * ([TextKitState.activeColorAnchor]). Follows the same pattern as [TextKitLinkPopup]: it renders
+ * nothing while the picker is closed, observes the editor state to know when to show, writes the
+ * pick back to the editor via [TextKitState.applyTextColor], and reflects the editor's current
+ * color by marking it in the grid ([TextKitState.currentTextColor]).
+ *
+ * Open it from the formatting bar's palette button, then place this popup next to the editor:
+ *
+ * ```
+ * TextKitFormattingBar(
+ *     // …
+ *     onTextAndColorClick = { bounds -> state.openColorPicker(bounds) },
+ * )
+ * Box {
+ *     TextKitEditor(state = state)
+ *     TextKitColorsPopup(state = state, colors = barState.colors)
+ * }
+ * ```
+ *
+ * @param colors palette shown in the grid. A leading "no color" swatch (emits null) is always added.
+ * @param onColorSelected invoked with the chosen color (null = reset to the default color). The
+ * default applies it to the editor and closes the popup.
+ * @param onClose invoked when the popup is dismissed (tap outside). Defaults to closing the picker.
+ */
+@Composable
+fun TextKitColorsPopup(
+    state: TextKitState,
+    colors: List<Color> = TextKitPickerPallete.DefaultPallete,
+    modifier: Modifier = Modifier,
+    onColorSelected: (Color?) -> Unit = { color ->
+        state.applyTextColor(color?.toHexWithAlpha())
+        state.dismissColorPicker()
+    },
+    onClose: () -> Unit = { state.dismissColorPicker() },
+) {
+    val anchor = state.activeColorAnchor ?: return
+
+    Popup(
+        popupPositionProvider = TextKitPopupAnchorProvider.positionProvider(anchor),
+        onDismissRequest = onClose,
+        properties = PopupProperties(focusable = true),
+    ) {
+        Card(
+            modifier = modifier.widthIn(max = 320.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 6.dp)
+        ) {
+            Column(
+                Modifier.defaultMinSize(minHeight = 32.dp, minWidth = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                // Mark the current selection's color when it exists (currentTextColor != null);
+                // when the selection has no color it is null and only the "no color" swatch marks.
+                TextKitColorPickerGrid(
+                    colors = colors,
+                    selected = state.currentTextColor,
+                    onColorSelected = onColorSelected,
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
@@ -109,10 +109,10 @@ private fun handleUndoRedoShortcut(event: KeyEvent, state: TextKitState): Boolea
     if (event.type != KeyEventType.KeyDown) return false
     val modifier = event.isCtrlPressed || event.isMetaPressed
     if (!modifier) return false
-    return when {
-        event.key == Key.Z && !event.isShiftPressed -> state.undo()
-        event.key == Key.Z && event.isShiftPressed -> state.redo()
-        event.key == Key.Y -> state.redo()
+    return when (event.key) {
+        Key.Z if !event.isShiftPressed -> state.undo()
+        Key.Z if event.isShiftPressed -> state.redo()
+        Key.Y -> state.redo()
         else -> false
     }
 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitFormatting.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitFormatting.kt
@@ -1,8 +1,11 @@
 package com.jjrodcast.textkit.ui
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -11,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -41,15 +45,21 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.jjrodcast.textkit.ui.state.TextKitFormattingBarState
 import com.jjrodcast.textkit.ui.state.rememberTextKitFormattingBarState
+import com.jjrodcast.textkit.ui.utils.TextKitPickerPallete
 import org.jetbrains.compose.resources.stringResource
 import textkit.shared.generated.resources.Res
 import textkit.shared.generated.resources.bold_text
@@ -70,8 +80,6 @@ fun TextKitScreen(
     content: @Composable () -> Unit
 ) {
     MaterialTheme {
-        // height(IntrinsicSize.Min) makes the Row as tall as its tallest child (a FormattingItem),
-        // so the separator's fillMaxHeight resolves to the item height instead of the whole bar.
         Scaffold(modifier) { innerPadding ->
             Column(modifier = Modifier.padding(innerPadding)) {
                 content()
@@ -82,8 +90,9 @@ fun TextKitScreen(
 
 @Composable
 fun TextKitFormattingBar(
-    barState: TextKitFormattingBarState = rememberTextKitFormattingBarState(),
     selectedColor: Color,
+    modifier: Modifier = Modifier,
+    barState: TextKitFormattingBarState = rememberTextKitFormattingBarState(),
     onBoldClick: (Boolean) -> Unit = {},
     onItalicClick: (Boolean) -> Unit = {},
     onUnderlineClick: (Boolean) -> Unit = {},
@@ -92,32 +101,58 @@ fun TextKitFormattingBar(
     onLinkClick: (Boolean) -> Unit = {},
     onOrderedListClick: (Boolean) -> Unit = {},
     onBulletedListClick: (Boolean) -> Unit = {},
+    onTextAndColorClick: (Rect) -> Unit = {},
     onUndoClick: () -> Unit = {},
     onRedoClick: () -> Unit = {},
     canUndo: Boolean = false,
-    canRedo: Boolean = false,
-    modifier: Modifier = Modifier
+    canRedo: Boolean = false
 ) {
-    Row(modifier = modifier.height(IntrinsicSize.Min)) {
-        TextKitTooltipFormattingItem(
-            tooltipText = stringResource(Res.string.undo_text),
-            rememberVectorPainter(Icons.AutoMirrored.Rounded.Undo),
-            onClick = { onUndoClick() },
-            value = false,
-            backgroundColor = selectedColor,
-            enabled = canUndo
-        )
-        TextKitFormattingSeparator()
-        TextKitTooltipFormattingItem(
-            tooltipText = stringResource(Res.string.redo_text),
-            rememberVectorPainter(Icons.AutoMirrored.Rounded.Redo),
-            onClick = { onRedoClick() },
-            value = false,
-            backgroundColor = selectedColor,
-            enabled = canRedo
-        )
-        TextKitFormattingDivider()
-        TextKitFormattingSeparator()
+    TextKitFormattingBarInternal(
+        selectedColor = selectedColor,
+        modifier = modifier,
+        barState = barState,
+        onBoldClick = onBoldClick,
+        onItalicClick = onItalicClick,
+        onUnderlineClick = onUnderlineClick,
+        onStrikeThroughClick = onStrikeThroughClick,
+        onHighlightClick = onHighlightClick,
+        onSizeAndColorClick = onTextAndColorClick,
+        onLinkClick = onLinkClick,
+        onOrderedListClick = onOrderedListClick,
+        onBulletedListClick = onBulletedListClick,
+        onUndoClick = onUndoClick,
+        onRedoClick = onRedoClick,
+        canUndo = canUndo,
+        canRedo = canRedo
+    )
+}
+
+@Composable
+fun TextKitFormattingBarInternal(
+    selectedColor: Color,
+    modifier: Modifier = Modifier,
+    barState: TextKitFormattingBarState = rememberTextKitFormattingBarState(),
+    onBoldClick: (Boolean) -> Unit = {},
+    onItalicClick: (Boolean) -> Unit = {},
+    onUnderlineClick: (Boolean) -> Unit = {},
+    onStrikeThroughClick: (Boolean) -> Unit = {},
+    onHighlightClick: (Boolean) -> Unit = {},
+    onSizeAndColorClick: (Rect) -> Unit = {},
+    onLinkClick: (Boolean) -> Unit = {},
+    onOrderedListClick: (Boolean) -> Unit = {},
+    onBulletedListClick: (Boolean) -> Unit = {},
+    onUndoClick: () -> Unit = {},
+    onRedoClick: () -> Unit = {},
+    canUndo: Boolean = false,
+    canRedo: Boolean = false
+) {
+    var textSizeAndColorBounds by remember { mutableStateOf(Rect.Zero) }
+
+    Row(
+        modifier = modifier
+            .horizontalScroll(rememberScrollState())
+            .height(IntrinsicSize.Min)
+    ) {
         TextKitTooltipFormattingItem(
             tooltipText = stringResource(Res.string.bold_text),
             rememberVectorPainter(Icons.Rounded.FormatBold),
@@ -157,6 +192,17 @@ fun TextKitFormattingBar(
             value = barState.isHighlight,
             backgroundColor = selectedColor
         )
+        TextKitFormattingSeparator()
+        TextKitTooltipFormattingItem(
+            tooltipText = stringResource(Res.string.text_color_text),
+            rememberVectorPainter(Icons.Outlined.Palette),
+            value = false,
+            isExpandable = true,
+            onClick = { onSizeAndColorClick(textSizeAndColorBounds) },
+            modifier = Modifier.onGloballyPositioned {
+                textSizeAndColorBounds = it.boundsInWindow()
+            }
+        )
         TextKitFormattingDivider()
         TextKitFormattingSeparator()
         TextKitTooltipFormattingItem(
@@ -186,10 +232,21 @@ fun TextKitFormattingBar(
         TextKitFormattingDivider()
         TextKitFormattingSeparator()
         TextKitTooltipFormattingItem(
-            tooltipText = stringResource(Res.string.text_color_text),
-            rememberVectorPainter(Icons.Outlined.Palette),
+            tooltipText = stringResource(Res.string.undo_text),
+            rememberVectorPainter(Icons.AutoMirrored.Rounded.Undo),
+            onClick = { onUndoClick() },
             value = false,
-            onClick = {}
+            backgroundColor = selectedColor,
+            enabled = canUndo
+        )
+        TextKitFormattingSeparator()
+        TextKitTooltipFormattingItem(
+            tooltipText = stringResource(Res.string.redo_text),
+            rememberVectorPainter(Icons.AutoMirrored.Rounded.Redo),
+            onClick = { onRedoClick() },
+            value = false,
+            backgroundColor = selectedColor,
+            enabled = canRedo
         )
     }
 }
@@ -199,6 +256,7 @@ fun TextKitTooltipFormattingItem(
     tooltipText: String,
     painter: Painter,
     value: Boolean,
+    isExpandable: Boolean = false,
     onClick: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     backgroundColor: Color = Color.Unspecified,
@@ -216,15 +274,40 @@ fun TextKitTooltipFormattingItem(
             }
         }
     ) {
-        TextKitFormattingItem(
-            painter = painter,
-            value = value,
-            onValueChange = onClick,
-            backgroundColor = backgroundColor,
-            enabled = enabled
-        )
+        val indicatorColor =
+            MaterialTheme.colorScheme.secondary.copy(alpha = if (enabled) 1f else 0.38f)
+        Box {
+            TextKitFormattingItem(
+                painter = painter,
+                value = value,
+                onValueChange = onClick,
+                backgroundColor = backgroundColor,
+                enabled = enabled
+            )
+            if (isExpandable) {
+                TextKitItemExpandableIndicator(indicatorColor)
+            }
+        }
     }
+}
 
+@Composable
+private fun BoxScope.TextKitItemExpandableIndicator(indicatorColor: Color) {
+    Canvas(
+        modifier = Modifier
+            .padding(2.dp)
+            .size(6.dp)
+            .align(Alignment.BottomEnd)
+    ) {
+        val path = Path().apply {
+            moveTo(size.width, size.height)     // right corner
+            lineTo(0f, size.height)             // lower left
+            lineTo(size.width, 0f)              // upper right
+            close()
+        }
+
+        drawPath(path = path, color = indicatorColor)
+    }
 }
 
 @Composable
@@ -287,6 +370,7 @@ private fun TextKitFormattingSeparator(
 private fun TextKitFormattingBarPreview() {
     MaterialTheme {
         TextKitFormattingBar(
+            barState = rememberTextKitFormattingBarState(colors = TextKitPickerPallete.DefaultPallete),
             selectedColor = Color.Yellow
         )
     }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitFormattingBarState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitFormattingBarState.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
 import com.jjrodcast.textkit.editor.components.TextEditorDecoratorItem
 import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.core.parser.BoldMark
@@ -15,7 +16,9 @@ import com.jjrodcast.textkit.editor.core.parser.ItalicMark
 import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.parser.StrikeMark
+import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
 import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
+import com.jjrodcast.textkit.ui.utils.TextKitPickerPallete
 import com.jjrodcast.textkit.ui.utils.restore
 import com.jjrodcast.textkit.ui.utils.save
 
@@ -25,12 +28,15 @@ import com.jjrodcast.textkit.ui.utils.save
  * The state reflects which formatting toggles (bold, italic, list type, …) are active at the
  * caret, so the [com.jjrodcast.textkit.ui.TextKitFormattingBar] can highlight them. Keep it in
  * sync with the editor via [TextKitFormattingBarState.syncFrom].
+ *
+ * @param colors The palette shown in the text-color picker popup. Re-applied on every composition,
+ * so it is caller-owned configuration (not persisted through the [TextKitFormattingBarState.Saver]).
  */
 @Composable
-fun rememberTextKitFormattingBarState(): TextKitFormattingBarState {
+fun rememberTextKitFormattingBarState(colors: List<Color> = emptyList()): TextKitFormattingBarState {
     return rememberSaveable(saver = TextKitFormattingBarState.Saver) {
         TextKitFormattingBarState()
-    }
+    }.also { it.colors = colors }
 }
 
 /**
@@ -51,6 +57,7 @@ class TextKitFormattingBarState(
     isUnderline: Boolean = false,
     isStrikethrough: Boolean = false,
     isHighlight: Boolean = false,
+    isTextStyle: Boolean = false,
     isLink: Boolean = false,
     listItem: TextEditorDecoratorItem = TextEditorListItem.None,
 ) {
@@ -76,6 +83,16 @@ class TextKitFormattingBarState(
     var listItem by mutableStateOf(listItem)
         private set
 
+    var isTextStyle by mutableStateOf(isTextStyle)
+        private set
+
+    /**
+     * Palette shown in the text-color picker popup. Set from [rememberTextKitFormattingBarState];
+     * read by [com.jjrodcast.textkit.ui.TextKitFormattingBar].
+     */
+    var colors by mutableStateOf<List<Color>>(emptyList())
+        internal set
+
     val isNumberedList get() = listItem == TextEditorListItem.NumberedList
 
     val isBulletedList get() = listItem == TextEditorListItem.BulletedList
@@ -94,6 +111,7 @@ class TextKitFormattingBarState(
         isStrikethrough = marks.any { it is StrikeMark }
         isHighlight = marks.any { it is HighlightMark }
         isLink = marks.any { it is LinkMark }
+        isTextStyle = marks.any { it is TextStyleMark }
         this.listItem = listItem
     }
 
@@ -107,6 +125,7 @@ class TextKitFormattingBarState(
                     save(it.isUnderline),
                     save(it.isStrikethrough),
                     save(it.isHighlight),
+                    save(it.isTextStyle),
                     save(it.isLink),
                     save(it.listItem.toTag()),
                 )
@@ -120,8 +139,9 @@ class TextKitFormattingBarState(
                     isUnderline = restore(list[2])!!,
                     isStrikethrough = restore(list[3])!!,
                     isHighlight = restore(list[4])!!,
-                    isLink = restore(list[5])!!,
-                    listItem = restore<String>(list[6])!!.toListItem(),
+                    isTextStyle = restore(list[5])!!,
+                    isLink = restore(list[6])!!,
+                    listItem = restore<String>(list[7])!!.toListItem(),
                 )
             }
         )

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -1,6 +1,5 @@
 package com.jjrodcast.textkit.ui.state
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
@@ -19,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.ParagraphStyle
@@ -71,6 +71,7 @@ import com.jjrodcast.textkit.ui.model.TextKitLinkInfo
 import com.jjrodcast.textkit.ui.utils.createStyle
 import com.jjrodcast.textkit.ui.utils.restore
 import com.jjrodcast.textkit.ui.utils.save
+import com.jjrodcast.textkit.ui.utils.toColorInt
 
 /**
  * A state object that can be used to remember the state of a RichText component across recomposition.
@@ -145,6 +146,37 @@ class TextKitState(
      */
     var lastListItem by mutableStateOf<TextEditorDecoratorItem>(TextEditorListItem.None)
         private set
+
+    /**
+     * Color of the text at the caret/selection ([lastMarks]'s text-style mark), or null when the
+     * text has no explicit color. Observe it to seed a color picker's initial selection — e.g. pass
+     * it as `defaultTextColor` to [com.jjrodcast.textkit.ui.TextKitFormattingBar] so the current
+     * color is marked when the picker opens (and nothing is marked when there is none).
+     */
+    val currentTextColor: Color?
+        get() = (lastMarks.firstOrNull { it is TextStyleMark } as? TextStyleMark)
+            ?.attrs?.color
+            ?.takeIf { it.isNotBlank() }
+            ?.let { runCatching { Color(it.toColorInt()) }.getOrNull() }
+
+    /**
+     * Window-coordinate bounds the colors popup is anchored to while open, or null when it is closed.
+     * Mirrors the [activeLink] pattern: observe it to show
+     * [com.jjrodcast.textkit.ui.TextKitColorsPopup], which reads [currentTextColor] to mark the active
+     * swatch and calls [applyTextColor] to write the pick back to the editor.
+     */
+    var activeColorAnchor by mutableStateOf<Rect?>(null)
+        private set
+
+    /** Opens the colors popup anchored at [anchor] (e.g. the formatting bar's palette button bounds). */
+    fun openColorPicker(anchor: Rect) {
+        activeColorAnchor = anchor
+    }
+
+    /** Closes the colors popup. */
+    fun dismissColorPicker() {
+        activeColorAnchor = null
+    }
 
     internal var textLayoutResult: TextLayoutResult? by mutableStateOf(null)
         private set
@@ -369,6 +401,34 @@ class TextKitState(
             TextStyleMark(TextStyleAttrs(fontSize = fontSize, color = color)),
             selected = true
         )
+
+    /**
+     * Changes only the text [color] (a hex string such as `#FF0000`, or null to reset to the
+     * configured default color) over the current selection, keeping whatever font size the text
+     * already has. Prefer this over [applyTextStyle] for a color picker: passing `fontSize = 0`
+     * to [applyTextStyle] would render the text at 0sp. With a collapsed caret the color is stored
+     * for the next typed text. Returns whether the state changed.
+     */
+    fun applyTextColor(color: String?): Boolean {
+        val target = markTarget()
+        if (target.collapsed) {
+            // Store a color-only text style so the next typed characters inherit it, keeping any
+            // font size already stored at the caret (falling back to the configured default).
+            val size = (lastMarks.firstOrNull { it is TextStyleMark } as? TextStyleMark)
+                ?.attrs?.fontSize ?: configuration.fontSize
+            lastMarks = lastMarks.filterNotTo(mutableSetOf()) { it is TextStyleMark } +
+                TextStyleMark(TextStyleAttrs(color = color, fontSize = size))
+            return true
+        }
+        // The Color transaction resolves the marks from the selection itself (preserving font size),
+        // so prev/curr marks are ignored here.
+        return updateDocument(
+            target,
+            TextEditorSelectedMark(marks = lastMarks, listItemSelectedValue = lastListItem),
+            TextEditorSelectedMark(marks = lastMarks, listItemSelectedValue = lastListItem),
+            transactionType = TextEditorTransactionType.Color(color)
+        )
+    }
 
     /**
      * Applies a heading of [level] (1..6) by setting the matching heading font size (see

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/utils/TextKitPickerPallete.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/utils/TextKitPickerPallete.kt
@@ -1,0 +1,77 @@
+package com.jjrodcast.textkit.ui.utils
+
+import androidx.compose.ui.graphics.Color
+
+object TextKitPickerPallete {
+
+    val DefaultPallete = listOf(
+
+        // Grises
+        Color.Black,
+        Color(0xFF444444),
+        Color(0xFF666666),
+        Color(0xFF999999),
+        Color(0xFFBBBBBB),
+        Color(0xFFDDDDDD),
+        Color.White,
+        Color(0xFFAA0000),
+        Color.Red,
+        Color(0xFFFF9800),
+
+        Color.Yellow,
+        Color.Green,
+        Color.Cyan,
+        Color(0xFF4A86E8),
+        Color.Blue,
+        Color(0xFF8A2BE2),
+        Color.Magenta,
+
+        // Light tones
+        Color(0xFFF4CCCC),
+        Color(0xFFFCE5CD),
+        Color(0xFFFFF2CC),
+        Color(0xFFD9EAD3),
+        Color(0xFFD0E0E3),
+        Color(0xFFC9DAF8),
+        Color(0xFFD9D2E9),
+        Color(0xFFEAD1DC),
+
+        // Medium tones
+        Color(0xFFEA9999),
+        Color(0xFFF9CB9C),
+        Color(0xFFFFE599),
+        Color(0xFFB6D7A8),
+        Color(0xFFA2C4C9),
+        Color(0xFFA4C2F4),
+        Color(0xFFB4A7D6),
+        Color(0xFFD5A6BD),
+
+        // Dark tones
+        Color(0xFFE06666),
+        Color(0xFFF6B26B),
+        Color(0xFFFFD966),
+        Color(0xFF93C47D),
+        Color(0xFF76A5AF),
+        Color(0xFF6D9EEB),
+        Color(0xFF8E7CC3),
+        Color(0xFFC27BA0),
+
+        Color(0xFFCC4125),
+        Color(0xFFE69138),
+        Color(0xFFF1C232),
+        Color(0xFF6AA84F),
+        Color(0xFF45818E),
+        Color(0xFF3C78D8),
+        Color(0xFF674EA7),
+        Color(0xFFA64D79),
+
+        Color(0xFF85200C),
+        Color(0xFFB45F06),
+        Color(0xFFBF9000),
+        Color(0xFF38761D),
+        Color(0xFF134F5C),
+        Color(0xFF1155CC),
+        Color(0xFF351C75),
+        Color(0xFF741B47)
+    )
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/utils/TextKitPopupAnchorProvider.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/utils/TextKitPopupAnchorProvider.kt
@@ -1,0 +1,53 @@
+package com.jjrodcast.textkit.ui.utils
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.window.PopupPositionProvider
+import com.jjrodcast.textkit.ui.TextKitFormattingBar
+import kotlin.math.roundToInt
+
+object TextKitPopupAnchorProvider {
+
+    /**
+     * A [PopupPositionProvider] that anchors a `Popup` to [anchorBoundsInWindow] (as delivered by
+     * [TextKitFormattingBar]'s `onTextAndColorClick`). It places the popup [gap] px below the anchor,
+     * flips it above when it would overflow the bottom, and clamps it horizontally so it always stays
+     * inside the window — i.e. it adapts to the screen.
+     *
+     * ```kotlin
+     * var anchor by remember { mutableStateOf<Rect?>(null) }
+     * TextKitFormattingBar(/* … */ onTextAndColorClick = { anchor = it })
+     * anchor?.let {
+     *     Popup(
+     *         popupPositionProvider = TextKitPopupAnchorProvider.positionProvider(it),
+     *         onDismissRequest = { anchor = null },
+     *     ) { /* your color & size picker */ }
+     * }
+     * ```
+     */
+    fun positionProvider(
+        anchorBoundsInWindow: Rect,
+        gap: Int = 8,
+    ): PopupPositionProvider = object : PopupPositionProvider {
+        override fun calculatePosition(
+            anchorBounds: IntRect,
+            windowSize: IntSize,
+            layoutDirection: LayoutDirection,
+            popupContentSize: IntSize,
+        ): IntOffset {
+            // Align the popup's left edge with the anchor, clamped so it never spills past the window.
+            val x = anchorBoundsInWindow.left.roundToInt()
+                .coerceIn(0, (windowSize.width - popupContentSize.width).coerceAtLeast(0))
+            // Prefer below the anchor; flip above when it would overflow the bottom (unless above is worse).
+            val below = anchorBoundsInWindow.bottom.roundToInt() + gap
+            val above = anchorBoundsInWindow.top.roundToInt() - gap - popupContentSize.height
+            val y =
+                if (below + popupContentSize.height <= windowSize.height || above < 0) below else above
+            return IntOffset(x, y)
+        }
+    }
+
+}


### PR DESCRIPTION
Text color picker
- TextKitColorsPopup — new component that mirrors the TextKitLinkPopup pattern: driven by editor state, applies the pick back to the document, and reflects the selection's current color.
- TextKitColorPickerGrid — palette grid with a leading "no color" swatch (white circle + red diagonal) that emits null.
- New TextKitState APIs: openColorPicker(bounds), dismissColorPicker(), observable activeColorAnchor: Rect?, applyTextColor(hex) (color-only — keeps the current font size; null resets to default), and currentTextColor: Color?.
- TextKitPopupAnchorProvider — screen-adaptive positioning (below the anchor, flips above / clamps horizontally).