### PR TITLE
Embed Table Edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 TextKit is a rope-backed, piece-table rich-text editor engine for **Compose Multiplatform**
 (Android, iOS, Desktop/JVM and Web — Wasm & JS). It ships a `TextKitState` holder, ready-made
 editor composables, a formatting bar, link popups, a generalized **trigger** system (mentions,
-hashtags, slash commands), **embedded blocks** (tables, images and other non-renderable content
-as clickable placeholders), full **undo/redo** with coalescing, and lossless (de)serialization
-to a **ProseMirror-style JSON document**.
+hashtags, slash commands), **embedded blocks** (images and other non-renderable content as clickable
+placeholders, plus fully **editable tables**), full **undo/redo** with coalescing, and lossless
+(de)serialization to a **ProseMirror-style JSON document**.
 
 Unlike editors that round-trip through HTML or Markdown, TextKit persists a structured JSON document
 (`type: "doc"` → block nodes → inline runs with marks), so styling, lists, links and inline tokens
@@ -345,6 +345,27 @@ Box {
 }
 ```
 
+### Editable tables
+
+`table` embeds get a full **editable, Notion-style grid** inside the popup — no extra wiring needed.
+`TextKitEmbedPopup` renders `TextKitEditableTable` for `EmbedTypes.Table` and defaults its `onSync` to
+`state.updateActiveEmbed(...)`, so users can add/remove rows and columns, merge and split cells (true
+`colspan`/`rowspan`), toggle header cells and edit text inline. Every change **auto-syncs** back to the
+document (there is no manual save step), the table carries its **own undo/redo**, and its JSON
+round-trips losslessly as a `table` block.
+
+You can also host the table yourself — it's a self-contained composable taking just `rawJson` and an
+`onSync` callback:
+
+```kotlin
+import com.jjrodcast.textkit.ui.table.TextKitEditableTable
+
+TextKitEditableTable(rawJson = tableJson, onSync = { updated -> /* persist updated table JSON */ })
+```
+
+See **[docs/table](docs/table/README.md)** for the interaction model, merge/split rules, the `table`
+JSON shape, theming and layout details.
+
 To let users insert embeds from the `/` menu, wrap `insertEmbed` in a custom slash command:
 
 ```kotlin
@@ -593,6 +614,10 @@ The block's original JSON is stored verbatim, so it round-trips unchanged:
 ```json
 { "type": "image", "attrs": { "src": "text_kit_banner" } }
 ```
+
+`table` embeds are fully editable in the popup and serialize as a ProseMirror `table`
+(`tableRow` → `tableCell` / `tableHeader` with `colspan` / `rowspan` / `colwidth`) — see
+**[docs/table](docs/table/README.md)** for the shape and editor.
 
 **Marks** (on inline runs): `bold`, `italic`, `underline`, `strike`, `highlight`, `link`
 (`attrs.href`, `attrs.target`), and `textStyle` (`attrs.color`, `attrs.fontSize`).

--- a/desktopApp/src/main/kotlin/com/jjrodcast/textkit/main.kt
+++ b/desktopApp/src/main/kotlin/com/jjrodcast/textkit/main.kt
@@ -1,21 +1,8 @@
 package com.jjrodcast.textkit
 
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
-import com.jjrodcast.textkit.editor.utils.DocumentUtils
 import com.jjrodcast.textkit.sample.TextKitSample
