### PR TITLE
Fix: Popup theming + Highlight colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ state.applyStrikeThrough(selected = true)
 state.applyHighlight(selected = true)
 ```
 
+The highlight background follows the theme's `highlight` role (a warm amber that adapts to light/dark)
+and is painted translucently so a range selection stays visible over highlighted text. Pin a fixed
+color with `highlightColor { … }` in the [Configuration](#configuration) to override the theme.
+
 ## Text style (color & size)
 
 `applyTextStyle` sets the font size (in the document's font-size units) and an optional hex color
@@ -515,7 +519,7 @@ import com.jjrodcast.textkit.editor.models.TextKitTrigger
 import com.jjrodcast.textkit.editor.models.createTextKitConfiguration
 
 val configuration = createTextKitConfiguration {
-    highlightColor { Color.Yellow }
+    highlightColor { Color.Yellow }                          // optional: pin the highlight background; omit to follow the theme's `highlight` role
     linkColor { Color(0xFF1B75D0) }
     textColor { Color(0xFF000000) }
     fontSize { 14 }                                          // default font size

--- a/docs/theming/README.md
+++ b/docs/theming/README.md
@@ -47,6 +47,7 @@ override it.
 | `primary` | Main accent: active/selected states (e.g. the toggled formatting-bar button background, cursor/caret), primary actions | `onPrimary` |
 | `primaryContainer` | Softer accent surfaces tied to primary: highlighted chips, selected embed placeholders, subtle emphasis | `onPrimaryContainer` |
 | `secondary` | Supporting accent for smaller UI cues (e.g. the expandable-item indicator) | `onSecondary` |
+| `highlight` | Background of text carrying the **highlight mark**. A warm amber, deliberately off the teal `primary` family so it stays distinct from the text selection painted over it | `onHighlight` |
 | `background` | The editor’s base surface (the `BasicTextField` area) | `onBackground` |
 | `surface` | Raised containers: the formatting bar `Card`, popups, tooltips, menus | `onSurface` |
 | `surfaceVariant` | Secondary/muted surfaces and muted content: popup sections, placeholder text, disabled backgrounds | `onSurfaceVariant` |
@@ -77,6 +78,18 @@ Box(Modifier.background(TextKitTheme.colors.primary)) {
   (input fields); `outlineVariant` for low-emphasis separators (dividers).
 - **`primary` vs `primaryContainer`** — `primary` is a strong fill with light content on top;
   `primaryContainer` is a tinted, low-contrast fill for subtle highlights.
+- **`highlight` vs `primaryContainer`** — both are soft fills, but `highlight` is a warm amber for the
+  *text highlight mark* specifically, chosen to contrast with the teal selection drawn on top of it;
+  `primaryContainer` stays in the teal family for accent chips/embeds. Don't swap them, or a range
+  selection over highlighted text becomes hard to see.
+
+### Text highlight
+
+The **highlight mark** (`state.applyHighlight(...)`) paints its background from the `highlight` role by
+default, so it adapts to light/dark automatically. The color is applied translucently so a range
+selection stays visible over highlighted text. You can pin a fixed highlight color per editor via the
+configuration's `highlightColor { … }` (see the main README's *Configuration*), which overrides the
+theme; leave it unset to track `highlight`.
 
 ## Typography & shapes
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/models/TextKitBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/models/TextKitBuilder.kt
@@ -4,7 +4,8 @@ import androidx.compose.ui.graphics.Color
 
 class TextKitBuilder {
 
-    private var highlightColor: Color = Color.Yellow
+    // null → the highlight tracks the active TextKitTheme's highlight role; set it to pin a color.
+    private var highlightColor: Color? = null
 
     // Full-alpha (0xFF…) Long literals. Without the alpha byte these are Int literals and hit the
     // Color(Int) constructor with alpha 0x00 → fully transparent, so links/text render invisibly.

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/models/TextKitConfiguration.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/models/TextKitConfiguration.kt
@@ -5,7 +5,13 @@ import androidx.compose.ui.graphics.Color
 
 @Immutable
 data class TextKitConfiguration(
-    val highlightColor: Color = Color.Yellow,
+    /**
+     * Background color for text carrying the highlight mark. `null` (the default) makes the highlight
+     * track the active `TextKitTheme`'s `highlight` role (a warm amber), so it adapts to light/dark;
+     * set a color to pin it regardless of theme. Either way an opaque color is painted translucently
+     * so a range selection stays visible over highlighted text.
+     */
+    val highlightColor: Color? = null,
     val linkColor: Color = Color(0xFF1B75D0),
     val textColor: Color = Color(0xFF000000),
     val fontSize: Int = 14,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/theme/TextKitColors.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/theme/TextKitColors.kt
@@ -21,6 +21,9 @@ import com.jjrodcast.textkit.theme.tokens.TextKitLightTokens
  * @property onPrimaryContainer Content drawn on top of [primaryContainer].
  * @property secondary Supporting accent for smaller cues (e.g. the expandable-item indicator).
  * @property onSecondary Content drawn on top of [secondary].
+ * @property highlight Background of text carrying the highlight mark. A warm amber, deliberately off
+ *   the teal [primary] family so it stays distinct from the text selection painted over it.
+ * @property onHighlight Content drawn on top of [highlight].
  * @property background The editor's base surface (the `BasicTextField` area).
  * @property onBackground Content drawn on top of [background].
  * @property surface Raised containers: the formatting-bar `Card`, popups, tooltips, menus.
@@ -40,6 +43,8 @@ class TextKitColors(
     val onPrimaryContainer: Color,
     val secondary: Color,
     val onSecondary: Color,
+    val highlight: Color,
+    val onHighlight: Color,
     val background: Color,
     val onBackground: Color,
     val surface: Color,
@@ -65,6 +70,8 @@ class TextKitColors(
             onPrimaryContainer: Color = TextKitLightTokens.ON_PRIMARY_CONTAINER,
             secondary: Color = TextKitLightTokens.SECONDARY,
             onSecondary: Color = TextKitLightTokens.ON_SECONDARY,
+            highlight: Color = TextKitLightTokens.HIGHLIGHT,
+            onHighlight: Color = TextKitLightTokens.ON_HIGHLIGHT,
             background: Color = TextKitLightTokens.BACKGROUND,
             onBackground: Color = TextKitLightTokens.ON_BACKGROUND,
             surface: Color = TextKitLightTokens.SURFACE,
@@ -84,6 +91,8 @@ class TextKitColors(
                 onPrimaryContainer = onPrimaryContainer,
                 secondary = secondary,
                 onSecondary = onSecondary,
+                highlight = highlight,
+                onHighlight = onHighlight,
                 background = background,
                 onBackground = onBackground,
                 surface = surface,
@@ -108,6 +117,8 @@ class TextKitColors(
             onPrimaryContainer: Color = TextKitDarkTokens.ON_PRIMARY_CONTAINER,
             secondary: Color = TextKitDarkTokens.SECONDARY,
             onSecondary: Color = TextKitDarkTokens.ON_SECONDARY,
+            highlight: Color = TextKitDarkTokens.HIGHLIGHT,
+            onHighlight: Color = TextKitDarkTokens.ON_HIGHLIGHT,
             background: Color = TextKitDarkTokens.BACKGROUND,
             onBackground: Color = TextKitDarkTokens.ON_BACKGROUND,
             surface: Color = TextKitDarkTokens.SURFACE,
@@ -127,6 +138,8 @@ class TextKitColors(
                 onPrimaryContainer = onPrimaryContainer,
                 secondary = secondary,
                 onSecondary = onSecondary,
+                highlight = highlight,
+                onHighlight = onHighlight,
                 background = background,
                 onBackground = onBackground,
                 surface = surface,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/theme/tokens/TextKitDarkTokens.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/theme/tokens/TextKitDarkTokens.kt
@@ -10,6 +10,8 @@ internal object TextKitDarkTokens {
      val ON_PRIMARY_CONTAINER = Color(0xFFA7F2DE)
      val SECONDARY = Color(0xFFB1CCC4)
      val ON_SECONDARY = Color(0xFF1C352F)
+     val HIGHLIGHT = Color(0xFF5C4600)
+     val ON_HIGHLIGHT = Color(0xFFFFE082)
      val BACKGROUND = Color(0xFF0E1513)
      val ON_BACKGROUND = Color(0xFFDEE4E1)
      val SURFACE = Color(0xFF1B211F)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/theme/tokens/TextKitLightTokens.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/theme/tokens/TextKitLightTokens.kt
@@ -10,6 +10,8 @@ internal object TextKitLightTokens  {
     val ON_PRIMARY_CONTAINER = Color(0xFF00201A)
     val SECONDARY = Color(0xFF4A635D)
     val ON_SECONDARY = Color(0xFFFFFFFF)
+    val HIGHLIGHT = Color(0xFFFFE9A8)
+    val ON_HIGHLIGHT = Color(0xFF3D2E00)
     val BACKGROUND = Color(0xFFF5FBF7)
     val ON_BACKGROUND = Color(0xFF171D1B)
     val SURFACE = Color(0xFFF5FBF7)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -60,7 +61,7 @@ fun TextKitEditor(
 
     // Highlight-mark background tracks the theme (unless the config pinned its own color).
     val highlightColor = TextKitTheme.colors.highlight
-    LaunchedEffect(highlightColor) { state.setThemeHighlightColor(highlightColor) }
+    SideEffect { state.setThemeHighlightColor(highlightColor) }
 
     BasicTextField(
         modifier = modifier

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
@@ -58,6 +58,10 @@ fun TextKitEditor(
         state.onUrlClicked = onUrlClicked
     }
 
+    // Highlight-mark background tracks the theme (unless the config pinned its own color).
+    val highlightColor = TextKitTheme.colors.highlight
+    LaunchedEffect(highlightColor) { state.setThemeHighlightColor(highlightColor) }
+
     BasicTextField(
         modifier = modifier
             .background(TextKitTheme.colors.background)
@@ -140,6 +144,10 @@ fun TextKitEditorOutlined(
     LaunchedEffect(Unit) {
         state.onUrlClicked = onUrlClicked
     }
+
+    // Highlight-mark background tracks the theme (unless the config pinned its own color).
+    val highlightColor = TextKitTheme.colors.highlight
+    LaunchedEffect(highlightColor) { state.setThemeHighlightColor(highlightColor) }
 
     val interactionSource = remember { MutableInteractionSource() }
     val enabled = true

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
@@ -1,12 +1,12 @@
 package com.jjrodcast.textkit.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,7 +20,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
@@ -35,9 +34,9 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.input.pointer.pointerInput
 import com.jjrodcast.textkit.editor.models.createTextKitConfiguration
 import com.jjrodcast.textkit.theme.TextKitTheme
 import com.jjrodcast.textkit.ui.state.TextKitState

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -161,7 +162,12 @@ private fun EmbedPopupContent(
             }
 
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                TextButton(onClick = onRemove) {
+                TextButton(
+                    onClick = onRemove,
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = TextKitTheme.colors.error
+                    ),
+                ) {
                     Text(stringResource(Res.string.remove_label))
                 }
             }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitLinkPopup.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitLinkPopup.kt
@@ -17,12 +17,14 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -266,6 +268,17 @@ private fun LinkPopupContent(
 ) {
     val textState = rememberTextFieldState(link.text)
     val urlState = rememberTextFieldState(link.url)
+    // Theme the text fields (input text, cursor, border and label) so they follow TextKit instead of
+    // falling back to the default Material color scheme.
+    val fieldColors = OutlinedTextFieldDefaults.colors(
+        focusedTextColor = TextKitTheme.colors.onSurface,
+        unfocusedTextColor = TextKitTheme.colors.onSurface,
+        cursorColor = TextKitTheme.colors.primary,
+        focusedBorderColor = TextKitTheme.colors.primary,
+        unfocusedBorderColor = TextKitTheme.colors.outline,
+        focusedLabelColor = TextKitTheme.colors.primary,
+        unfocusedLabelColor = TextKitTheme.colors.onSurfaceVariant,
+    )
     Card(
         modifier = modifier.widthIn(max = 320.dp),
         shape = shape,
@@ -304,19 +317,26 @@ private fun LinkPopupContent(
                 state = textState,
                 lineLimits = TextFieldLineLimits.SingleLine,
                 label = { Text(stringResource(Res.string.text_label)) },
+                colors = fieldColors,
                 modifier = Modifier.fillMaxWidth(),
             )
             OutlinedTextField(
                 state = urlState,
                 lineLimits = TextFieldLineLimits.SingleLine,
                 label = { Text(stringResource(Res.string.url_label)) },
+                colors = fieldColors,
                 modifier = Modifier.fillMaxWidth(),
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End,
             ) {
-                TextButton(onClick = { onRemove(link) }) {
+                TextButton(
+                    onClick = { onRemove(link) },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = TextKitTheme.colors.error
+                    ),
+                ) {
                     Text(stringResource(Res.string.remove_label))
                 }
                 Spacer(Modifier.size(8.dp))
@@ -328,7 +348,11 @@ private fun LinkPopupContent(
                                 url = urlState.text.toString(),
                             )
                         )
-                    }
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = TextKitTheme.colors.primary,
+                        contentColor = TextKitTheme.colors.onPrimary,
+                    ),
                 ) {
                     Text(stringResource(Res.string.edit_label))
                 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitViewer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitViewer.kt
@@ -2,7 +2,6 @@ package com.jjrodcast.textkit.ui
 
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import com.jjrodcast.textkit.editor.utils.DocumentUtils

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitViewer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitViewer.kt
@@ -2,7 +2,7 @@ package com.jjrodcast.textkit.ui
 
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import com.jjrodcast.textkit.editor.utils.DocumentUtils
 import com.jjrodcast.textkit.theme.TextKitTheme
@@ -23,7 +23,7 @@ fun TextKitViewer(
 ) {
     // Highlight-mark background tracks the theme (unless the config pinned its own color).
     val highlightColor = TextKitTheme.colors.highlight
-    LaunchedEffect(highlightColor) { state.setThemeHighlightColor(highlightColor) }
+    SideEffect { state.setThemeHighlightColor(highlightColor) }
 
     val (text, inlineContent) = state.viewerTextValue
     BasicText(

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitViewer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitViewer.kt
@@ -2,8 +2,10 @@ package com.jjrodcast.textkit.ui
 
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import com.jjrodcast.textkit.editor.utils.DocumentUtils
+import com.jjrodcast.textkit.theme.TextKitTheme
 import com.jjrodcast.textkit.ui.state.TextKitState
 import com.jjrodcast.textkit.ui.state.rememberTextKitState
 
@@ -19,6 +21,10 @@ fun TextKitViewer(
     state: TextKitState,
     modifier: Modifier = Modifier
 ) {
+    // Highlight-mark background tracks the theme (unless the config pinned its own color).
+    val highlightColor = TextKitTheme.colors.highlight
+    LaunchedEffect(highlightColor) { state.setThemeHighlightColor(highlightColor) }
+
     val (text, inlineContent) = state.viewerTextValue
     BasicText(
         modifier = modifier,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitViewer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitViewer.kt
@@ -3,6 +3,7 @@ package com.jjrodcast.textkit.ui
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import com.jjrodcast.textkit.editor.utils.DocumentUtils
 import com.jjrodcast.textkit.theme.TextKitTheme
@@ -23,7 +24,7 @@ fun TextKitViewer(
 ) {
     // Highlight-mark background tracks the theme (unless the config pinned its own color).
     val highlightColor = TextKitTheme.colors.highlight
-    LaunchedEffect(highlightColor) { state.setThemeHighlightColor(highlightColor) }
+    SideEffect { state.setThemeHighlightColor(highlightColor) }
 
     val (text, inlineContent) = state.viewerTextValue
     BasicText(

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -238,6 +238,15 @@ class TextKitState(
      */
     private var lastRangeSelection: TextRange = TextRange.Zero
 
+    /**
+     * Effective highlight-mark background. When the configuration pins
+     * [TextKitConfiguration.highlightColor] that color is used; otherwise it tracks the active theme's
+     * highlight role, pushed in from the composable via [setThemeHighlightColor] so highlights adapt
+     * to light/dark. [Color.Unspecified] until the first push when no override is set (no highlight
+     * drawn), which the composable resolves on its first frame.
+     */
+    private var highlightColor: Color = configuration.highlightColor ?: Color.Unspecified
+
     private var annotatedString by mutableStateOf(AnnotatedString(text = ""))
 
     private val viewerAnnotatedStringState = derivedStateOf {
@@ -271,6 +280,18 @@ class TextKitState(
         val offset = layout.getOffsetForPosition(position).coerceIn(0, textFieldValue.text.length)
         val (href, _) = manager.getLink(offset, offset)
         return href != null
+    }
+
+    /**
+     * Points the highlight-mark background at the active theme's `highlight` role (passed from
+     * [com.jjrodcast.textkit.ui.TextKitEditor] / [com.jjrodcast.textkit.ui.TextKitViewer]). No-op when
+     * the configuration pins its own [TextKitConfiguration.highlightColor]. Rebuilds the rendered text
+     * so a light/dark switch repaints existing highlights right away.
+     */
+    internal fun setThemeHighlightColor(color: Color) {
+        if (configuration.highlightColor != null || color == highlightColor) return
+        highlightColor = color
+        updateAnnotatedString(textFieldValue.selection)
     }
 
     internal fun setup() {
@@ -1111,12 +1132,12 @@ class TextKitState(
                     paragraph.children.forEach { child ->
                         if (child.text.endsWith(lineBreak)) {
                             val text = child.text.dropLast(1)
-                            withStyle(child.createStyle(manager.configuration)) {
+                            withStyle(child.createStyle(manager.configuration, highlightColor)) {
                                 append(text)
                             }
                             append(lineBreak)
                         } else {
-                            withStyle(child.createStyle(manager.configuration)) {
+                            withStyle(child.createStyle(manager.configuration, highlightColor)) {
                                 append(child.text)
                             }
                         }
@@ -1161,7 +1182,7 @@ class TextKitState(
                                     link = LinkAnnotation.Url(
                                         url = child.marks.filterIsInstance<LinkMark>()
                                             .first().attrs.href,
-                                        styles = TextLinkStyles(child.createStyle(manager.configuration)),
+                                        styles = TextLinkStyles(child.createStyle(manager.configuration, highlightColor)),
                                         linkInteractionListener = {
                                             val url = (it as LinkAnnotation.Url).url
                                             onUrlClicked?.invoke(
@@ -1177,7 +1198,7 @@ class TextKitState(
                             } else {
                                 append(text)
                                 addStyle(
-                                    style = child.createStyle(manager.configuration),
+                                    style = child.createStyle(manager.configuration, highlightColor),
                                     start = child.start,
                                     end = child.end
                                 )

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/utils/TextEditorStyles.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/utils/TextEditorStyles.kt
@@ -20,13 +20,16 @@ import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorItem
 import com.jjrodcast.textkit.editor.models.TextKitConfiguration
 
 
-internal fun TextEditorItem.createStyle(configuration: TextKitConfiguration): SpanStyle {
+internal fun TextEditorItem.createStyle(
+    configuration: TextKitConfiguration,
+    highlightColor: Color,
+): SpanStyle {
     val base = SpanStyle(
         color = createColorSpanStyle(configuration.linkColor),
         fontWeight = createBoldSpanStyle(),
         fontStyle = createItalicSpanStyle(),
         fontSize = createTextSizeStyle(),
-        background = createHighlightSpanStyle(configuration.highlightColor),
+        background = createHighlightSpanStyle(highlightColor),
         textDecoration = TextDecoration.combine(
             listOfNotNull(
                 createLinkSpanStyle(),
@@ -85,8 +88,13 @@ private fun TextEditorItem.createTextSizeStyle(textSize: TextUnit = TextUnit.Uns
     } else textSize
 }
 
-private fun TextEditorItem.createHighlightSpanStyle(defaultColor: Color) =
-    if (marks.any { it is HighlightMark }) defaultColor else Color.Unspecified
+private fun TextEditorItem.createHighlightSpanStyle(color: Color): Color {
+    if (marks.none { it is HighlightMark } || color == Color.Unspecified) return Color.Unspecified
+    // Paint an opaque highlight translucently so a range selection (drawn beneath the span
+    // background) stays visible over highlighted text; an override that already carries its own alpha
+    // is honored as-is.
+    return if (color.alpha == 1f) color.copy(alpha = HighlightAlpha) else color
+}
 
 private fun TextEditorItem.createLinkSpanStyle() =
     if (marks.any { it is LinkMark || it is UnderlineMark }) TextDecoration.Underline else null
@@ -110,6 +118,9 @@ private fun TextStyleAttrs.createColor(): Color {
  *
  * @throws IllegalArgumentException if the string is not a valid 6/8-digit hex color.
  */
+/** Opacity applied to an opaque highlight color so a text selection still shows through it. */
+private const val HighlightAlpha = 0.4f
+
 internal fun String.toColorInt(): Int = toColorLong().toInt()
 
 /**


### PR DESCRIPTION
## Problem

The highlight mark was painted with a fixed, opaque Color.Yellow, which caused two issues:
1. It fully covered the range-selection color (primary at 40%), leaving the selection invisible over highlighted text.
2. It was disconnected from TextKitTheme, so it didn't adapt to light/dark.

## Solution

- Dedicated highlight / onHighlight color role in the palette (a warm amber), deliberately off the teal primary family so it contrasts with the selection. Defined in TextKitLightTokens/TextKitDarkTokens and exposed as a parameter in TextKitColors.light()/dark().
- Highlight follows the theme by default: TextKitConfiguration.highlightColor is now Color? = null. When null, the highlight background uses TextKitTheme.colors.highlight (adapts to light/dark); when set, it honors the user's color (optional override, backward compatible).
- Selection shows over the highlight: the highlight background is painted translucently (alpha 0.4) when the color is opaque, letting the selection color come through. An override that already carries its own alpha is respected as-is.
- The theme color is propagated to rendering from the composables (TextKitEditor, TextKitEditorOutlined, TextKitViewer) into TextKitState, which rebuilds the rendered text on a light/dark switch.

## Changes

- theme/tokens/TextKitLightTokens.kt, TextKitDarkTokens.kt — HIGHLIGHT / ON_HIGHLIGHT tokens.
- theme/TextKitColors.kt — highlight / onHighlight roles (constructor, KDoc, light(), dark()).
- editor/models/TextKitConfiguration.kt, TextKitBuilder.kt — highlightColor is now nullable (default → theme).
- ui/utils/TextEditorStyles.kt — createStyle takes the effective color; highlight painted translucently.
- ui/state/TextKitState.kt — effective highlight color + setThemeHighlightColor() with rebuild.
- ui/TextKitEditor.kt, ui/TextKitViewer.kt — push TextKitTheme.colors.highlight into the state.
- README.md and docs/theming/README.md — documented the highlight role and the mark's behavior.

## Notes

- Minor API change: TextKitConfiguration.highlightColor is now Color? (was Color = Color.Yellow). Backward compatible for builder users; the default is no longer yellow — it now follows the theme.
- :shared:compileKotlinJvm builds successfully (only pre-existing warnings unrelated to this change).