### PR TITLE
fix: clamp cursor to 0 when converting the first list item to a paragraph

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
@@ -142,7 +142,17 @@ internal object ListItemTransaction {
         val flattenItems = PositionalListItemUtils.reorderItems(items = positionalListItems, coerceLevel = false)
         val transactions = flattenItems.createTransactions()
         val length = flattenItems.firstOrNull { it.index == currentIndex }.getNewDecoratorLength()
-        return Pair(transactions, TextRange(start = range.start - length, end = range.end - length))
+        // Clamp both endpoints at 0: for the first item `range.start` is at/near the document
+        // start, so subtracting the removed decorator width would otherwise underflow and make
+        // `TextRange` throw. For any non-first item `range.start - length` is already >= 0, so
+        // the coercion is a no-op there.
+        return Pair(
+            transactions,
+            TextRange(
+                start = (range.start - length).coerceAtLeast(0),
+                end = (range.end - length).coerceAtLeast(0)
+            )
+        )
     }
 
     private fun updateNestedListItems(

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListsAndDecoratorsTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListsAndDecoratorsTest.kt
@@ -67,6 +67,49 @@ class ListsAndDecoratorsTest {
     }
 
     @Test
+    fun converts_the_first_ordered_list_item_back_to_a_paragraph() {
+        val editor = editorFrom(SampleDocuments.ORDERED_LIST)
+        // First item text "one" starts at offset 0 — the case that used to underflow TextRange.
+        val one = editor.rangeOf("one")
+
+        assertTrue(
+            editor.toListItem(one, from = TextEditorListItem.NumberedList, to = TextEditorListItem.None)
+        )
+
+        // The first paragraph loses its decorator; the second list item is untouched.
+        val paragraphs = editor.getParagraphs()
+        assertFalse(paragraphs.first().children.any { it.decorator != null })
+        assertTrue(paragraphs.last().children.first().decorator is TextDecoratorModel.NumberDecoratorModel)
+    }
+
+    @Test
+    fun converts_the_first_bulleted_list_item_back_to_a_paragraph() {
+        // Start from a plain paragraph at offset 0, make it a bullet, then convert it back — the
+        // same first-item path, to show the fix is not specific to numbered lists.
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        editor.toListItem(TextRange(0, 5), TextEditorListItem.None, TextEditorListItem.BulletedList)
+
+        assertTrue(
+            editor.toListItem(TextRange(0, 5), TextEditorListItem.BulletedList, TextEditorListItem.None)
+        )
+
+        assertTrue(firstDecorator(editor) == null)
+    }
+
+    @Test
+    fun converts_the_first_task_list_item_back_to_a_paragraph_with_a_collapsed_caret() {
+        // A collapsed caret at offset 0 is the other way into the first-item path, and task lists
+        // have the widest decorator — so this underflowed the furthest before the fix.
+        val editor = editorFrom(SampleDocuments.TASK_LIST)
+
+        assertTrue(
+            editor.toListItem(TextRange(0, 0), from = TextEditorListItem.CheckList, to = TextEditorListItem.None)
+        )
+
+        assertTrue(firstDecorator(editor) == null)
+    }
+
+    @Test
     fun loaded_ordered_list_exposes_number_decorators_on_each_item() {
         val editor = editorFrom(SampleDocuments.ORDERED_LIST)
 

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/PotentialBugsTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/PotentialBugsTest.kt
@@ -1,12 +1,9 @@
 package com.jjrodcast.textkit
 
-import androidx.compose.ui.text.TextRange
-import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.utils.DocumentUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -17,46 +14,6 @@ import kotlin.test.assertTrue
  * corrected behavior.
  */
 class PotentialBugsTest {
-
-    /**
-     * BUG: Converting the **first** list item in the document (which starts at offset 0) back to a
-     * plain paragraph crashes.
-     *
-     * `ListItemTransaction.updateListItemToParagraph` computes the new cursor as
-     * `TextRange(range.start - length, range.end - length)` where `length` is the removed decorator
-     * width. For the first item `range.start` is at/near 0, so the subtraction underflows to a
-     * negative value and `TextRange` throws `IllegalArgumentException: start and end cannot be negative`.
-     *
-     * EXPECTED: the item should convert to a paragraph and the cursor should be clamped to `>= 0`,
-     * exactly like the (working) non-first-item case in
-     * [ListsAndDecoratorsTest.converts_a_non_first_list_item_back_to_a_paragraph].
-     */
-    @Test
-    fun converting_the_first_list_item_to_paragraph_currently_crashes() {
-        val editor = editorFrom(SampleDocuments.ORDERED_LIST)
-
-        assertFailsWith<IllegalArgumentException> {
-            editor.toListItem(
-                range = TextRange(0, 5),
-                from = TextEditorListItem.NumberedList,
-                to = TextEditorListItem.None
-            )
-        }
-    }
-
-    /**
-     * Same underflow, reached through a bulleted list, to show it is not specific to numbered lists.
-     */
-    @Test
-    fun converting_the_first_bulleted_item_to_paragraph_currently_crashes() {
-        // Start from a plain paragraph, turn it into a bullet, then try to turn it back.
-        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
-        editor.toListItem(TextRange(0, 5), TextEditorListItem.None, TextEditorListItem.BulletedList)
-
-        assertFailsWith<IllegalArgumentException> {
-            editor.toListItem(TextRange(0, 5), TextEditorListItem.BulletedList, TextEditorListItem.None)
-        }
-    }
 
     /**
      * BUG: Re-serializing [DocumentUtils.complexJsonV3] is not idempotent.


### PR DESCRIPTION
Closes #31.

## The bug

`ListItemTransaction.updateListItemToParagraph` shifted the cursor left by the
removed decorator width with no lower bound:

```kotlin
TextRange(start = range.start - length, end = range.end - length)
```

When the caret/selection starts inside the decorator region
(`range.start < decoratorLength`) the subtraction underflows and `TextRange`
throws `IllegalArgumentException: start and end cannot be negative`.

## Scope

Probing against the unfixed code showed this is wider than the two originally
reported paths — it also affects **task lists**, and triggers from a
**collapsed caret at offset 0**, not only from a selection:

| Scenario | Before |
|---|---|
| Ordered, caret collapsed at offset 0 | throws `[start: -3]` |
| Ordered, selection over the first item | throws `[start: -2, end: 3]` |
| Task list, caret collapsed at offset 0 | throws `[start: -4]` |
| Bulleted first item → paragraph | throws |

## The fix

Coerce both endpoints to `>= 0`. `getNewDecoratorLength()` is
`decorator?.length ?: 0`, so `length` is always non-negative — the clamp isn't
hiding a bad value; the underflow is inherent, since the cursor can't shift
left past offset 0. It's also a no-op for any non-first item, where
`range.start - length` is already `>= 0`.

`updateListItemToParagraph` is the only `TextRange` construction involving
subtraction in the `editor/` layer (checked all 31 `TextRange(` sites); the
sibling `updateParagraphToListItem` uses `range.start + offset`.

The clamp is semantically correct, not just crash-avoidance: for `[0, 5]` with
a 3-char decorator, the result `[0, 2]` is exactly the text that survives once
the decorator is removed.

## Tests

Replaced the two characterization tests in `PotentialBugsTest` that pinned the
crash with passing tests in `ListsAndDecoratorsTest`, alongside the existing
non-first-item test — plus a task-list + collapsed-caret case matching the real
trigger condition.

Each new test fails with the exact `IllegalArgumentException` when the fix is
reverted, so they're genuine regression guards. Full suite green (179 tests)
on `:shared:jvmTest`, rebased onto current `main`.