-import com.jjrodcast.textkit.ui.TextKitEditor
-import com.jjrodcast.textkit.ui.TextKitFormattingBar
-import com.jjrodcast.textkit.ui.TextKitScreen
-import com.jjrodcast.textkit.ui.state.rememberTextKitFormattingBarState
-import com.jjrodcast.textkit.ui.state.rememberTextKitState
 
 fun main() = application {
     Window(

--- a/docs/table/README.md
+++ b/docs/table/README.md
@@ -1,0 +1,292 @@
+# TextKitEditableTable
+
+`TextKitEditableTable` is an **editable, Notion-style rich table** for a `table` embed. Where the
+embed placeholder shows a one-line label in the text and the embed popup usually renders content
+read-only, this component lets the user actually *mutate* the table: add/remove rows and columns,
+merge and split cells (true `colspan`/`rowspan`), toggle header cells, and edit cell text inline.
+
+It is designed to live **inside the embed popup** and to work equally well with touch (mobile/tablet)
+and pointer (web/desktop). Every change **auto-syncs** back to the host document — there is no manual
+"save" step — and the component carries its **own undo/redo** for the table's structure and content.
+
+- Source: [`shared/.../ui/table/`](../../shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/)
+- Public composable: `com.jjrodcast.textkit.ui.table.TextKitEditableTable`
+- Serialized shape: a ProseMirror-style `table` node (see [JSON format](#json-format)).
+
+## Table of contents
+
+- [How it fits in](#how-it-fits-in)
+- [Zero-config: through the embed popup](#zero-config-through-the-embed-popup)
+- [Standalone usage](#standalone-usage)
+- [Interaction model](#interaction-model)
+- [Auto-sync (no manual save)](#auto-sync-no-manual-save)
+- [Undo / redo](#undo--redo)
+- [Merge & split rules](#merge--split-rules)
+- [Header cells](#header-cells)
+- [JSON format](#json-format)
+- [Theming](#theming)
+- [Layout dimensions](#layout-dimensions)
+- [Localization](#localization)
+- [Behavior notes & invariants](#behavior-notes--invariants)
+
+## How it fits in
+
+A table is an [**embedded block**](../../README.md#embedded-blocks): a `table` node stored verbatim in
+the document and rendered inline as a clickable placeholder. Tapping the placeholder opens
+`TextKitEmbedPopup`, and for `EmbedTypes.Table` the popup body *is* `TextKitEditableTable`. The chain
+is:
+
+```
+document JSON ──▶ EmbedInfo.rawJson ──▶ TextKitEditableTable(rawJson, onSync)
+       ▲                                          │
+       └──────────── onSync(newJson) ◀────────────┘   (state.updateActiveEmbed)
+```
+
+So editing a cell updates the table's JSON, which flows through `onSync` back into the embed, which
+updates the document — and it all round-trips losslessly.
+
+## Zero-config: through the embed popup
+
+If you already render `TextKitEmbedPopup` next to the editor (see the main README), **table editing is
+on automatically** — `TextKitEmbedPopup` wires `TextKitEditableTable` for `EmbedTypes.Table` and
+defaults `onSync` to `state.updateActiveEmbed(...)`:
+
+```kotlin
+import com.jjrodcast.textkit.ui.TextKitEditor
+import com.jjrodcast.textkit.ui.TextKitEmbedPopup
+
+Box {
+    TextKitEditor(state = state)
+    TextKitEmbedPopup(state = state) // table embeds become editable, changes auto-sync to the document
+}
+```
+
+To insert a table so there's something to edit, use `insertEmbed` (e.g. from a `/` slash command):
+
+```kotlin
+import com.jjrodcast.textkit.editor.core.parser.EmbedTypes
+
+state.insertEmbed(embedType = EmbedTypes.Table, rawJson = tableJson, label = "📊 Table")
+```
+
+Everything below is only needed if you want to host the table yourself or understand what happens
+under the hood.
+
+## Standalone usage
+
+`TextKitEditableTable` is a self-contained composable with just two required parameters:
+
+```kotlin
+import com.jjrodcast.textkit.ui.table.TextKitEditableTable
+
+@Composable
+fun MyTableEditor(tableJson: String) {
+    var current by remember { mutableStateOf(tableJson) }
+
+    TextKitEditableTable(
+        rawJson = current,             // ProseMirror `table` JSON
+        onSync = { updated -> current = updated }, // called after EVERY edit
+        modifier = Modifier.padding(12.dp),
+    )
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `rawJson` | `String` | The ProseMirror `table` JSON. It **seeds** the editor; a genuine *external* change to it is reloaded in place. Malformed input falls back to a starter 3×3 grid. |
+| `onSync` | `(String) -> Unit` | Called with the updated `table` JSON **after every edit** (auto-sync). |
+| `modifier` | `Modifier` | Layout modifier for the root. |
+
+Wrap it in `TextKitTheme { }` (or `TextKitScreen`) so it can read colors and typography — see
+[Theming](#theming).
+
+## Interaction model
+
+The UI is **gutter-driven**, like Notion, so selecting a line never fights with editing a cell:
+
+| Element | Where | What it does |
+|---|---|---|
+| **Column handle** | thin strip along the top | Tap to select that column; tap more to grow the selection. |
+| **Row handle** | thin strip along the left | Tap to select that row; tap more to grow the selection. |
+| **Corner handle** | top-left corner | Clears the current selection (shows a ✕ while a selection exists). |
+| **`+` handles** | far right (column) and bottom (row) edges | Append a new column / row. |
+| **Cell body** | inside each cell | Plain inline editable text. |
+| **Action rail** | icon column to the right of the grid | Acts on the current selection (see below). |
+
+**Action rail** buttons (each enabled only when applicable):
+
+| Icon | Action | Enabled when |
+|---|---|---|
+| Merge | Merge the selected rectangle into one cell | The selection is a clean rectangle covering >1 cell |
+| Split | Split a merged cell back into single cells | Exactly one merged cell is selected |
+| Header (Title) | Toggle header styling on the selected block | Anything is selected |
+| Delete | Delete the selected rows or columns | Anything is selected |
+| Undo | Undo the last table change | There is history to undo |
+| Redo | Redo the last undone change | There is a redo step |
+
+The rail is a single column when the popup is tall enough, and **falls back to two columns** in short
+layouts (typically mobile landscape) so every action stays reachable without scrolling.
+
+Selection is **line-based**: you pick whole rows and/or columns, and the acted-upon region is their
+bounding box. A hint under the grid reminds users how to select.
+
+## Auto-sync (no manual save)
+
+There is **no "Sync"/"Save" button** — `onSync` fires after every committed change (typing, add,
+delete, merge, split, header toggle, undo, redo). The state is the single source of truth and is
+deliberately **not** rebuilt from its own emitted JSON, so:
+
+- typing never loses focus, cursor, selection, or scroll to a recomposition;
+- consecutive keystrokes in one cell are one logical change;
+- a **genuine external** change to `rawJson` (e.g. a document-level undo from the host editor) *is*
+  detected and reloaded in place.
+
+Echo detection is exact-match first (the string it last emitted), then **canonical** comparison
+(re-serialize both and compare), so cosmetic reformatting by the host doesn't trigger a needless
+rebuild.
+
+## Undo / redo
+
+The table keeps its **own** bounded history (default **100** steps) covering both structure and cell
+text, exposed to the rail via observable `canUndo` / `canRedo` flags. Consecutive keystrokes in the
+**same** cell **coalesce** into a single undo step (mirroring how the text editor groups typing);
+structural actions (add/delete/merge/split/header) are each their own step. History is cleared when
+the table is reloaded from an external change.
+
+> This is independent of the main editor's undo/redo. Inside the table popup, undo/redo affects the
+> table; the document-level history still sees each synced table change as one embed update.
+
+## Merge & split rules
+
+- **Merge** requires a selection that forms a *fully-covered rectangle* (no cell straddles its edges)
+  spanning more than one cell. The merged cell keeps the **top-left** cell's content and header flag;
+  spans are emitted as `colspan` / `rowspan`.
+- **Split** requires a selection that corresponds **exactly** to one merged cell. The top-left slot
+  keeps the original content; the freed slots become fresh empty single cells (inheriting the header
+  flag).
+- Adding a row/column *inside* a merged region **grows** that merged cell (Notion behavior) rather
+  than punching a hole; elsewhere it inserts fresh empty single cells.
+- The grid is always kept **dense and rectangular** — every row has the same width, and at least one
+  row and one column always remain (delete is a no-op past that floor).
+
+Spans are never stored directly: the model stores a cell id in every grid slot the cell covers and
+**derives** spans from that grid, so a merge/split/add/delete can't leave spans inconsistent.
+
+## Header cells
+
+Toggle header styling on any selected block with the Header rail action. Header cells serialize as
+`tableHeader` (vs `tableCell`) and render with a more prominent color (`primaryContainer` +
+semibold), so they stand out from body rows. Toggling is all-or-nothing over the selection: if every
+selected cell is already a header, it turns them all off; otherwise it turns them all on.
+
+## JSON format
+
+`TextKitEditableTable` reads and writes a ProseMirror-style `table` node. This is exactly the
+`rawJson` carried by a `table` embed, so it round-trips through the document unchanged:
+
+```json
+{
+  "type": "table",
+  "content": [
+    { "type": "tableRow", "content": [
+      { "type": "tableHeader", "attrs": { "colspan": 1, "rowspan": 1, "colwidth": null },
+        "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Product" }] }] },
+      { "type": "tableHeader", "attrs": { "colspan": 1, "rowspan": 1, "colwidth": null },
+        "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Region" }] }] },
+      { "type": "tableHeader", "attrs": { "colspan": 1, "rowspan": 1, "colwidth": null },
+        "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Sales" }] }] }
+    ]},
+    { "type": "tableRow", "content": [
+      { "type": "tableCell", "attrs": { "colspan": 2, "rowspan": 1, "colwidth": null },
+        "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Subtotal" }] }] },
+      { "type": "tableCell", "attrs": { "colspan": 1, "rowspan": 1, "colwidth": null },
+        "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "1200" }] }] }
+    ]}
+  ]
+}
+```
+
+**Nodes**
+
+| Node | Role | Notable attrs |
+|---|---|---|
+| `table` | Root of the block | — |
+| `tableRow` | One row; `content` is a list of cells | — |
+| `tableCell` | A body cell | `colspan`, `rowspan`, `colwidth` |
+| `tableHeader` | A header cell (styled) | `colspan`, `rowspan`, `colwidth` |
+
+- Cell text is stored as a single `paragraph` of `text` runs; an empty cell serializes an empty
+  paragraph.
+- `colspan` / `rowspan` default to `1`. Only the **anchor** (top-left) slot of a merged cell is
+  emitted; the covered slots are implied by the spans.
+- `colwidth` is written as `null` (fixed column width is used for layout; per-column widths are not
+  edited by this component).
+
+Parsing is tolerant: unknown keys are ignored, ragged rows are padded, holes are filled with empty
+cells, and completely malformed input falls back to a 3×3 starter grid.
+
+## Theming
+
+Every part of the table — cells, gutters, handles, the action rail — reads its colors and font from
+[`TextKitTheme`](../theming/README.md), so it adapts to light/dark automatically. Key role usage:
+
+| Element | Role |
+|---|---|
+| Body cell background / text | `surface` / `onSurface` |
+| Header cell background / text | `primaryContainer` / `onPrimaryContainer` |
+| Selected line handle / highlighted cell | `primary` (translucent fill for highlighted cells) |
+| Cell borders & hairlines | `outlineVariant` |
+| Gutters, rail buttons | `surfaceVariant` / `onSurfaceVariant` |
+| Disabled rail button content | `onSurfaceVariant` at reduced alpha |
+
+Provide the theme somewhere above the table:
+
+```kotlin
+TextKitTheme(darkTheme = isSystemInDarkTheme()) {
+    TextKitEditableTable(rawJson = json, onSync = { /* ... */ })
+}
+```
+
+## Layout dimensions
+
+Sizes live in one place (`TextKitTableConstants`) so the grid, gutters and rail size from a single
+source of truth:
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `ColumnWidth` | `132.dp` | Fixed width of every column |
+| `MinRowHeight` | `44.dp` | Minimum row height (rows grow to fit content) |
+| `GutterSize` | `26.dp` | Thickness of the row/column selection gutters |
+| `AddSize` | `26.dp` | Thickness of the `+` add-row / add-column handles |
+| `MaxTableHeight` | `360.dp` | Max height of the scrollable table area (so it never overflows the popup) |
+| `RailButtonSize` | `42.dp` | Diameter of a rail action button |
+
+The grid uses a custom `Layout` so merged cells span multiple rows/columns correctly, and both axes
+scroll when the table is larger than the popup.
+
+## Localization
+
+All user-facing strings are in `composeResources/values/strings.xml` and resolved via
+`stringResource`, so they localize with the rest of your app:
+
+| Key | Default |
+|---|---|
+| `table_merge_cells_text` | "Merge cells" |
+| `table_split_cell_text` | "Split cell" |
+| `table_toggle_header_text` | "Toggle header" |
+| `table_delete_selection_text` | "Delete selection" |
+| `table_clear_selection_text` | "Clear selection" |
+| `table_add_text` | "Add" |
+| `table_selection_hint_text` | "Tap the edges to select rows or columns; use the icons to merge, split, or delete." |
+| `undo_text` / `redo_text` | "Undo" / "Redo" |
+
+## Behavior notes & invariants
+
+- **State is the source of truth.** The composable state is *not* keyed on `rawJson`, so the auto-sync
+  echo can't rebuild it and drop focus/cursor/selection.
+- **Spans are derived, never stored.** The grid holds a cell id per slot; anchors + spans are computed
+  from it, keeping every mutation consistent by construction.
+- **Dense rectangle.** All rows share the same width; at least one row and one column always remain.
+- **Bounded history.** 100 undo steps, keystroke coalescing per cell, cleared on external reload.
+- **Lossless round-trip.** The emitted JSON matches the embed's `table` shape, so it flows straight
+  back into the document.

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -21,4 +21,13 @@
     <string name="edit_label">Edit</string>
     <string name="remove_label">Remove</string>
 
+    <string name="table_merge_cells_text">Merge cells</string>
+    <string name="table_split_cell_text">Split cell</string>
+    <string name="table_toggle_header_text">Toggle header</string>
+    <string name="table_delete_selection_text">Delete selection</string>
+    <string name="table_clear_selection_text">Clear selection</string>
+    <string name="table_add_text">Add</string>
+    <string name="table_selection_hint_text">Tap the edges to select rows or columns; use the icons to merge, split, or delete.</string>
+    <string name="table_synced_json_text">Synced JSON</string>
+
 </resources>

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -222,8 +222,16 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
 
     // region Embedded blocks (tables, images, documents, …)
 
-    /** A placeholder currently in the document: its [range], the block [rawJson] and its [embedType]. */
-    data class EmbedInfo(val range: TextRange, val embedType: String, val rawJson: String)
+    /**
+     * A placeholder currently in the document: its [range], the block [rawJson], its [embedType] and
+     * the visible [label] shown in the editor (e.g. "📊 Table").
+     */
+    data class EmbedInfo(
+        val range: TextRange,
+        val embedType: String,
+        val rawJson: String,
+        val label: String,
+    )
 
     private var embedSeq = 0
 
@@ -290,7 +298,8 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
                     return EmbedInfo(
                         range = TextRange(child.start, child.end),
                         embedType = embedTypeOf(payload),
-                        rawJson = payload
+                        rawJson = payload,
+                        label = child.embedLabel ?: child.text.trimEnd('\n')
                     )
                 }
             }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/models/TextEditorParagraph.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/models/TextEditorParagraph.kt
@@ -32,6 +32,9 @@ class TextEditorItem internal constructor(
     /** The embedded block's JSON (verbatim), or null when this item is not an embed. */
     val embedPayload get() = if (isEmbed) token?.payload else null
 
+    /** The embed placeholder's visible label (e.g. "📊 Table"), or null when this item is not an embed. */
+    val embedLabel get() = if (isEmbed) token?.attrs?.label else null
+
     companion object {
         internal fun from(model: TextEditorModel) = TextEditorItem(
             text = model.text,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
@@ -189,7 +189,7 @@ fun TextKitTable() {
                 TextKitEditableTable(
                     rawJson = DEMO_TABLE_JSON,
                     onSync = { json ->
-                        println("json $json")
+                        // Every change is captured here with the new json structure
                     },
                     modifier = Modifier.padding(16.dp),
                 )

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
@@ -1,10 +1,13 @@
 package com.jjrodcast.textkit.sample
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -14,6 +17,7 @@ import com.jjrodcast.textkit.editor.core.parser.EmbedTypes
 import com.jjrodcast.textkit.editor.models.TextKitTrigger
 import com.jjrodcast.textkit.editor.models.createTextKitConfiguration
 import com.jjrodcast.textkit.editor.utils.DocumentUtils
+import com.jjrodcast.textkit.theme.TextKitTheme
 import com.jjrodcast.textkit.ui.TextKitColorsPopup
 import com.jjrodcast.textkit.ui.TextKitEditor
 import com.jjrodcast.textkit.ui.TextKitEmbedPopup
@@ -26,6 +30,7 @@ import com.jjrodcast.textkit.ui.model.TextKitCommand
 import com.jjrodcast.textkit.ui.model.TextKitTokenSuggestion
 import com.jjrodcast.textkit.ui.state.rememberTextKitFormattingBarState
 import com.jjrodcast.textkit.ui.state.rememberTextKitState
+import com.jjrodcast.textkit.ui.table.TextKitEditableTable
 import com.jjrodcast.textkit.ui.utils.TextKitPickerPallete
 
 // A demo table (ProseMirror shape) inserted by the "Insertar tabla" button. It is stored verbatim on
@@ -167,4 +172,29 @@ fun TextKitSample() {
             TextKitSlashCommandPopup(state = state, commands = sampleCommands)
         }
     }
+}
+
+@Composable
+fun TextKitTable() {
+    TextKitTheme {
+        Scaffold(
+            containerColor = TextKitTheme.colors.background,
+            contentColor = TextKitTheme.colors.onBackground
+        ) { innerPadding ->
+            Column(
+                modifier = Modifier
+                    .background(TextKitTheme.colors.background)
+                    .padding(innerPadding)
+            ) {
+                TextKitEditableTable(
+                    rawJson = DEMO_TABLE_JSON,
+                    onSync = { json ->
+                        println("json $json")
+                    },
+                    modifier = Modifier.padding(16.dp),
+                )
+            }
+        }
+    }
+
 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
@@ -163,7 +163,7 @@ private fun EmbedPopupContent(
                     modifier = Modifier.size(18.dp),
                 )
                 Text(
-                    text = embed.embedType.replaceFirstChar { it.uppercase() },
+                    text = embed.label,
                     style = MaterialTheme.typography.titleSmall,
                     modifier = Modifier.weight(1f).padding(start = 6.dp),
                 )

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.DragIndicator
@@ -32,6 +33,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -42,6 +44,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import com.jjrodcast.textkit.editor.core.TextKitEditorManager
 import com.jjrodcast.textkit.editor.core.parser.EmbedTypes
@@ -99,11 +102,20 @@ fun TextKitEmbedPopup(
 
         // Add the user's drag, then clamp so the card stays fully on-screen — this is what keeps a
         // large table popup reachable in landscape, where the anchor may sit off the visible area.
-        val x = (baseX + dragOffset.x.roundToInt()).coerceIn(0, (maxW - cardSize.width).coerceAtLeast(0))
-        val y = (baseY + dragOffset.y.roundToInt()).coerceIn(0, (maxH - cardSize.height).coerceAtLeast(0))
+        val x = (baseX + dragOffset.x.roundToInt())
+            .coerceIn(
+                0, (maxW - cardSize.width)
+                    .coerceAtLeast(0)
+            )
+        val y = (baseY + dragOffset.y.roundToInt())
+            .coerceIn(
+                0, (maxH - cardSize.height)
+                    .coerceAtLeast(0)
+            )
 
         // Never let the card exceed the viewport height; its content scrolls within this cap.
-        val availableHeight = with(density) { maxH.toDp() } - 16.dp
+        val availableHeight = (with(density) { maxH.toDp() } - 16.dp)
+            .coerceAtLeast(0.dp)
 
         EmbedPopupContent(
             embed = embed,
@@ -168,7 +180,10 @@ private fun EmbedPopupContent(
                     modifier = Modifier.weight(1f).padding(start = 6.dp),
                 )
                 IconButton(onClick = onClose, modifier = Modifier.size(28.dp)) {
-                    Icon(Icons.Rounded.Close, contentDescription = stringResource(Res.string.close_text))
+                    Icon(
+                        Icons.Rounded.Close,
+                        contentDescription = stringResource(Res.string.close_text)
+                    )
                 }
             }
             HorizontalDivider()
@@ -190,7 +205,14 @@ private fun EmbedPopupContent(
                     )
 
                     // Any other embed: show the stored JSON so it is at least inspectable.
-                    else -> Text(text = embed.rawJson, style = MaterialTheme.typography.bodySmall)
+                    else -> {
+                        Box(
+                            modifier = Modifier.fillMaxWidth()
+                                .verticalScroll(rememberScrollState())
+                        ) {
+                            Text(text = embed.rawJson, style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
                 }
             }
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
@@ -1,8 +1,7 @@
 package com.jjrodcast.textkit.ui
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -14,12 +13,10 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.DragIndicator
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -37,10 +34,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -48,11 +47,7 @@ import com.jjrodcast.textkit.editor.core.TextKitEditorManager
 import com.jjrodcast.textkit.editor.core.parser.EmbedTypes
 import com.jjrodcast.textkit.theme.TextKitTheme
 import com.jjrodcast.textkit.ui.state.TextKitState
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import com.jjrodcast.textkit.ui.table.TextKitEditableTable
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import textkit.shared.generated.resources.Res
@@ -83,6 +78,7 @@ fun TextKitEmbedPopup(
     modifier: Modifier = Modifier,
     onClose: () -> Unit = { state.dismissEmbedPopup() },
     onRemove: () -> Unit = { state.removeActiveEmbed() },
+    onSync: (String) -> Unit = { state.updateActiveEmbed(it) },
 ) {
     val embed = state.activeEmbed ?: return
     val anchor = state.activeEmbedBoundingBox() ?: return
@@ -93,17 +89,29 @@ fun TextKitEmbedPopup(
         val maxW = constraints.maxWidth
         val maxH = constraints.maxHeight
         var cardSize by remember { mutableStateOf(IntSize.Zero) }
+        val dragOffset = state.embedPopupOffset
 
-        // Clamp X within the container; place below the placeholder, flipping above if it overflows.
-        val x = anchor.left.roundToInt().coerceIn(0, (maxW - cardSize.width).coerceAtLeast(0))
+        // Anchored base position: below the placeholder, flipping above if it would overflow.
+        val baseX = anchor.left.roundToInt()
         val below = anchor.bottom.roundToInt() + gap
         val above = anchor.top.roundToInt() - gap - cardSize.height
-        val y = if (below + cardSize.height <= maxH || above < 0) below else above
+        val baseY = if (below + cardSize.height <= maxH || above < 0) below else above
+
+        // Add the user's drag, then clamp so the card stays fully on-screen — this is what keeps a
+        // large table popup reachable in landscape, where the anchor may sit off the visible area.
+        val x = (baseX + dragOffset.x.roundToInt()).coerceIn(0, (maxW - cardSize.width).coerceAtLeast(0))
+        val y = (baseY + dragOffset.y.roundToInt()).coerceIn(0, (maxH - cardSize.height).coerceAtLeast(0))
+
+        // Never let the card exceed the viewport height; its content scrolls within this cap.
+        val availableHeight = with(density) { maxH.toDp() } - 16.dp
 
         EmbedPopupContent(
             embed = embed,
             onClose = onClose,
             onRemove = onRemove,
+            onSync = onSync,
+            onDrag = { state.dragEmbedPopup(it) },
+            maxHeight = availableHeight,
             modifier = Modifier
                 .offset { IntOffset(x, y) }
                 .onSizeChanged { cardSize = it },
@@ -116,10 +124,15 @@ private fun EmbedPopupContent(
     embed: TextKitEditorManager.EmbedInfo,
     onClose: () -> Unit,
     onRemove: () -> Unit,
+    onSync: (String) -> Unit,
+    onDrag: (Offset) -> Unit,
+    maxHeight: Dp,
     modifier: Modifier = Modifier,
 ) {
+    // Tables carry an inline editor (with a side rail), so give them more room than image/document.
+    val maxWidth = if (embed.embedType == EmbedTypes.Table) 460.dp else 360.dp
     Card(
-        modifier = modifier.widthIn(max = 360.dp),
+        modifier = modifier.widthIn(max = maxWidth).heightIn(max = maxHeight),
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(
             containerColor = TextKitTheme.colors.surface,
@@ -131,11 +144,28 @@ private fun EmbedPopupContent(
             modifier = Modifier.padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            // Header doubles as a drag handle so the popup can be moved anywhere on screen.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .pointerInput(embed.range) {
+                        detectDragGestures { change, dragAmount ->
+                            change.consume()
+                            onDrag(dragAmount)
+                        }
+                    },
+            ) {
+                Icon(
+                    Icons.Rounded.DragIndicator,
+                    contentDescription = null,
+                    tint = TextKitTheme.colors.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp),
+                )
                 Text(
                     text = embed.embedType.replaceFirstChar { it.uppercase() },
                     style = MaterialTheme.typography.titleSmall,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f).padding(start = 6.dp),
                 )
                 IconButton(onClick = onClose, modifier = Modifier.size(28.dp)) {
                     Icon(Icons.Rounded.Close, contentDescription = stringResource(Res.string.close_text))
@@ -143,22 +173,25 @@ private fun EmbedPopupContent(
             }
             HorizontalDivider()
 
-            when (embed.embedType) {
-                EmbedTypes.Image -> Image(
-                    painter = painterResource(Res.drawable.text_kit_banner),
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp),
-                )
+            // The body flexes to the available height (fill = false keeps small embeds compact) and
+            // its own scroll handles anything taller than the capped popup.
+            Box(modifier = Modifier.weight(1f, fill = false)) {
+                when (embed.embedType) {
+                    EmbedTypes.Image -> Image(
+                        painter = painterResource(Res.drawable.text_kit_banner),
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp),
+                    )
 
-                EmbedTypes.Table -> {
-                    val rows = remember(embed.rawJson) { parseTableRows(embed.rawJson) }
-                    if (rows.isNotEmpty()) TableView(rows)
-                    else Text(text = embed.rawJson, style = MaterialTheme.typography.bodySmall)
+                    EmbedTypes.Table -> TextKitEditableTable(
+                        rawJson = embed.rawJson,
+                        onSync = onSync,
+                    )
+
+                    // Any other embed: show the stored JSON so it is at least inspectable.
+                    else -> Text(text = embed.rawJson, style = MaterialTheme.typography.bodySmall)
                 }
-
-                // Any other embed: show the stored JSON so it is at least inspectable.
-                else -> Text(text = embed.rawJson, style = MaterialTheme.typography.bodySmall)
             }
 
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
@@ -175,63 +208,3 @@ private fun EmbedPopupContent(
     }
 }
 
-/** A parsed table row: its cell texts and whether it is a header row. */
-private data class DemoTableRow(val cells: List<String>, val isHeader: Boolean)
-
-@Composable
-private fun TableView(rows: List<DemoTableRow>) {
-    Column(modifier = Modifier.horizontalScroll(rememberScrollState())) {
-        rows.forEach { row ->
-            Row {
-                row.cells.forEach { cell ->
-                    Box(
-                        modifier = Modifier
-                            .width(120.dp)
-                            .border(BorderStroke(1.dp, TextKitTheme.colors.outlineVariant))
-                            .padding(horizontal = 10.dp, vertical = 8.dp),
-                    ) {
-                        Text(
-                            text = cell,
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = if (row.isHeader) FontWeight.SemiBold else FontWeight.Normal,
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-private val lenientJson = Json { ignoreUnknownKeys = true }
-
-/**
- * Parses a ProseMirror `table` JSON into rows of cell texts. Returns an empty list for non-tables or
- * malformed input (the popup then falls back to showing the raw JSON).
- */
-private fun parseTableRows(rawJson: String): List<DemoTableRow> = runCatching {
-    val table = lenientJson.parseToJsonElement(rawJson).jsonObject
-    if (table["type"]?.jsonPrimitive?.content != "table") return emptyList()
-    val rows = table["content"]?.jsonArray ?: return emptyList()
-    rows.map { rowElement ->
-        val cells = rowElement.jsonObject["content"]?.jsonArray ?: JsonArray(emptyList())
-        var isHeader = false
-        val texts = cells.map { cellElement ->
-            val cell = cellElement.jsonObject
-            if (cell["type"]?.jsonPrimitive?.content == "tableHeader") isHeader = true
-            cellText(cell["content"]?.jsonArray)
-        }
-        DemoTableRow(cells = texts, isHeader = isHeader)
-    }
-}.getOrElse { emptyList() }
-
-/** Concatenates all `text` leaves inside a cell's paragraph content. */
-private fun cellText(paragraphs: JsonArray?): String {
-    if (paragraphs == null) return ""
-    val builder = StringBuilder()
-    paragraphs.forEach { paragraph ->
-        paragraph.jsonObject["content"]?.jsonArray?.forEach { inline ->
-            inline.jsonObject["text"]?.jsonPrimitive?.content?.let { builder.append(it) }
-        }
-    }
-    return builder.toString()
-}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -333,6 +333,9 @@ class TextKitState(
         selection = restoredSelection
         updateAnnotatedString(restoredSelection)
         readSelectionContext()
+        // Refresh the open embed popup (if any) so a document-level undo/redo of a table edit is
+        // reflected in the live editor: the re-derived JSON flows back into the table, which reloads.
+        activeEmbed = activeEmbed?.let { manager.embedAt(it.range.min) }
         syncHistoryAvailability()
     }
 
@@ -845,6 +848,8 @@ class TextKitState(
         val info = manager.embedAt(offset) ?: return false
         activeEmbed = info
         embedPopupOffset = Offset.Zero
+        // Start a fresh coalescing run so this embed's edits don't merge with a previous session.
+        manager.breakHistoryCoalescing()
         return true
     }
 
@@ -852,6 +857,8 @@ class TextKitState(
     fun dismissEmbedPopup() {
         activeEmbed = null
         embedPopupOffset = Offset.Zero
+        // End the embed's coalescing run so the next unrelated edit is a separate undo step.
+        manager.breakHistoryCoalescing()
     }
 
     /** Restores the open embed (by document offset) and its drag offset after a state restore. */
@@ -886,16 +893,24 @@ class TextKitState(
         }
     }
 
-    /** Replaces the JSON of the currently open embed (one undo step). */
+    /**
+     * Replaces the JSON of the currently open embed. Consecutive updates to the same embed **coalesce
+     * into a single undo step** (via [recordBefore]'s coalescing), so a table's live auto-sync — which
+     * fires on every keystroke/action — collapses to one global editor step instead of flooding it.
+     * The run ends when the popup closes/opens ([dismissEmbedPopup]/[openEmbedAt]) or any other edit
+     * happens.
+     */
     fun updateActiveEmbed(rawJson: String): Boolean {
         val info = activeEmbed ?: return false
-        val changed = recordBefore {
+        return recordBefore(coalesceKey = "embed:${info.range.min}", breakAfter = false) {
             manager.updateEmbedAt(info.range, rawJson)
             updateAnnotatedString(selection)
             true
         }
-        if (changed) activeEmbed = manager.embedAt(info.range.min)
-        return changed
+        // Intentionally does NOT reassign `activeEmbed`: the editor UI (e.g. the editable table) is the
+        // source of truth for its own live edits, and reassigning would change `activeEmbed.rawJson`
+        // on every keystroke, recomposing the whole popup and disrupting the focused text field.
+        // External changes (document-level undo/redo) refresh `activeEmbed` via applyRestoredHistory.
     }
 
     /** Removes the currently open embed and closes its popup (one undo step). */

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -821,6 +821,20 @@ class TextKitState(
         private set
 
     /**
+     * User drag delta (px) applied on top of the embed popup's anchored position; `Offset.Zero` means
+     * the popup sits where it is anchored. Lets the user drag the popup somewhere visible (e.g. when
+     * the anchor is off-screen in landscape). Reset whenever a new embed opens; persisted across
+     * configuration changes so the popup keeps its place after a rotation.
+     */
+    var embedPopupOffset by mutableStateOf(Offset.Zero)
+        private set
+
+    /** Accumulates a drag on the embed popup so the user can reposition it. */
+    fun dragEmbedPopup(delta: Offset) {
+        embedPopupOffset += delta
+    }
+
+    /**
      * Opens the embed popup when [position] (text-field local coordinates) sits on a placeholder.
      * Returns true when it opened one, so the caller can consume the click.
      */
@@ -830,12 +844,21 @@ class TextKitState(
         val offset = layout.getOffsetForPosition(position).coerceIn(0, textFieldValue.text.length)
         val info = manager.embedAt(offset) ?: return false
         activeEmbed = info
+        embedPopupOffset = Offset.Zero
         return true
     }
 
     /** Closes the embed popup. */
     fun dismissEmbedPopup() {
         activeEmbed = null
+        embedPopupOffset = Offset.Zero
+    }
+
+    /** Restores the open embed (by document offset) and its drag offset after a state restore. */
+    internal fun restoreEmbedPopup(embedOffset: Int, popupOffset: Offset) {
+        if (embedOffset < 0) return
+        activeEmbed = manager.embedAt(embedOffset) ?: return
+        embedPopupOffset = popupOffset
     }
 
     /** Bounding box of the active embed placeholder (to anchor its popup), or null. */
@@ -1298,18 +1321,26 @@ class TextKitState(
                 arrayListOf(
                     save(it.selection, TextRangeSaver, this),
                     save(it.toJson()),
+                    // Keep the embed popup open (and where the user dragged it) across rotation.
+                    save(it.activeEmbed?.range?.min ?: -1),
+                    save(it.embedPopupOffset.x),
+                    save(it.embedPopupOffset.y),
                 )
             },
             restore = {
                 @Suppress("UNCHECKED_CAST")
                 val list = it as List<Any>
-                val selection: TextRange = restore(list[list.size - 2], TextRangeSaver)!!
-                val json: String = restore(list[list.size - 1])!!
+                val selection: TextRange = restore(list[0], TextRangeSaver)!!
+                val json: String = restore(list[1])!!
+                val embedOffset: Int = restore(list[2]) ?: -1
+                val popupX: Float = restore(list[3]) ?: 0f
+                val popupY: Float = restore(list[4]) ?: 0f
                 TextKitState(json, configuration).apply {
                     setup()
                     updateAnnotatedString(selection)
                     this.selection = textFieldValue.selection
                     readSelectionContext()
+                    restoreEmbedPopup(embedOffset, Offset(popupX, popupY))
                 }
             }
         )

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/Anchor.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/Anchor.kt
@@ -1,0 +1,13 @@
+package com.jjrodcast.textkit.ui.table
+
+/**
+ * A cell's top-left position and how many rows/columns it spans. Derived from the grid by
+ * [TextKitEditableTableState.anchors]; never stored directly, so spans can't drift from the grid.
+ */
+internal data class Anchor(
+    val id: Long,
+    val row: Int,
+    val col: Int,
+    val rowSpan: Int,
+    val colSpan: Int,
+)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/CellContent.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/CellContent.kt
@@ -1,0 +1,14 @@
+package com.jjrodcast.textkit.ui.table
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+/**
+ * Mutable content of one table cell. [text] and [isHeader] are Compose state so editing a cell
+ * recomposes only that cell, not the whole grid.
+ */
+internal class CellContent(text: String, isHeader: Boolean) {
+    var text by mutableStateOf(text)
+    var isHeader by mutableStateOf(isHeader)
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/GridChild.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/GridChild.kt
@@ -1,0 +1,26 @@
+package com.jjrodcast.textkit.ui.table
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ParentDataModifier
+import androidx.compose.ui.unit.Density
+
+/**
+ * Parent data identifying what a child of the table [androidx.compose.ui.layout.Layout] is, so the
+ * measure/place pass can size and position it: a cell (with its span), a gutter handle, the corner,
+ * or one of the "+" add handles.
+ */
+internal sealed interface GridChild
+
+internal data class CellChild(val row: Int, val col: Int, val rowSpan: Int, val colSpan: Int) : GridChild
+internal data class ColHandleChild(val col: Int) : GridChild
+internal data class RowHandleChild(val row: Int) : GridChild
+internal data object CornerChild : GridChild
+internal data object AddColChild : GridChild
+internal data object AddRowChild : GridChild
+
+private class GridChildModifier(private val child: GridChild) : ParentDataModifier {
+    override fun Density.modifyParentData(parentData: Any?): Any = child
+}
+
+/** Tags a composable with its [GridChild] role for the table layout. */
+internal fun Modifier.gridChild(child: GridChild): Modifier = this.then(GridChildModifier(child))

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TableJsonCodec.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TableJsonCodec.kt
@@ -1,0 +1,122 @@
+package com.jjrodcast.textkit.ui.table
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Decodes a ProseMirror `table` JSON document into the dense grid model used by
+ * [TextKitEditableTableState] (`grid[r][c]` = cell id; a merged cell repeats its id over the slots it
+ * covers). Serialization back to JSON lives in the state itself, since it reads the live grid/cells.
+ *
+ * Malformed or non-`table` input falls back to a starter 3×3 table.
+ */
+internal object TableJsonCodec {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** JSON keys and node-type values of the ProseMirror `table` shape, kept in one place to reuse. */
+    private object Keys {
+        const val TYPE = "type"
+        const val CONTENT = "content"
+        const val ATTRS = "attrs"
+        const val COLSPAN = "colspan"
+        const val ROWSPAN = "rowspan"
+        const val TEXT = "text"
+
+        const val TABLE = "table"
+        const val TABLE_HEADER = "tableHeader"
+    }
+
+    /** A decoded table: a dense grid of cell ids, the cell content by id, and the next free id. */
+    class Decoded(
+        val grid: MutableList<MutableList<Long>>,
+        val cells: MutableMap<Long, CellContent>,
+        val nextId: Long,
+    )
+
+    fun decode(rawJson: String): Decoded = runCatching { parse(rawJson) }.getOrNull() ?: default()
+
+    private fun default(): Decoded {
+        val grid = MutableList(3) { r -> MutableList(3) { c -> (r * 3 + c).toLong() } }
+        val cells = HashMap<Long, CellContent>()
+        for (r in 0..2) for (c in 0..2) {
+            val id = (r * 3 + c).toLong()
+            cells[id] = CellContent(if (r == 0) "Header ${c + 1}" else "", r == 0)
+        }
+        return Decoded(grid, cells, 9L)
+    }
+
+    private fun parse(rawJson: String): Decoded {
+        val obj = json.parseToJsonElement(rawJson).jsonObject
+        require(obj[Keys.TYPE]?.jsonPrimitive?.content == Keys.TABLE)
+        val rowsJson = obj[Keys.CONTENT]?.jsonArray ?: JsonArray(emptyList())
+
+        val grid: MutableList<MutableList<Long>> = ArrayList()
+        val cells = HashMap<Long, CellContent>()
+        var nextId = 0L
+
+        fun ensure(r: Int, c: Int) {
+            while (grid.size <= r) grid.add(ArrayList())
+            val row = grid[r]
+            while (row.size <= c) row.add(-1L)
+        }
+
+        fun get(r: Int, c: Int): Long {
+            if (r >= grid.size) return -1L
+            val row = grid[r]
+            if (c >= row.size) return -1L
+            return row[c]
+        }
+
+        fun set(r: Int, c: Int, id: Long) { ensure(r, c); grid[r][c] = id }
+
+        rowsJson.forEachIndexed { r, rowEl ->
+            ensure(r, 0)
+            val cs = rowEl.jsonObject[Keys.CONTENT]?.jsonArray ?: JsonArray(emptyList())
+            var c = 0
+            cs.forEach { cellEl ->
+                val cell = cellEl.jsonObject
+                while (get(r, c) != -1L) c++
+                val attrs = cell[Keys.ATTRS]?.jsonObject
+                val colspan = attrs?.get(Keys.COLSPAN)?.jsonPrimitive?.content?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+                val rowspan = attrs?.get(Keys.ROWSPAN)?.jsonPrimitive?.content?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+                val isHeader = cell[Keys.TYPE]?.jsonPrimitive?.content == Keys.TABLE_HEADER
+                val id = nextId++
+                cells[id] = CellContent(cellText(cell[Keys.CONTENT]?.jsonArray), isHeader)
+                for (dr in 0 until rowspan) for (dc in 0 until colspan) set(r + dr, c + dc, id)
+                c += colspan
+            }
+        }
+
+        require(grid.isNotEmpty())
+        // Rectangularize: pad every row to the widest and fill any holes with fresh single cells.
+        val cols = grid.maxOf { it.size }.coerceAtLeast(1)
+        for (r in grid.indices) {
+            ensure(r, cols - 1)
+            val row = grid[r]
+            for (c in 0 until cols) {
+                if (row[c] == -1L) {
+                    val id = nextId++
+                    cells[id] = CellContent("", false)
+                    row[c] = id
+                }
+            }
+        }
+        return Decoded(grid, cells, nextId)
+    }
+
+    /** Concatenates all `text` leaves inside a cell's paragraph content. */
+    private fun cellText(paragraphs: JsonArray?): String {
+        if (paragraphs == null) return ""
+        val builder = StringBuilder()
+        paragraphs.forEach { paragraph ->
+            paragraph.jsonObject[Keys.CONTENT]?.jsonArray?.forEach { inline ->
+                inline.jsonObject[Keys.TEXT]?.jsonPrimitive?.content?.let { builder.append(it) }
+            }
+        }
+        return builder.toString()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TableSnapshot.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TableSnapshot.kt
@@ -1,0 +1,12 @@
+package com.jjrodcast.textkit.ui.table
+
+/**
+ * An immutable deep copy of a table used as a single undo/redo point: the grid of cell ids, each
+ * cell's `(text, isHeader)`, and the next free id. Produced and consumed by
+ * [TextKitEditableTableState]'s history.
+ */
+internal class TableSnapshot(
+    val grid: List<List<Long>>,
+    val cells: Map<Long, Pair<String, Boolean>>,
+    val nextId: Long,
+)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitEditableTable.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitEditableTable.kt
@@ -7,33 +7,34 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.CallMerge
+import androidx.compose.material.icons.automirrored.rounded.CallSplit
+import androidx.compose.material.icons.automirrored.rounded.Redo
+import androidx.compose.material.icons.automirrored.rounded.Undo
 import androidx.compose.material.icons.rounded.Add
-import androidx.compose.material.icons.rounded.CallMerge
-import androidx.compose.material.icons.rounded.CallSplit
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.DeleteOutline
-import androidx.compose.material.icons.rounded.Sync
 import androidx.compose.material.icons.rounded.Title
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -44,13 +45,27 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.jjrodcast.textkit.theme.TextKitTheme
+import org.jetbrains.compose.resources.stringResource
+import textkit.shared.generated.resources.Res
+import textkit.shared.generated.resources.redo_text
+import textkit.shared.generated.resources.table_add_text
+import textkit.shared.generated.resources.table_clear_selection_text
+import textkit.shared.generated.resources.table_delete_selection_text
+import textkit.shared.generated.resources.table_merge_cells_text
+import textkit.shared.generated.resources.table_selection_hint_text
+import textkit.shared.generated.resources.table_split_cell_text
+import textkit.shared.generated.resources.table_synced_json_text
+import textkit.shared.generated.resources.table_toggle_header_text
+import textkit.shared.generated.resources.undo_text
 
 /**
  * An **editable**, Notion-style rich table for a `table` embed — designed to live inside a popup and
@@ -64,14 +79,16 @@ import com.jjrodcast.textkit.theme.TextKitTheme
  * - Cells are plain editable text, so tapping a cell never fights with selecting it.
  *
  * Header cells use a more prominent color (`primaryContainer`) so they stand out from body rows.
- * Nothing leaves the component until the user taps **Sync** (the primary rail icon), which hands
- * [onSync] the table re-serialized to the same ProseMirror JSON shape as the embed's `rawJson`.
+ * Every change **auto-syncs**: [onSync] receives the updated ProseMirror JSON on each edit, and the
+ * rail offers granular **undo/redo** of the table's own changes. The table is the source of truth and
+ * never rebuilds from its own echo, so editing never loses focus/cursor/selection; genuine external
+ * changes to [rawJson] (e.g. a document-level undo) are reloaded in place.
  *
  * Everything is themed through [TextKitTheme] (colors + font family), so it adapts to light/dark.
  *
- * @param rawJson The ProseMirror `table` JSON from the embed model (`EmbedInfo.rawJson`). A fresh
- *   editable state is rebuilt whenever this changes. Malformed input falls back to a starter 3×3.
- * @param onSync Called with the updated ProseMirror `table` JSON when the user syncs their changes.
+ * @param rawJson The ProseMirror `table` JSON from the embed model (`EmbedInfo.rawJson`). Its content
+ *   seeds the editor and an external change to it is reloaded. Malformed input falls back to 3×3.
+ * @param onSync Called with the updated ProseMirror `table` JSON after every edit (auto-sync).
  * @param modifier Layout modifier for the root.
  */
 @Composable
@@ -80,7 +97,23 @@ fun TextKitEditableTable(
     onSync: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val state = remember(rawJson) { TextKitEditableTableState.from(rawJson) }
+    // The state is the source of truth; it is NOT keyed on rawJson so our own auto-sync echo doesn't
+    // rebuild it (which would drop focus/cursor/selection).
+    val state = remember { TextKitEditableTableState.from(rawJson) }
+
+    // Keep the auto-sync sink current.
+    SideEffect { state.setOnChange(onSync) }
+
+    // Reload only on a *genuine* external change. Fast path: exact match with what we last emitted is
+    // our own echo → ignore. Otherwise compare canonically so cosmetic reformatting from the host
+    // doesn't force a rebuild that would drop focus/selection.
+    LaunchedEffect(rawJson) {
+        if (rawJson != state.lastSyncedRaw &&
+            TextKitEditableTableState.canonical(rawJson) != TextKitEditableTableState.canonical(state.lastSyncedRaw)
+        ) {
+            state.loadFrom(rawJson)
+        }
+    }
 
     Column(
         modifier = modifier,
@@ -98,71 +131,67 @@ fun TextKitEditableTable(
             }
             TextKitActionRail(
                 state = state,
-                onSync = onSync,
                 modifier = Modifier.padding(start = 6.dp),
             )
         }
 
         Text(
-            text = "Toca los bordes para seleccionar filas o columnas; usa los íconos para fusionar, dividir o eliminar.",
+            text = stringResource(Res.string.table_selection_hint_text),
             style = captionStyle(),
         )
     }
 }
 
+/** One action button in the rail. */
+private class RailAction(
+    val icon: ImageVector,
+    val description: String,
+    val enabled: Boolean,
+    val onClick: () -> Unit,
+)
+
 @Composable
 private fun TextKitActionRail(
     state: TextKitEditableTableState,
-    onSync: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier.width(TextKitTableConstants.RailWidth),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        // Scroll the contextual actions so they all stay reachable when the popup is short (landscape),
-        // while the primary "Sincronizar" action stays pinned at the bottom. The heightIn cap keeps the
-        // inner scroll bounded even if the rail is placed in an unbounded-height parent.
+    val actions = listOf(
+        RailAction(Icons.AutoMirrored.Rounded.CallMerge, stringResource(Res.string.table_merge_cells_text), state.canMerge()) { state.mergeSelection() },
+        RailAction(Icons.AutoMirrored.Rounded.CallSplit, stringResource(Res.string.table_split_cell_text), state.canSplit()) { state.splitSelection() },
+        RailAction(Icons.Rounded.Title, stringResource(Res.string.table_toggle_header_text), state.hasSelection()) { state.toggleHeaderBlock() },
+        RailAction(Icons.Rounded.DeleteOutline, stringResource(Res.string.table_delete_selection_text), state.hasSelection()) { state.deleteSelection() },
+        RailAction(Icons.AutoMirrored.Rounded.Undo, stringResource(Res.string.undo_text), state.canUndo) { state.undo() },
+        RailAction(Icons.AutoMirrored.Rounded.Redo, stringResource(Res.string.redo_text), state.canRedo) { state.redo() },
+    )
+
+    val spacing = 6.dp
+    BoxWithConstraints(modifier) {
+        // Height a single column of every action would need; when the popup is too short for it
+        // (typically mobile landscape) fall back to two columns so all actions stay visible without
+        // relying on scrolling. A scroll + height cap remain as a safety net for extreme sizes.
+        val singleColumnHeight =
+            TextKitTableConstants.RailButtonSize * actions.size + spacing * (actions.size - 1)
+        val columns = if (maxHeight >= singleColumnHeight) 1 else 2
+
         Column(
             modifier = Modifier
-                .weight(1f, fill = false)
                 .heightIn(max = TextKitTableConstants.MaxTableHeight)
                 .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(spacing),
         ) {
-            TextKitRailButton(
-                Icons.Rounded.CallMerge,
-                "Fusionar celdas",
-                enabled = state.canMerge()
-            ) {
-                state.mergeSelection()
+            actions.chunked(columns).forEach { rowActions ->
+                Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+                    rowActions.forEach { action ->
+                        TextKitRailButton(
+                            icon = action.icon,
+                            contentDescription = action.description,
+                            enabled = action.enabled,
+                            onClick = action.onClick,
+                        )
+                    }
+                }
             }
-            TextKitRailButton(
-                Icons.Rounded.CallSplit,
-                "Dividir celda",
-                enabled = state.canSplit()
-            ) {
-                state.splitSelection()
-            }
-            TextKitRailButton(
-                Icons.Rounded.Title,
-                "Alternar encabezado",
-                enabled = state.hasSelection()
-            ) {
-                state.toggleHeaderBlock()
-            }
-            TextKitRailButton(
-                Icons.Rounded.DeleteOutline,
-                "Eliminar selección",
-                enabled = state.hasSelection()
-            ) {
-                state.deleteSelection()
-            }
-        }
-        Spacer(Modifier.height(6.dp))
-        TextKitRailButton(Icons.Rounded.Sync, "Sincronizar cambios", primary = true) {
-            onSync(state.toProseMirrorJson())
         }
     }
 }
@@ -348,10 +377,22 @@ private fun TextKitTableCellView(
         BorderStroke(1.dp, TextKitTheme.colors.outlineVariant)
     }
 
+    // Keep the field's own TextFieldValue (cursor/selection) locally so live typing is never disturbed
+    // by recompositions. Reflect *external* content changes (undo/redo/reload) only when they differ.
+    var value by remember(id) { mutableStateOf(TextFieldValue(content.text)) }
+    LaunchedEffect(content.text) {
+        if (content.text != value.text) {
+            value = TextFieldValue(content.text, TextRange(content.text.length))
+        }
+    }
+
     Box(modifier = Modifier.fillMaxSize().background(background).border(border)) {
         BasicTextField(
-            value = content.text,
-            onValueChange = { content.text = it },
+            value = value,
+            onValueChange = {
+                value = it
+                state.editCell(id, it.text)
+            },
             textStyle = cellTextStyle(isHeader),
             cursorBrush = SolidColor(TextKitTheme.colors.primary),
             modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 10.dp),
@@ -372,7 +413,7 @@ private fun TextKitCornerHandle(state: TextKitEditableTableState) {
         if (state.hasSelection()) {
             Icon(
                 Icons.Rounded.Close,
-                contentDescription = "Quitar selección",
+                contentDescription = stringResource(Res.string.table_clear_selection_text),
                 tint = TextKitTheme.colors.onSurfaceVariant,
                 modifier = Modifier.size(14.dp),
             )
@@ -433,7 +474,7 @@ private fun TextKitAddHandle(onClick: () -> Unit) {
     ) {
         Icon(
             Icons.Rounded.Add,
-            contentDescription = "Agregar",
+            contentDescription = stringResource(Res.string.table_add_text),
             tint = TextKitTheme.colors.primary,
             modifier = Modifier.size(16.dp),
         )
@@ -483,7 +524,7 @@ private fun TextKitEditableTablePreview() {
             }
             if (synced.isNotEmpty()) {
                 Text(
-                    text = "JSON sincronizado",
+                    text = stringResource(Res.string.table_synced_json_text),
                     style = TextStyle(
                         fontFamily = TextKitTheme.typography.fontFamily,
                         fontSize = 13.sp,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitEditableTable.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitEditableTable.kt
@@ -1,0 +1,512 @@
+package com.jjrodcast.textkit.ui.table
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.CallMerge
+import androidx.compose.material.icons.rounded.CallSplit
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.DeleteOutline
+import androidx.compose.material.icons.rounded.Sync
+import androidx.compose.material.icons.rounded.Title
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.jjrodcast.textkit.theme.TextKitTheme
+
+/**
+ * An **editable**, Notion-style rich table for a `table` embed — designed to live inside a popup and
+ * work equally well with touch (mobile/tablet) and pointer (web/desktop).
+ *
+ * The interaction is gutter-driven, like Notion:
+ * - Tap a **column handle** (top strip) or a **row handle** (left strip) to select that line; tap
+ *   several to grow the selection. The corner clears it.
+ * - The side **icon rail** acts on the current selection: merge, split, toggle header, delete.
+ * - The **+** handles at the far edges append a column / a row.
+ * - Cells are plain editable text, so tapping a cell never fights with selecting it.
+ *
+ * Header cells use a more prominent color (`primaryContainer`) so they stand out from body rows.
+ * Nothing leaves the component until the user taps **Sync** (the primary rail icon), which hands
+ * [onSync] the table re-serialized to the same ProseMirror JSON shape as the embed's `rawJson`.
+ *
+ * Everything is themed through [TextKitTheme] (colors + font family), so it adapts to light/dark.
+ *
+ * @param rawJson The ProseMirror `table` JSON from the embed model (`EmbedInfo.rawJson`). A fresh
+ *   editable state is rebuilt whenever this changes. Malformed input falls back to a starter 3×3.
+ * @param onSync Called with the updated ProseMirror `table` JSON when the user syncs their changes.
+ * @param modifier Layout modifier for the root.
+ */
+@Composable
+fun TextKitEditableTable(
+    rawJson: String,
+    onSync: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state = remember(rawJson) { TextKitEditableTableState.from(rawJson) }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(verticalAlignment = Alignment.Top) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .heightIn(max = TextKitTableConstants.MaxTableHeight)
+                    .verticalScroll(rememberScrollState())
+                    .horizontalScroll(rememberScrollState()),
+            ) {
+                TextKitTableGrid(state = state)
+            }
+            TextKitActionRail(
+                state = state,
+                onSync = onSync,
+                modifier = Modifier.padding(start = 6.dp),
+            )
+        }
+
+        Text(
+            text = "Toca los bordes para seleccionar filas o columnas; usa los íconos para fusionar, dividir o eliminar.",
+            style = captionStyle(),
+        )
+    }
+}
+
+@Composable
+private fun TextKitActionRail(
+    state: TextKitEditableTableState,
+    onSync: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.width(TextKitTableConstants.RailWidth),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Scroll the contextual actions so they all stay reachable when the popup is short (landscape),
+        // while the primary "Sincronizar" action stays pinned at the bottom. The heightIn cap keeps the
+        // inner scroll bounded even if the rail is placed in an unbounded-height parent.
+        Column(
+            modifier = Modifier
+                .weight(1f, fill = false)
+                .heightIn(max = TextKitTableConstants.MaxTableHeight)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            TextKitRailButton(
+                Icons.Rounded.CallMerge,
+                "Fusionar celdas",
+                enabled = state.canMerge()
+            ) {
+                state.mergeSelection()
+            }
+            TextKitRailButton(
+                Icons.Rounded.CallSplit,
+                "Dividir celda",
+                enabled = state.canSplit()
+            ) {
+                state.splitSelection()
+            }
+            TextKitRailButton(
+                Icons.Rounded.Title,
+                "Alternar encabezado",
+                enabled = state.hasSelection()
+            ) {
+                state.toggleHeaderBlock()
+            }
+            TextKitRailButton(
+                Icons.Rounded.DeleteOutline,
+                "Eliminar selección",
+                enabled = state.hasSelection()
+            ) {
+                state.deleteSelection()
+            }
+        }
+        Spacer(Modifier.height(6.dp))
+        TextKitRailButton(Icons.Rounded.Sync, "Sincronizar cambios", primary = true) {
+            onSync(state.toProseMirrorJson())
+        }
+    }
+}
+
+@Composable
+private fun TextKitRailButton(
+    icon: ImageVector,
+    contentDescription: String,
+    enabled: Boolean = true,
+    primary: Boolean = false,
+    onClick: () -> Unit,
+) {
+    val background = when {
+        primary -> TextKitTheme.colors.primary
+        else -> TextKitTheme.colors.surfaceVariant
+    }
+    val content = when {
+        primary -> TextKitTheme.colors.onPrimary
+        enabled -> TextKitTheme.colors.onSurfaceVariant
+        else -> TextKitTheme.colors.onSurfaceVariant.copy(alpha = 0.35f)
+    }
+    Surface(
+        onClick = onClick,
+        enabled = enabled || primary,
+        shape = CircleShape,
+        color = background,
+        contentColor = content,
+        modifier = Modifier.size(TextKitTableConstants.RailButtonSize),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(icon, contentDescription = contentDescription, modifier = Modifier.size(20.dp))
+        }
+    }
+}
+
+@Composable
+private fun TextKitTableGrid(
+    state: TextKitEditableTableState,
+    modifier: Modifier = Modifier
+) {
+    // Read `version` so structural mutations trigger a recomposition + re-measure, and `blockRect`
+    // (which reads the selection) so cell highlighting refreshes when the selection changes.
+    @Suppress("UNUSED_VARIABLE") val version = state.version
+    val rect = state.blockRect()
+    val anchors = state.anchors()
+    val rowCount = state.rows()
+    val colCount = state.cols()
+
+    fun highlighted(a: Anchor): Boolean = rect != null &&
+            a.row <= rect[2] && a.row + a.rowSpan - 1 >= rect[0] &&
+            a.col <= rect[3] && a.col + a.colSpan - 1 >= rect[1]
+
+    Layout(
+        modifier = modifier,
+        content = {
+            key("corner") { Box(Modifier.gridChild(CornerChild)) { TextKitCornerHandle(state) } }
+            for (c in 0 until colCount) {
+                key("col$c") {
+                    Box(Modifier.gridChild(ColHandleChild(c))) {
+                        TextKitColumnHandle(
+                            state,
+                            c
+                        )
+                    }
+                }
+            }
+            key("addCol") {
+                Box(Modifier.gridChild(AddColChild)) {
+                    TextKitAddHandle {
+                        state.addColumn(
+                            state.cols()
+                        )
+                    }
+                }
+            }
+            for (r in 0 until rowCount) {
+                key("row$r") {
+                    Box(Modifier.gridChild(RowHandleChild(r))) {
+                        TextKitRowHandle(
+                            state,
+                            r
+                        )
+                    }
+                }
+            }
+            key("addRow") {
+                Box(Modifier.gridChild(AddRowChild)) {
+                    TextKitAddHandle {
+                        state.addRow(
+                            state.rows()
+                        )
+                    }
+                }
+            }
+            anchors.forEach { a ->
+                key("cell${a.id}") {
+                    Box(Modifier.gridChild(CellChild(a.row, a.col, a.rowSpan, a.colSpan))) {
+                        TextKitTableCellView(state = state, id = a.id, highlighted = highlighted(a))
+                    }
+                }
+            }
+        },
+    ) { measurables, _ ->
+        val gutterPx = TextKitTableConstants.GutterSize.roundToPx()
+        val addPx = TextKitTableConstants.AddSize.roundToPx()
+        val colPx = TextKitTableConstants.ColumnWidth.roundToPx()
+        val minRowPx = TextKitTableConstants.MinRowHeight.roundToPx()
+        val kids = measurables.map { it.parentData as GridChild }
+
+        // Row heights come from the cells (single-row cells set them; multi-row cells grow the last
+        // spanned row). Intrinsics give the natural height since a Measurable can be measured once.
+        val rowH = IntArray(rowCount) { minRowPx }
+        measurables.forEachIndexed { i, m ->
+            val k = kids[i]
+            if (k is CellChild && k.rowSpan == 1) {
+                rowH[k.row] = maxOf(rowH[k.row], m.maxIntrinsicHeight(k.colSpan * colPx))
+            }
+        }
+        measurables.forEachIndexed { i, m ->
+            val k = kids[i]
+            if (k is CellChild && k.rowSpan > 1) {
+                val h = m.maxIntrinsicHeight(k.colSpan * colPx)
+                val have = (k.row until k.row + k.rowSpan).sumOf { rowH[it] }
+                if (h > have) rowH[k.row + k.rowSpan - 1] += h - have
+            }
+        }
+        val rowY = IntArray(rowCount)
+        for (r in 1 until rowCount) rowY[r] = rowY[r - 1] + rowH[r - 1]
+        val cellsH = rowH.sum()
+        val gridW = colCount * colPx
+
+        val placeables = measurables.mapIndexed { i, m ->
+            when (val k = kids[i]) {
+                is CellChild -> {
+                    val h = (k.row until k.row + k.rowSpan).sumOf { rowH[it] }
+                    m.measure(Constraints.fixed(k.colSpan * colPx, h))
+                }
+
+                is ColHandleChild -> m.measure(Constraints.fixed(colPx, gutterPx))
+                is RowHandleChild -> m.measure(Constraints.fixed(gutterPx, rowH[k.row]))
+                CornerChild -> m.measure(Constraints.fixed(gutterPx, gutterPx))
+                AddColChild -> m.measure(Constraints.fixed(addPx, cellsH.coerceAtLeast(minRowPx)))
+                AddRowChild -> m.measure(Constraints.fixed(gridW, addPx))
+            }
+        }
+
+        val totalW = gutterPx + gridW + addPx
+        val totalH = gutterPx + cellsH + addPx
+        layout(totalW, totalH) {
+            placeables.forEachIndexed { i, p ->
+                val pos = when (val k = kids[i]) {
+                    is CellChild -> Pair(gutterPx + k.col * colPx, gutterPx + rowY[k.row])
+                    is ColHandleChild -> Pair(gutterPx + k.col * colPx, 0)
+                    is RowHandleChild -> Pair(0, gutterPx + rowY[k.row])
+                    CornerChild -> Pair(0, 0)
+                    AddColChild -> Pair(gutterPx + gridW, gutterPx)
+                    AddRowChild -> Pair(gutterPx, gutterPx + cellsH)
+                }
+                p.place(pos.first, pos.second)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TextKitTableCellView(
+    state: TextKitEditableTableState,
+    id: Long,
+    highlighted: Boolean
+) {
+    val content = state.cells[id] ?: return
+    val isHeader = content.isHeader
+
+    val background = when {
+        isHeader && highlighted -> TextKitTheme.colors.primaryContainer.copy(alpha = 0.7f)
+        isHeader -> TextKitTheme.colors.primaryContainer
+        highlighted -> TextKitTheme.colors.primary.copy(alpha = 0.12f)
+        else -> TextKitTheme.colors.surface
+    }
+    val border = if (highlighted) {
+        BorderStroke(2.dp, TextKitTheme.colors.primary)
+    } else {
+        BorderStroke(1.dp, TextKitTheme.colors.outlineVariant)
+    }
+
+    Box(modifier = Modifier.fillMaxSize().background(background).border(border)) {
+        BasicTextField(
+            value = content.text,
+            onValueChange = { content.text = it },
+            textStyle = cellTextStyle(isHeader),
+            cursorBrush = SolidColor(TextKitTheme.colors.primary),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 10.dp),
+        )
+    }
+}
+
+
+@Composable
+private fun TextKitCornerHandle(state: TextKitEditableTableState) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(TextKitTheme.colors.surfaceVariant)
+            .clickable { state.clearSelection() },
+        contentAlignment = Alignment.Center,
+    ) {
+        if (state.hasSelection()) {
+            Icon(
+                Icons.Rounded.Close,
+                contentDescription = "Quitar selección",
+                tint = TextKitTheme.colors.onSurfaceVariant,
+                modifier = Modifier.size(14.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TextKitColumnHandle(state: TextKitEditableTableState, col: Int) {
+    val selected = col in state.selectedCols
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(if (selected) TextKitTheme.colors.primary else TextKitTheme.colors.surfaceVariant)
+            .clickable { state.toggleCol(col) },
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = 16.dp, height = 3.dp)
+                .background(
+                    color = if (selected) TextKitTheme.colors.onPrimary else TextKitTheme.colors.onSurfaceVariant,
+                    shape = RoundedCornerShape(2.dp),
+                ),
+        )
+    }
+}
+
+@Composable
+private fun TextKitRowHandle(state: TextKitEditableTableState, row: Int) {
+    val selected = row in state.selectedRows
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(if (selected) TextKitTheme.colors.primary else TextKitTheme.colors.surfaceVariant)
+            .clickable { state.toggleRow(row) },
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = 3.dp, height = 16.dp)
+                .background(
+                    color = if (selected) TextKitTheme.colors.onPrimary else TextKitTheme.colors.onSurfaceVariant,
+                    shape = RoundedCornerShape(2.dp),
+                ),
+        )
+    }
+}
+
+@Composable
+private fun TextKitAddHandle(onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(TextKitTheme.colors.surface)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            Icons.Rounded.Add,
+            contentDescription = "Agregar",
+            tint = TextKitTheme.colors.primary,
+            modifier = Modifier.size(16.dp),
+        )
+    }
+}
+
+@Composable
+private fun cellTextStyle(isHeader: Boolean): TextStyle = TextStyle(
+    fontFamily = TextKitTheme.typography.fontFamily,
+    fontSize = 14.sp,
+    fontWeight = if (isHeader) FontWeight.SemiBold else FontWeight.Normal,
+    color = if (isHeader) TextKitTheme.colors.onPrimaryContainer else TextKitTheme.colors.onSurface,
+)
+
+@Composable
+private fun captionStyle(): TextStyle = TextStyle(
+    fontFamily = TextKitTheme.typography.fontFamily,
+    fontSize = 11.sp,
+    color = TextKitTheme.colors.onSurfaceVariant,
+)
+
+@Preview(showBackground = true, backgroundColor = 0xFFF5FBF7, widthDp = 560, heightDp = 620)
+@Composable
+private fun TextKitEditableTablePreview() {
+    var synced by remember { mutableStateOf("") }
+
+    TextKitTheme(darkTheme = false) {
+        Column(
+            modifier = Modifier
+                .background(TextKitTheme.colors.background)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Rendered inside a card so it reads like the popup it will live in.
+            Surface(
+                shape = RoundedCornerShape(14.dp),
+                color = TextKitTheme.colors.surface,
+                contentColor = TextKitTheme.colors.onSurface,
+                border = BorderStroke(1.dp, TextKitTheme.colors.outlineVariant),
+            ) {
+                TextKitEditableTable(
+                    rawJson = TextKitTableConstants.SampleTableJson,
+                    onSync = { synced = it },
+                    modifier = Modifier.padding(12.dp),
+                )
+            }
+            if (synced.isNotEmpty()) {
+                Text(
+                    text = "JSON sincronizado",
+                    style = TextStyle(
+                        fontFamily = TextKitTheme.typography.fontFamily,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = TextKitTheme.colors.onBackground,
+                    ),
+                )
+                Text(text = synced, style = captionStyle())
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF0E1513, widthDp = 560, heightDp = 460)
+@Composable
+private fun TextKitEditableTableDarkPreview() {
+    TextKitTheme(darkTheme = true) {
+        Column(
+            modifier = Modifier
+                .background(TextKitTheme.colors.background)
+                .padding(16.dp),
+        ) {
+            TextKitEditableTable(rawJson = TextKitTableConstants.SampleTableJson, onSync = {})
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitEditableTable.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitEditableTable.kt
@@ -105,7 +105,7 @@ fun TextKitEditableTable(
     SideEffect { state.setOnChange(onSync) }
 
     // Reload only on a *genuine* external change. Fast path: exact match with what we last emitted is
-    // our own echo → ignore. Otherwise compare canonically so cosmetic reformatting from the host
+    // our own echo → ignore. Otherwise, compare canonically so cosmetic reformatting from the host
     // doesn't force a rebuild that would drop focus/selection.
     LaunchedEffect(rawJson) {
         if (rawJson != state.lastSyncedRaw &&
@@ -232,9 +232,6 @@ private fun TextKitTableGrid(
     state: TextKitEditableTableState,
     modifier: Modifier = Modifier
 ) {
-    // Read `version` so structural mutations trigger a recomposition + re-measure, and `blockRect`
-    // (which reads the selection) so cell highlighting refreshes when the selection changes.
-    @Suppress("UNUSED_VARIABLE") val version = state.version
     val rect = state.blockRect()
     val anchors = state.anchors()
     val rowCount = state.rows()

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitEditableTableState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitEditableTableState.kt
@@ -1,0 +1,365 @@
+package com.jjrodcast.textkit.ui.table
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.setValue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * Holds the editable table. `grid[r][c]` stores the id of the cell occupying that logical slot; a
+ * merged cell simply has its id in every slot it covers. Spans are always *derived* from the grid
+ * (see [anchors]), which keeps every mutation (add/remove/merge/split) a simple grid edit that can't
+ * leave the model inconsistent. The rectangle is kept dense (all rows share the same width).
+ *
+ * Selection is line-based: [selectedRows] / [selectedCols] hold whole-line indices (chosen via the
+ * gutter handles). The acted-upon rectangle is their bounding box ([blockRect]).
+ */
+@Stable
+internal class TextKitEditableTableState(
+    private val grid: MutableList<MutableList<Long>>,
+    val cells: MutableMap<Long, CellContent>,
+    startId: Long,
+) {
+    private var nextId = startId
+
+    /** Bumped on structural changes (rows/cols/spans) to invalidate the grid layout. */
+    var version by mutableIntStateOf(0)
+        private set
+
+    val selectedRows = mutableStateListOf<Int>()
+    val selectedCols = mutableStateListOf<Int>()
+
+    private fun newId(): Long = nextId++
+    private fun bump() { version++ }
+
+    fun rows(): Int = grid.size
+    fun cols(): Int = grid.firstOrNull()?.size ?: 0
+
+    /** Derive every anchor (top-left + span) from the grid, sorted row-major for stable rendering. */
+    fun anchors(): List<Anchor> {
+        val box = HashMap<Long, IntArray>() // id -> [minR, minC, maxR, maxC]
+        for (r in grid.indices) {
+            val row = grid[r]
+            for (c in row.indices) {
+                val id = row[c]
+                val b = box[id]
+                if (b == null) {
+                    box[id] = intArrayOf(r, c, r, c)
+                } else {
+                    if (r < b[0]) b[0] = r
+                    if (c < b[1]) b[1] = c
+                    if (r > b[2]) b[2] = r
+                    if (c > b[3]) b[3] = c
+                }
+            }
+        }
+        return box.entries
+            .map { (id, b) -> Anchor(id, b[0], b[1], b[2] - b[0] + 1, b[3] - b[1] + 1) }
+            .sortedWith(compareBy({ it.row }, { it.col }))
+    }
+
+    private fun anchorMap(): Map<Long, Anchor> = anchors().associateBy { it.id }
+
+    // --- selection --------------------------------------------------------------------------
+
+    fun toggleRow(r: Int) { if (r in selectedRows) selectedRows.remove(r) else selectedRows.add(r) }
+    fun toggleCol(c: Int) { if (c in selectedCols) selectedCols.remove(c) else selectedCols.add(c) }
+    fun clearSelection() { selectedRows.clear(); selectedCols.clear() }
+    fun hasSelection(): Boolean = selectedRows.isNotEmpty() || selectedCols.isNotEmpty()
+
+    /** Bounding box [r0, c0, r1, c1] of the current selection (whole rows/cols fall back to full). */
+    fun blockRect(): IntArray? {
+        if (!hasSelection()) return null
+        val r0 = if (selectedRows.isEmpty()) 0 else selectedRows.min()
+        val r1 = if (selectedRows.isEmpty()) rows() - 1 else selectedRows.max()
+        val c0 = if (selectedCols.isEmpty()) 0 else selectedCols.min()
+        val c1 = if (selectedCols.isEmpty()) cols() - 1 else selectedCols.max()
+        return intArrayOf(r0, c0, r1, c1)
+    }
+
+    /** True when no cell straddles the rectangle's edges (so it can be merged/split cleanly). */
+    private fun rectValid(r0: Int, c0: Int, r1: Int, c1: Int): Boolean {
+        val am = anchorMap()
+        for (r in r0..r1) for (c in c0..c1) {
+            val a = am[grid[r][c]] ?: return false
+            if (a.row < r0 || a.col < c0 || a.row + a.rowSpan - 1 > r1 || a.col + a.colSpan - 1 > c1) {
+                return false
+            }
+        }
+        return true
+    }
+
+    // --- structural mutations ---------------------------------------------------------------
+
+    fun addRow(at: Int) {
+        val n = cols()
+        val newRow = ArrayList<Long>(n)
+        for (c in 0 until n) {
+            val above = if (at > 0) grid[at - 1][c] else -1L
+            val below = if (at < grid.size) grid[at][c] else -1L
+            // Inserting *inside* a vertically-merged cell grows it (Notion behavior); otherwise the
+            // new slot is a fresh empty single cell.
+            if (at in 1 until grid.size && above == below) {
+                newRow.add(above)
+            } else {
+                val id = newId()
+                cells[id] = CellContent("", false)
+                newRow.add(id)
+            }
+        }
+        grid.add(at, newRow)
+        clearSelection()
+        bump()
+    }
+
+    fun addColumn(at: Int) {
+        for (row in grid) {
+            val left = if (at > 0) row[at - 1] else -1L
+            val right = if (at < row.size) row[at] else -1L
+            if (at in 1 until row.size && left == right) {
+                row.add(at, left) // grow a horizontally-merged cell
+            } else {
+                val id = newId()
+                cells[id] = CellContent("", false)
+                row.add(at, id)
+            }
+        }
+        clearSelection()
+        bump()
+    }
+
+    private fun deleteRows(indices: List<Int>) {
+        val distinct = indices.distinct()
+        if (rows() - distinct.size < 1) return // always keep at least one row
+        distinct.sortedDescending().forEach { if (it in grid.indices) grid.removeAt(it) }
+        purge()
+        clearSelection()
+        bump()
+    }
+
+    private fun deleteColumns(indices: List<Int>) {
+        val distinct = indices.distinct()
+        if (cols() - distinct.size < 1) return // always keep at least one column
+        val desc = distinct.sortedDescending()
+        for (row in grid) for (c in desc) if (c < row.size) row.removeAt(c)
+        purge()
+        clearSelection()
+        bump()
+    }
+
+    fun deleteSelection() {
+        when {
+            selectedRows.isNotEmpty() -> deleteRows(selectedRows.toList())
+            selectedCols.isNotEmpty() -> deleteColumns(selectedCols.toList())
+        }
+    }
+
+    // --- merge / split ----------------------------------------------------------------------
+
+    fun canMerge(): Boolean {
+        val rect = blockRect() ?: return false
+        val (r0, c0, r1, c1) = listOf(rect[0], rect[1], rect[2], rect[3])
+        if ((r1 - r0 + 1) * (c1 - c0 + 1) <= 1) return false
+        if (!rectValid(r0, c0, r1, c1)) return false
+        val ids = HashSet<Long>()
+        for (r in r0..r1) for (c in c0..c1) ids.add(grid[r][c])
+        return ids.size > 1
+    }
+
+    fun mergeSelection() {
+        if (!canMerge()) return
+        val rect = blockRect() ?: return
+        val target = grid[rect[0]][rect[1]] // keep the top-left cell's content
+        for (r in rect[0]..rect[2]) for (c in rect[1]..rect[3]) grid[r][c] = target
+        purge()
+        clearSelection()
+        bump()
+    }
+
+    fun canSplit(): Boolean {
+        val rect = blockRect() ?: return false
+        val a = anchorMap()[grid[rect[0]][rect[1]]] ?: return false
+        // The selection must correspond exactly to one merged cell.
+        return a.row == rect[0] && a.col == rect[1] &&
+            a.row + a.rowSpan - 1 == rect[2] && a.col + a.colSpan - 1 == rect[3] &&
+            (a.rowSpan > 1 || a.colSpan > 1)
+    }
+
+    fun splitSelection() {
+        if (!canSplit()) return
+        val rect = blockRect() ?: return
+        val id = grid[rect[0]][rect[1]]
+        val header = cells[id]?.isHeader == true
+        var first = true
+        for (r in rect[0]..rect[2]) for (c in rect[1]..rect[3]) {
+            if (first) { first = false; continue } // top-left keeps the id + content
+            val nid = newId()
+            cells[nid] = CellContent("", header)
+            grid[r][c] = nid
+        }
+        clearSelection()
+        bump()
+    }
+
+    fun toggleHeaderBlock() {
+        val rect = blockRect() ?: return
+        val ids = HashSet<Long>()
+        for (r in rect[0]..rect[2]) for (c in rect[1]..rect[3]) ids.add(grid[r][c])
+        if (ids.isEmpty()) return
+        val allHeader = ids.all { cells[it]?.isHeader == true }
+        ids.forEach { cells[it]?.isHeader = !allHeader }
+    }
+
+    private fun purge() {
+        val live = grid.flatten().toHashSet()
+        cells.keys.retainAll(live)
+    }
+
+    // --- serialization ----------------------------------------------------------------------
+
+    /** Serialize back to the ProseMirror `table` JSON shape carried by the embed's `rawJson`. */
+    fun toProseMirrorJson(): String {
+        val anchorMap = anchorMap()
+        val root = buildJsonObject {
+            put("type", "table")
+            putJsonArray("content") {
+                for (r in 0 until rows()) {
+                    add(
+                        buildJsonObject {
+                            put("type", "tableRow")
+                            putJsonArray("content") {
+                                for (c in 0 until cols()) {
+                                    val id = grid[r][c]
+                                    val a = anchorMap[id] ?: continue
+                                    if (a.row != r || a.col != c) continue // emit only the anchor slot
+                                    val content = cells[id] ?: continue
+                                    add(
+                                        buildJsonObject {
+                                            put("type", if (content.isHeader) "tableHeader" else "tableCell")
+                                            putJsonObject("attrs") {
+                                                put("colspan", a.colSpan)
+                                                put("rowspan", a.rowSpan)
+                                                put("colwidth", JsonNull)
+                                            }
+                                            putJsonArray("content") { add(paragraphJson(content.text)) }
+                                        },
+                                    )
+                                }
+                            }
+                        },
+                    )
+                }
+            }
+        }
+        return root.toString()
+    }
+
+    companion object {
+        private val json = Json { ignoreUnknownKeys = true }
+
+        fun from(rawJson: String): TextKitEditableTableState =
+            runCatching { parse(rawJson) }.getOrNull() ?: default()
+
+        private fun default(): TextKitEditableTableState {
+            val grid = MutableList(3) { r -> MutableList(3) { c -> (r * 3 + c).toLong() } }
+            val cells = HashMap<Long, CellContent>()
+            for (r in 0..2) for (c in 0..2) {
+                val id = (r * 3 + c).toLong()
+                cells[id] = CellContent(if (r == 0) "Encabezado ${c + 1}" else "", r == 0)
+            }
+            return TextKitEditableTableState(grid, cells, 9L)
+        }
+
+        private fun parse(rawJson: String): TextKitEditableTableState {
+            val obj = json.parseToJsonElement(rawJson).jsonObject
+            require(obj["type"]?.jsonPrimitive?.content == "table")
+            val rowsJson = obj["content"]?.jsonArray ?: JsonArray(emptyList())
+
+            val grid: MutableList<MutableList<Long>> = ArrayList()
+            val cells = HashMap<Long, CellContent>()
+            var nextId = 0L
+
+            fun ensure(r: Int, c: Int) {
+                while (grid.size <= r) grid.add(ArrayList())
+                val row = grid[r]
+                while (row.size <= c) row.add(-1L)
+            }
+
+            fun get(r: Int, c: Int): Long {
+                if (r >= grid.size) return -1L
+                val row = grid[r]
+                if (c >= row.size) return -1L
+                return row[c]
+            }
+
+            fun set(r: Int, c: Int, id: Long) { ensure(r, c); grid[r][c] = id }
+
+            rowsJson.forEachIndexed { r, rowEl ->
+                ensure(r, 0)
+                val cs = rowEl.jsonObject["content"]?.jsonArray ?: JsonArray(emptyList())
+                var c = 0
+                cs.forEach { cellEl ->
+                    val cell = cellEl.jsonObject
+                    while (get(r, c) != -1L) c++
+                    val attrs = cell["attrs"]?.jsonObject
+                    val colspan = attrs?.get("colspan")?.jsonPrimitive?.content?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+                    val rowspan = attrs?.get("rowspan")?.jsonPrimitive?.content?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+                    val isHeader = cell["type"]?.jsonPrimitive?.content == "tableHeader"
+                    val id = nextId++
+                    cells[id] = CellContent(cellText(cell["content"]?.jsonArray), isHeader)
+                    for (dr in 0 until rowspan) for (dc in 0 until colspan) set(r + dr, c + dc, id)
+                    c += colspan
+                }
+            }
+
+            require(grid.isNotEmpty())
+            // Rectangularize: pad every row to the widest and fill any holes with fresh single cells.
+            val cols = grid.maxOf { it.size }.coerceAtLeast(1)
+            for (r in grid.indices) {
+                ensure(r, cols - 1)
+                val row = grid[r]
+                for (c in 0 until cols) {
+                    if (row[c] == -1L) {
+                        val id = nextId++
+                        cells[id] = CellContent("", false)
+                        row[c] = id
+                    }
+                }
+            }
+            return TextKitEditableTableState(grid, cells, nextId)
+        }
+
+        /** Concatenates all `text` leaves inside a cell's paragraph content. */
+        private fun cellText(paragraphs: JsonArray?): String {
+            if (paragraphs == null) return ""
+            val builder = StringBuilder()
+            paragraphs.forEach { paragraph ->
+                paragraph.jsonObject["content"]?.jsonArray?.forEach { inline ->
+                    inline.jsonObject["text"]?.jsonPrimitive?.content?.let { builder.append(it) }
+                }
+            }
+            return builder.toString()
+        }
+
+        private fun paragraphJson(text: String): JsonObject = buildJsonObject {
+            put("type", "paragraph")
+            putJsonArray("content") {
+                if (text.isNotEmpty()) {
+                    add(buildJsonObject { put("type", "text"); put("text", text) })
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitEditableTableState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitEditableTableState.kt
@@ -4,18 +4,19 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
+
+/** Max number of undo snapshots kept per editing session. */
+private const val MaxHistory = 100
 
 /**
  * Holds the editable table. `grid[r][c]` stores the id of the cell occupying that logical slot; a
@@ -25,13 +26,31 @@ import kotlinx.serialization.json.putJsonObject
  *
  * Selection is line-based: [selectedRows] / [selectedCols] hold whole-line indices (chosen via the
  * gutter handles). The acted-upon rectangle is their bounding box ([blockRect]).
+ *
+ * **Undo/redo & sync.** This state is the single source of truth. Every mutation:
+ * 1. pushes a snapshot onto [undoStack] (consecutive keystrokes in one cell coalesce into a single
+ *    snapshot, exactly like the text editor groups typing), and
+ * 2. emits the new JSON via [onChange] so the host document stays in sync automatically — no manual
+ *    "sync" step.
+ *
+ * Because the table drives the JSON (and never rebuilds itself from its own echo — see [loadFrom] /
+ * [lastSyncedRaw]), editing never loses focus, cursor, selection or scroll. External changes
+ * (e.g. a document-level undo) come back through [loadFrom], which reloads in place.
  */
 @Stable
 internal class TextKitEditableTableState(
     private val grid: MutableList<MutableList<Long>>,
-    val cells: MutableMap<Long, CellContent>,
+    initialCells: Map<Long, CellContent>,
     startId: Long,
 ) {
+    /**
+     * Cell content by id. Backed by a **snapshot state map** so restoring a snapshot (undo/redo) or a
+     * reload recomposes exactly the cells whose content changed — even when the grid layout and the
+     * cell composable's parameters are otherwise identical (a plain map read wouldn't invalidate it).
+     */
+    val cells: SnapshotStateMap<Long, CellContent> =
+        mutableStateMapOf<Long, CellContent>().also { it.putAll(initialCells) }
+
     private var nextId = startId
 
     /** Bumped on structural changes (rows/cols/spans) to invalidate the grid layout. */
@@ -40,6 +59,33 @@ internal class TextKitEditableTableState(
 
     val selectedRows = mutableStateListOf<Int>()
     val selectedCols = mutableStateListOf<Int>()
+
+    // --- history + sync ---------------------------------------------------------------------
+
+    private val undoStack = ArrayDeque<TableSnapshot>()
+    private val redoStack = ArrayDeque<TableSnapshot>()
+
+    /** Coalescing key of the run in progress (e.g. `"text:5"`); `null` = no run, next edit is atomic. */
+    private var coalesceKey: Any? = null
+
+    /** Whether an [undo] / [redo] is available. Observe them to enable/disable the rail buttons. */
+    var canUndo by mutableStateOf(false)
+        private set
+    var canRedo by mutableStateOf(false)
+        private set
+
+    /** Called with the new ProseMirror JSON after every committed change (auto-sync sink). */
+    private var onChange: ((String) -> Unit)? = null
+
+    /**
+     * The exact JSON string of the last state we emitted. Used to recognize our own echo: an incoming
+     * `rawJson` equal to this (or canonically equal to it) is *our* change and is ignored; anything
+     * else is a genuine external change and triggers [loadFrom].
+     */
+    var lastSyncedRaw: String = ""
+        private set
+
+    fun setOnChange(callback: (String) -> Unit) { onChange = callback }
 
     private fun newId(): Long = nextId++
     private fun bump() { version++ }
@@ -104,6 +150,7 @@ internal class TextKitEditableTableState(
     // --- structural mutations ---------------------------------------------------------------
 
     fun addRow(at: Int) {
+        pushUndo(null)
         val n = cols()
         val newRow = ArrayList<Long>(n)
         for (c in 0 until n) {
@@ -122,9 +169,11 @@ internal class TextKitEditableTableState(
         grid.add(at, newRow)
         clearSelection()
         bump()
+        emit()
     }
 
     fun addColumn(at: Int) {
+        pushUndo(null)
         for (row in grid) {
             val left = if (at > 0) row[at - 1] else -1L
             val right = if (at < row.size) row[at] else -1L
@@ -138,25 +187,30 @@ internal class TextKitEditableTableState(
         }
         clearSelection()
         bump()
+        emit()
     }
 
     private fun deleteRows(indices: List<Int>) {
         val distinct = indices.distinct()
         if (rows() - distinct.size < 1) return // always keep at least one row
+        pushUndo(null)
         distinct.sortedDescending().forEach { if (it in grid.indices) grid.removeAt(it) }
         purge()
         clearSelection()
         bump()
+        emit()
     }
 
     private fun deleteColumns(indices: List<Int>) {
         val distinct = indices.distinct()
         if (cols() - distinct.size < 1) return // always keep at least one column
+        pushUndo(null)
         val desc = distinct.sortedDescending()
         for (row in grid) for (c in desc) if (c < row.size) row.removeAt(c)
         purge()
         clearSelection()
         bump()
+        emit()
     }
 
     fun deleteSelection() {
@@ -164,6 +218,20 @@ internal class TextKitEditableTableState(
             selectedRows.isNotEmpty() -> deleteRows(selectedRows.toList())
             selectedCols.isNotEmpty() -> deleteColumns(selectedCols.toList())
         }
+    }
+
+    // --- text editing -----------------------------------------------------------------------
+
+    /**
+     * Sets [id]'s text. Consecutive edits to the *same* cell coalesce into one undo step (so undo
+     * reverts the whole typing burst, like the text editor), and each change auto-syncs the JSON.
+     */
+    fun editCell(id: Long, text: String) {
+        val cell = cells[id] ?: return
+        if (cell.text == text) return
+        pushUndo("text:$id")
+        cell.text = text
+        emit()
     }
 
     // --- merge / split ----------------------------------------------------------------------
@@ -180,12 +248,14 @@ internal class TextKitEditableTableState(
 
     fun mergeSelection() {
         if (!canMerge()) return
+        pushUndo(null)
         val rect = blockRect() ?: return
         val target = grid[rect[0]][rect[1]] // keep the top-left cell's content
         for (r in rect[0]..rect[2]) for (c in rect[1]..rect[3]) grid[r][c] = target
         purge()
         clearSelection()
         bump()
+        emit()
     }
 
     fun canSplit(): Boolean {
@@ -199,6 +269,7 @@ internal class TextKitEditableTableState(
 
     fun splitSelection() {
         if (!canSplit()) return
+        pushUndo(null)
         val rect = blockRect() ?: return
         val id = grid[rect[0]][rect[1]]
         val header = cells[id]?.isHeader == true
@@ -211,6 +282,7 @@ internal class TextKitEditableTableState(
         }
         clearSelection()
         bump()
+        emit()
     }
 
     fun toggleHeaderBlock() {
@@ -218,13 +290,102 @@ internal class TextKitEditableTableState(
         val ids = HashSet<Long>()
         for (r in rect[0]..rect[2]) for (c in rect[1]..rect[3]) ids.add(grid[r][c])
         if (ids.isEmpty()) return
+        pushUndo(null)
         val allHeader = ids.all { cells[it]?.isHeader == true }
         ids.forEach { cells[it]?.isHeader = !allHeader }
+        bump()
+        emit()
     }
 
     private fun purge() {
         val live = grid.flatten().toHashSet()
         cells.keys.retainAll(live)
+    }
+
+    // --- undo / redo ------------------------------------------------------------------------
+
+    private fun snapshot(): TableSnapshot = TableSnapshot(
+        grid = grid.map { it.toList() },
+        cells = cells.mapValues { (_, v) -> v.text to v.isHeader },
+        nextId = nextId,
+    )
+
+    private fun restoreSnapshot(s: TableSnapshot) {
+        grid.clear()
+        s.grid.forEach { grid.add(it.toMutableList()) }
+        cells.clear()
+        s.cells.forEach { (id, v) -> cells[id] = CellContent(v.first, v.second) }
+        nextId = s.nextId
+        clearSelection()
+        bump()
+    }
+
+    /**
+     * Records the current state as an undo point before a mutation. Same non-null [coalesce] key as
+     * the previous edit reuses that point (coalescing), so a run of edits collapses to one step.
+     */
+    private fun pushUndo(coalesce: Any?) {
+        val coalesced = coalesce != null && coalesce == coalesceKey && undoStack.isNotEmpty()
+        if (!coalesced) {
+            undoStack.addLast(snapshot())
+            if (undoStack.size > MaxHistory) undoStack.removeFirst()
+            redoStack.clear()
+        }
+        coalesceKey = coalesce
+        syncHistoryFlags()
+    }
+
+    fun undo() {
+        if (undoStack.isEmpty()) return
+        redoStack.addLast(snapshot())
+        restoreSnapshot(undoStack.removeLast())
+        coalesceKey = null // end any coalescing run
+        syncHistoryFlags()
+        emit()
+    }
+
+    fun redo() {
+        if (redoStack.isEmpty()) return
+        undoStack.addLast(snapshot())
+        restoreSnapshot(redoStack.removeLast())
+        coalesceKey = null
+        syncHistoryFlags()
+        emit()
+    }
+
+    private fun syncHistoryFlags() {
+        canUndo = undoStack.isNotEmpty()
+        canRedo = redoStack.isNotEmpty()
+    }
+
+    // --- external sync ----------------------------------------------------------------------
+
+    /** Emits the current table JSON to the host, remembering it so its echo is ignored. */
+    private fun emit() {
+        val json = toProseMirrorJson()
+        lastSyncedRaw = json
+        onChange?.invoke(json)
+    }
+
+    /**
+     * Replaces the whole table from an external [rawJson] (e.g. after a document-level undo), in
+     * place so the composable identity is kept. Clears history and selection; does not emit (the
+     * change originated outside).
+     */
+    fun loadFrom(rawJson: String) {
+        val fresh = from(rawJson)
+        grid.clear()
+        fresh.grid.forEach { grid.add(it.toMutableList()) }
+        cells.clear()
+        fresh.cells.forEach { (id, v) -> cells[id] = CellContent(v.text, v.isHeader) }
+        nextId = fresh.nextId
+        undoStack.clear()
+        redoStack.clear()
+        coalesceKey = null
+        clearSelection()
+        lastSyncedRaw = toProseMirrorJson()
+        syncHistoryFlags()
+        bump()
     }
 
     // --- serialization ----------------------------------------------------------------------
@@ -267,91 +428,17 @@ internal class TextKitEditableTableState(
     }
 
     companion object {
-        private val json = Json { ignoreUnknownKeys = true }
 
-        fun from(rawJson: String): TextKitEditableTableState =
-            runCatching { parse(rawJson) }.getOrNull() ?: default()
-
-        private fun default(): TextKitEditableTableState {
-            val grid = MutableList(3) { r -> MutableList(3) { c -> (r * 3 + c).toLong() } }
-            val cells = HashMap<Long, CellContent>()
-            for (r in 0..2) for (c in 0..2) {
-                val id = (r * 3 + c).toLong()
-                cells[id] = CellContent(if (r == 0) "Encabezado ${c + 1}" else "", r == 0)
-            }
-            return TextKitEditableTableState(grid, cells, 9L)
+        /** Builds a fresh state by decoding [rawJson] (see [TableJsonCodec]). */
+        fun from(rawJson: String): TextKitEditableTableState {
+            val decoded = TableJsonCodec.decode(rawJson)
+            val state = TextKitEditableTableState(decoded.grid, decoded.cells, decoded.nextId)
+            state.lastSyncedRaw = state.toProseMirrorJson()
+            return state
         }
 
-        private fun parse(rawJson: String): TextKitEditableTableState {
-            val obj = json.parseToJsonElement(rawJson).jsonObject
-            require(obj["type"]?.jsonPrimitive?.content == "table")
-            val rowsJson = obj["content"]?.jsonArray ?: JsonArray(emptyList())
-
-            val grid: MutableList<MutableList<Long>> = ArrayList()
-            val cells = HashMap<Long, CellContent>()
-            var nextId = 0L
-
-            fun ensure(r: Int, c: Int) {
-                while (grid.size <= r) grid.add(ArrayList())
-                val row = grid[r]
-                while (row.size <= c) row.add(-1L)
-            }
-
-            fun get(r: Int, c: Int): Long {
-                if (r >= grid.size) return -1L
-                val row = grid[r]
-                if (c >= row.size) return -1L
-                return row[c]
-            }
-
-            fun set(r: Int, c: Int, id: Long) { ensure(r, c); grid[r][c] = id }
-
-            rowsJson.forEachIndexed { r, rowEl ->
-                ensure(r, 0)
-                val cs = rowEl.jsonObject["content"]?.jsonArray ?: JsonArray(emptyList())
-                var c = 0
-                cs.forEach { cellEl ->
-                    val cell = cellEl.jsonObject
-                    while (get(r, c) != -1L) c++
-                    val attrs = cell["attrs"]?.jsonObject
-                    val colspan = attrs?.get("colspan")?.jsonPrimitive?.content?.toIntOrNull()?.coerceAtLeast(1) ?: 1
-                    val rowspan = attrs?.get("rowspan")?.jsonPrimitive?.content?.toIntOrNull()?.coerceAtLeast(1) ?: 1
-                    val isHeader = cell["type"]?.jsonPrimitive?.content == "tableHeader"
-                    val id = nextId++
-                    cells[id] = CellContent(cellText(cell["content"]?.jsonArray), isHeader)
-                    for (dr in 0 until rowspan) for (dc in 0 until colspan) set(r + dr, c + dc, id)
-                    c += colspan
-                }
-            }
-
-            require(grid.isNotEmpty())
-            // Rectangularize: pad every row to the widest and fill any holes with fresh single cells.
-            val cols = grid.maxOf { it.size }.coerceAtLeast(1)
-            for (r in grid.indices) {
-                ensure(r, cols - 1)
-                val row = grid[r]
-                for (c in 0 until cols) {
-                    if (row[c] == -1L) {
-                        val id = nextId++
-                        cells[id] = CellContent("", false)
-                        row[c] = id
-                    }
-                }
-            }
-            return TextKitEditableTableState(grid, cells, nextId)
-        }
-
-        /** Concatenates all `text` leaves inside a cell's paragraph content. */
-        private fun cellText(paragraphs: JsonArray?): String {
-            if (paragraphs == null) return ""
-            val builder = StringBuilder()
-            paragraphs.forEach { paragraph ->
-                paragraph.jsonObject["content"]?.jsonArray?.forEach { inline ->
-                    inline.jsonObject["text"]?.jsonPrimitive?.content?.let { builder.append(it) }
-                }
-            }
-            return builder.toString()
-        }
+        /** Canonical JSON of [rawJson] as this model would serialize it (for echo detection). */
+        fun canonical(rawJson: String): String = from(rawJson).toProseMirrorJson()
 
         private fun paragraphJson(text: String): JsonObject = buildJsonObject {
             put("type", "paragraph")

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitTableConstants.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitTableConstants.kt
@@ -1,0 +1,57 @@
+package com.jjrodcast.textkit.ui.table
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Layout dimensions and sample data for [TextKitEditableTable].
+ *
+ * Kept in one place so the custom grid layout, the gutters and the side rail all size themselves
+ * from a single source of truth.
+ */
+internal object TextKitTableConstants {
+
+    /** Thickness of the row/column selection gutters. */
+    val GutterSize: Dp = 26.dp
+
+    /** Thickness of the "+" add-row / add-column handles at the table edges. */
+    val AddSize: Dp = 26.dp
+
+    /** Fixed width of every table column. */
+    val ColumnWidth: Dp = 132.dp
+
+    /** Minimum height of a table row. */
+    val MinRowHeight: Dp = 44.dp
+
+    /** Max height of the scrollable table area so it never overflows the host popup. */
+    val MaxTableHeight: Dp = 360.dp
+
+    /** Width of the side action rail. */
+    val RailWidth: Dp = 48.dp
+
+    /** Diameter of a rail action button. */
+    val RailButtonSize: Dp = 42.dp
+
+    /** A demo ProseMirror `table` document used by the previews. */
+    const val SampleTableJson: String = """
+{
+  "type": "table",
+  "content": [
+    { "type": "tableRow", "content": [
+      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Producto"}]}] },
+      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Región"}]}] },
+      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Ventas"}]}] }
+    ]},
+    { "type": "tableRow", "content": [
+      { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Laptop"}]}] },
+      { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Norte"}]}] },
+      { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"1200"}]}] }
+    ]},
+    { "type": "tableRow", "content": [
+      { "type": "tableCell", "attrs": {"colspan": 2, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Total parcial"}]}] },
+      { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"1200"}]}] }
+    ]}
+  ]
+}
+"""
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitTableConstants.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/table/TextKitTableConstants.kt
@@ -26,9 +26,6 @@ internal object TextKitTableConstants {
     /** Max height of the scrollable table area so it never overflows the host popup. */
     val MaxTableHeight: Dp = 360.dp
 
-    /** Width of the side action rail. */
-    val RailWidth: Dp = 48.dp
-
     /** Diameter of a rail action button. */
     val RailButtonSize: Dp = 42.dp
 
@@ -38,17 +35,17 @@ internal object TextKitTableConstants {
   "type": "table",
   "content": [
     { "type": "tableRow", "content": [
-      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Producto"}]}] },
-      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Región"}]}] },
-      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Ventas"}]}] }
+      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Product"}]}] },
+      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Region"}]}] },
+      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Sales"}]}] }
     ]},
     { "type": "tableRow", "content": [
       { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Laptop"}]}] },
-      { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Norte"}]}] },
+      { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"North"}]}] },
       { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"1200"}]}] }
     ]},
     { "type": "tableRow", "content": [
-      { "type": "tableCell", "attrs": {"colspan": 2, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Total parcial"}]}] },
+      { "type": "tableCell", "attrs": {"colspan": 2, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Subtotal"}]}] },
       { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"1200"}]}] }
     ]}
   ]


### PR DESCRIPTION
# Editable table for embedded blocks

Adds a full inline table editor for table-type embeds, replacing the previous read-only/raw JSON view in the embed popup. Tables can now be edited directly inside the editor, with edits synced back to the document automatically.

## What's new

Editable table UI (ui/table/)
- TextKitEditableTable — a custom-Layout grid with per-cell BasicTextField editing, row/column selection gutters, "+" add handles, and a side action rail.
- Supported operations: edit cell text, add/remove rows & columns, merge and split cells, toggle header cells, delete selection, clear selection, and per-table undo/redo.
- Selection is line-based (tap the edges to select whole rows/columns); the acted-upon region is their bounding box.

## Grid model
- grid[r][c] stores the cell id occupying each slot; merged cells simply repeat their id across covered slots, so spans are always derived from the grid (Anchor) and can't drift out of sync. New supporting types: CellContent, GridChild, TableSnapshot, TextKitTableConstants.
- TableJsonCodec decodes ProseMirror table JSON into the dense grid model (falls back to a 3×3 starter on malformed input); TextKitEditableTableState serializes the live grid back to JSON.

## Auto-sync & history
- The table is the single source of truth: every mutation emits new JSON via onChange, so the host document stays in sync with no manual "sync" step. It never rebuilds from its own echo (lastSyncedRaw), so editing never loses focus, cursor, selection, or scroll.
- Consecutive edits to the same embed coalesce into one editor undo step (updateActiveEmbed with coalesceKey), instead of flooding history on every keystroke. The run breaks when the popup opens/closes.
- Document-level undo/redo of a table edit now refreshes the open popup (applyRestoredHistory / restoreEmbedPopup), and the open embed + drag position survive configuration changes (rotation).

## Embed popup improvements (TextKitEmbedPopup)
- Header doubles as a drag handle — the popup can be repositioned anywhere on screen (fixes the action rail / popup being unreachable in landscape where the anchor sits off-screen).
- Position is clamped fully on-screen; tables get a wider card (460dp) and content scrolls within a viewport-height cap.

## Misc
- EmbedInfo / TextEditorItem now expose the placeholder's visible label (e.g. "📊 Table"), fixing the title shown for editor-inserted embeds.
- Table UI strings moved into strings.xml.
- Added a TextKitTable sample composable; trimmed dead imports/scaffolding from desktopApp/main.kt.