### PR TITLE
Bug: Fixing paragraph type on empty paragraphs

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/MultiPieceParagraph.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/MultiPieceParagraph.kt
@@ -1,6 +1,7 @@
 package com.jjrodcast.textkit.editor.core.models
 
 import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorDecoratorItem
 import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.core.parser.Mark
@@ -70,6 +71,25 @@ internal data class MultiPieceParagraph(
                 if (end == pieceEnd || intersect(start, end, pieceStart, pieceEnd)) add(model)
             }
         }
+    }
+
+    /**
+     * Paragraph type of the first paragraph holding a piece within [[start], [end]] — the same piece
+     * selection rule as [getAllModelsInRange] (`end == pieceEnd || intersect`), but returning on the
+     * first match with no list/model allocation. Used to resolve the list type at a caret cheaply on
+     * every selection change. Null when no piece falls in range.
+     */
+    fun firstParagraphTypeInRange(): TextEditorDecoratorItem? {
+        paragraphs.fastForEach { paragraph ->
+            paragraph.pieces.fastForEach { piece ->
+                val pieceStart = piece.offsetInDocument
+                val pieceEnd = pieceStart + piece.piece.length
+                if (end == pieceEnd || intersect(start, end, pieceStart, pieceEnd)) {
+                    return paragraph.paragraphType
+                }
+            }
+        }
+        return null
     }
 
     fun findSelectedParagraphIndicesByLevel(level: Int): List<Int> {

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
@@ -135,9 +135,10 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
         // For a collapsed caret the line-content walk resolves to the paragraph that ENDS at the
         // caret, so a caret sitting right after a list item's trailing line break inherits that
         // item's list type — even when it actually rests on the following (often empty) paragraph.
-        // Re-derive the list type from the paragraph that STARTS at the caret (peek one char
-        // forward) so an empty paragraph after a list is not marked as a list, while the start of a
-        // following list item still is.
+        // The forward paragraph is NOT present in that walk's data (data.size == 1 at the boundary),
+        // so it can't be derived in-layer; re-derive the list type from the paragraph that STARTS at
+        // the caret (peek one char forward) so an empty paragraph after a list is not marked as a
+        // list, while the start of a following list item still is.
         if (start != end) return base
         return base.copy(listItem = forwardListItemAt(start))
     }
@@ -151,9 +152,7 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
     private fun forwardListItemAt(offset: Int): TextEditorDecoratorItem {
         val end = (offset + 1).coerceAtMost(text.length)
         return pieceTable.getLineContent(offset, end)
-            .getAllModelsInRange()
-            .firstOrNull()
-            ?.paragraphType
+            .firstParagraphTypeInRange()
             ?: TextEditorListItem.None
     }
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
@@ -2,6 +2,7 @@ package com.jjrodcast.textkit.editor.core.transactions
 
 import androidx.compose.ui.text.TextRange
 import com.jjrodcast.textkit.editor.components.TextEditorDecoratorItem
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.core.converters.PieceTableConverter
 import com.jjrodcast.textkit.editor.core.converters.TextEditorConverter
 import com.jjrodcast.textkit.editor.core.interfaces.TextEditorInitTransaction
@@ -130,7 +131,30 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
         end: Int,
         configuration: TextKitConfiguration
     ): MarkSearchType {
-        return pieceTable.getLineContent(start, end).getMarksWithType(configuration)
+        val base = pieceTable.getLineContent(start, end).getMarksWithType(configuration)
+        // For a collapsed caret the line-content walk resolves to the paragraph that ENDS at the
+        // caret, so a caret sitting right after a list item's trailing line break inherits that
+        // item's list type — even when it actually rests on the following (often empty) paragraph.
+        // Re-derive the list type from the paragraph that STARTS at the caret (peek one char
+        // forward) so an empty paragraph after a list is not marked as a list, while the start of a
+        // following list item still is.
+        if (start != end) return base
+        return base.copy(listItem = forwardListItemAt(start))
+    }
+
+    /**
+     * List type of the paragraph the collapsed caret at [offset] belongs to, resolved forward: the
+     * first piece of the range `[offset, offset + 1)` carries its paragraph's type (a bare line-break
+     * piece for an empty paragraph yields [TextEditorListItem.None]; a list item's decorator yields
+     * its list type). At the document end the range collapses and falls back to the last paragraph.
+     */
+    private fun forwardListItemAt(offset: Int): TextEditorDecoratorItem {
+        val end = (offset + 1).coerceAtMost(text.length)
+        return pieceTable.getLineContent(offset, end)
+            .getAllModelsInRange()
+            .firstOrNull()
+            ?.paragraphType
+            ?: TextEditorListItem.None
     }
 
     override fun containsDecorator(start: Int, end: Int): Pair<Boolean, TextRange> {

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyParagraphAfterListTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyParagraphAfterListTest.kt
@@ -1,0 +1,58 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EmptyParagraphAfterListTest {
+
+    // An ordered list, then a genuinely empty paragraph (it survives because content follows it),
+    // then a plain text paragraph. Mirrors complexJsonV1's "empty paragraph after the list" case.
+    private val listThenEmptyThenText = """
+        {"type":"doc","content":[
+          {"type":"orderedList","attrs":{"start":1},"content":[
+            {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"one"}]}]},
+            {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"two"}]}]}
+          ]},
+          {"type":"paragraph"},
+          {"type":"paragraph","content":[{"type":"text","text":"after"}]}
+        ]}
+    """
+
+    @Test
+    fun caretOnEmptyParagraphBetweenListAndText_isNotMarkedAsList() {
+        val editor = editorFrom(listThenEmptyThenText)
+        // The empty paragraph sits between the "two\n" list item and "after"; its offset is right
+        // after the list's last line break.
+        val emptyOffset = editor.offsetOf("after") - 1
+        assertEquals(
+            TextEditorListItem.None,
+            editor.getSearchMarkType(TextRange(emptyOffset)).listItem,
+            "Empty paragraph after the list must not be marked as a list"
+        )
+    }
+
+    @Test
+    fun caretInsideOrderedListItem_staysMarkedAsList() {
+        val editor = editorFrom(listThenEmptyThenText)
+        val inside = editor.offsetOf("two")
+        assertEquals(
+            TextEditorListItem.NumberedList,
+            editor.getSearchMarkType(TextRange(inside)).listItem,
+            "Caret inside a list item must still report the list type"
+        )
+    }
+
+    @Test
+    fun caretAtStartOfSecondListItem_staysMarkedAsList() {
+        val editor = editorFrom(listThenEmptyThenText)
+        // Boundary right after the first item's line break and before the second item's marker.
+        val startOfSecond = editor.offsetOf("		2.")
+        assertEquals(
+            TextEditorListItem.NumberedList,
+            editor.getSearchMarkType(TextRange(startOfSecond)).listItem,
+            "Caret at the start of a following list item must still report the list type"
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyParagraphAfterListTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyParagraphAfterListTest.kt
@@ -2,6 +2,7 @@ package com.jjrodcast.textkit
 
 import androidx.compose.ui.text.TextRange
 import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.utils.TABS
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -48,7 +49,7 @@ class EmptyParagraphAfterListTest {
     fun caretAtStartOfSecondListItem_staysMarkedAsList() {
         val editor = editorFrom(listThenEmptyThenText)
         // Boundary right after the first item's line break and before the second item's marker.
-        val startOfSecond = editor.offsetOf("		2.")
+        val startOfSecond = editor.offsetOf("${TABS}2.")
         assertEquals(
             TextEditorListItem.NumberedList,
             editor.getSearchMarkType(TextRange(startOfSecond)).listItem,


### PR DESCRIPTION
- There was an issue when the caret moves to an empty paragraph and the previos was a numbered, unordered or tasklist it keep that type of paragraph but its wrong it needs to be a regular paragraph and the formatting bar doesnt need to select any type.