### PR TITLE
feat: HTML export (toHtml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,25 @@ val plain: String = state.textFieldValue.text
 
 // The full structured document (ProseMirror-style JSON) — use this to persist:
 val json: String = state.toJson()
+
+// The same document as HTML — use this to export/share:
+val html: String = state.toHtml()
 ```
 
 `toJson()` is lossless: marks, lists, links and inline tokens (mentions, hashtags) are all preserved.
+
+`toHtml()` is **export only** — the editor is still loaded from, and persisted as, the JSON produced
+by `toJson()`. It emits semantic markup (`<strong>`, `<em>`, `<blockquote>`, …) rather than inline
+styles; the one exception is a text style (colour + font size), which has no semantic equivalent and
+becomes a `<span style="…">`. Task items keep a real, enabled `<input type="checkbox">` so the
+exported markup stays interactive, and inline tokens carry their identity on `data-type` / `data-id`:
+
+```html
+<p>Hi <span data-type="mention" data-id="42">@ada</span></p>
+<ul data-type="taskList">
+  <li data-type="taskItem" data-checked="true"><input type="checkbox" checked><p>done</p></li>
+</ul>
+```
 
 ## Inline styling
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -3,6 +3,7 @@ package com.jjrodcast.textkit.editor.core
 import androidx.compose.ui.text.TextRange
 import com.jjrodcast.textkit.editor.core.history.EditorHistoryManager
 import com.jjrodcast.textkit.editor.core.history.HistorySnapshot
+import com.jjrodcast.textkit.editor.core.export.HtmlSerializer
 import com.jjrodcast.textkit.editor.core.models.TextEditorModel
 import com.jjrodcast.textkit.editor.core.parser.EmbedTokenType
 import com.jjrodcast.textkit.editor.core.parser.Mark
@@ -89,6 +90,12 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
     val text get() = transaction.text
 
     fun toJson() = transaction.json
+
+    /**
+     * Exports the current document as semantic HTML. Export only — the editor is still loaded from,
+     * and persisted as, the JSON produced by [toJson].
+     */
+    fun toHtml(): String = HtmlSerializer().serialize(transaction.document)
 
     val isViewer get() = transaction.isViewer
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/DocumentSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/DocumentSerializer.kt
@@ -1,0 +1,19 @@
+package com.jjrodcast.textkit.editor.core.export
+
+import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
+
+/**
+ * Turns a parsed [TextEditorDocument] into a text representation.
+ *
+ * The document is already an AST — `TextEditorDocument` → `BaseParagraph` → `BaseText` are sealed
+ * hierarchies — so an implementation is a visitor over that tree: one exhaustive `when` per node
+ * level, no piece-table knowledge required.
+ *
+ * Keeping the export layer behind this interface means the output format is a strategy: [HtmlSerializer]
+ * is the first implementation, and further formats can be added without touching call sites.
+ */
+internal interface DocumentSerializer {
+
+    /** Serializes [document]; returns an empty string for an empty document. */
+    fun serialize(document: TextEditorDocument): String
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/HtmlSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/HtmlSerializer.kt
@@ -1,0 +1,186 @@
+package com.jjrodcast.textkit.editor.core.export
+
+import com.jjrodcast.textkit.editor.core.parser.BaseParagraph
+import com.jjrodcast.textkit.editor.core.parser.BaseText
+import com.jjrodcast.textkit.editor.core.parser.Blockquote
+import com.jjrodcast.textkit.editor.core.parser.BoldMark
+import com.jjrodcast.textkit.editor.core.parser.BulletedList
+import com.jjrodcast.textkit.editor.core.parser.EmbedBlock
+import com.jjrodcast.textkit.editor.core.parser.HardBreak
+import com.jjrodcast.textkit.editor.core.parser.Hashtag
+import com.jjrodcast.textkit.editor.core.parser.HashtagType
+import com.jjrodcast.textkit.editor.core.parser.Heading
+import com.jjrodcast.textkit.editor.core.parser.HeadingLevels
+import com.jjrodcast.textkit.editor.core.parser.HighlightMark
+import com.jjrodcast.textkit.editor.core.parser.ItalicMark
+import com.jjrodcast.textkit.editor.core.parser.LinkMark
+import com.jjrodcast.textkit.editor.core.parser.ListItem
+import com.jjrodcast.textkit.editor.core.parser.Mark
+import com.jjrodcast.textkit.editor.core.parser.Mention
+import com.jjrodcast.textkit.editor.core.parser.MentionType
+import com.jjrodcast.textkit.editor.core.parser.None
+import com.jjrodcast.textkit.editor.core.parser.OrderedList
+import com.jjrodcast.textkit.editor.core.parser.Paragraph
+import com.jjrodcast.textkit.editor.core.parser.ParagraphNone
+import com.jjrodcast.textkit.editor.core.parser.StrikeMark
+import com.jjrodcast.textkit.editor.core.parser.TaskList
+import com.jjrodcast.textkit.editor.core.parser.TaskListItem
+import com.jjrodcast.textkit.editor.core.parser.Text
+import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
+import com.jjrodcast.textkit.editor.core.parser.TextStyleAttrs.Companion.UNSET_FONT_SIZE
+import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
+import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
+
+/**
+ * Exports a [TextEditorDocument] as semantic HTML.
+ *
+ * Semantic tags are used over inline styles (`<strong>` rather than `<span style="font-weight:bold">`);
+ * the only inline style emitted is for `textStyle`, which carries a colour and font size that have no
+ * semantic equivalent.
+ *
+ * Block nodes the editor keeps as opaque embeds (tables, images, …) are not emitted yet — see
+ * [EmbedBlock]. Inline tokens (mentions, hashtags) are emitted as their visible label text; carrying
+ * their identity in `data-*` attributes is deferred to the same follow-up.
+ */
+internal class HtmlSerializer : DocumentSerializer {
+
+    override fun serialize(document: TextEditorDocument): String =
+        document.content.joinToString(separator = "") { block(it) }
+
+    // ── Blocks ───────────────────────────────────────────────────────────────
+
+    private fun block(paragraph: BaseParagraph): String = when (paragraph) {
+        is Paragraph -> tag("p", inline(paragraph.content))
+
+        is Heading -> {
+            val level = paragraph.attrs.level.coerceIn(HeadingLevels.H1, HeadingLevels.H6)
+            tag("h$level", inline(paragraph.content))
+        }
+
+        is BulletedList -> tag("ul", paragraph.content.joinToString(separator = "") { listItem(it) })
+
+        is OrderedList -> {
+            // `start` is only meaningful when the list does not begin at 1.
+            val start = paragraph.attrs.start
+            val attributes = if (start != DEFAULT_LIST_START) " start=\"$start\"" else ""
+            tag("ol", paragraph.content.joinToString(separator = "") { listItem(it) }, attributes)
+        }
+
+        is TaskList -> tag(
+            name = "ul",
+            body = paragraph.content.joinToString(separator = "") { taskItem(it) },
+            attributes = " data-type=\"$TASK_LIST_TYPE\"",
+        )
+
+        is Blockquote -> tag("blockquote", paragraph.content.joinToString(separator = "") { block(it) })
+
+        // Opaque embedded blocks (table, image, …) are handled in a follow-up.
+        is EmbedBlock -> ""
+
+        is ParagraphNone -> ""
+    }
+
+    /** A `<li>` of an ordered or bulleted list. Only [ListItem] carries block content. */
+    private fun listItem(item: BaseText): String = when (item) {
+        is ListItem -> tag("li", item.content.joinToString(separator = "") { block(it) })
+        // A list whose children are not list items is malformed; render the inline content directly
+        // rather than dropping it.
+        else -> tag("li", inline(listOf(item)))
+    }
+
+    /**
+     * A task `<li>`. The checkbox is a real, enabled `<input>` so the exported HTML stays
+     * interactive; `data-checked` mirrors the state for consumers that re-import the markup.
+     */
+    private fun taskItem(item: TaskListItem): String {
+        val checked = item.attrs.checked
+        val input = "<input type=\"checkbox\"${if (checked) " checked" else ""}>"
+        return tag(
+            name = "li",
+            body = input + item.content.joinToString(separator = "") { block(it) },
+            attributes = " data-type=\"$TASK_ITEM_TYPE\" data-checked=\"$checked\"",
+        )
+    }
+
+    // ── Inline ───────────────────────────────────────────────────────────────
+
+    private fun inline(content: List<BaseText>): String =
+        content.joinToString(separator = "") { text(it) }
+
+    private fun text(node: BaseText): String = when (node) {
+        is Text -> wrapInMarks(escapeText(node.text), node.marks)
+        is HardBreak -> "<br>"
+        // Tokens render as the label the user sees; identity attributes come in the follow-up.
+        is Mention -> wrapInMarks(
+            escapeText(MentionType.DEFAULT_MENTION_CHAR + node.attrs.label.orEmpty()),
+            node.marks,
+        )
+
+        is Hashtag -> wrapInMarks(
+            escapeText(HashtagType.DEFAULT_HASHTAG_CHAR + node.attrs.label.orEmpty()),
+            node.marks,
+        )
+        // List items are emitted by the list branches above, never as free inline content.
+        is ListItem, is TaskListItem -> ""
+    }
+
+    // ── Marks ────────────────────────────────────────────────────────────────
+
+    /**
+     * Wraps [body] in one element per mark. Marks are applied in a fixed order — [markPriority] —
+     * so the nesting is deterministic regardless of the iteration order of the underlying `Set`.
+     */
+    private fun wrapInMarks(body: String, marks: Set<Mark>): String =
+        marks.sortedBy(::markPriority).foldRight(body) { mark, acc -> wrapInMark(acc, mark) }
+
+    private fun wrapInMark(body: String, mark: Mark): String = when (mark) {
+        is LinkMark -> tag("a", body, " href=\"${escapeAttribute(mark.attrs.href)}\"")
+        is TextStyleMark -> styleOf(mark)?.let { tag("span", body, " style=\"$it\"") } ?: body
+        is BoldMark -> tag("strong", body)
+        is ItalicMark -> tag("em", body)
+        is UnderlineMark -> tag("u", body)
+        is StrikeMark -> tag("s", body)
+        is HighlightMark -> tag("mark", body)
+        is None -> body
+    }
+
+    /** Outermost first. Keeps output stable across runs and platforms. */
+    private fun markPriority(mark: Mark): Int = when (mark) {
+        is LinkMark -> 0
+        is TextStyleMark -> 1
+        is BoldMark -> 2
+        is ItalicMark -> 3
+        is UnderlineMark -> 4
+        is StrikeMark -> 5
+        is HighlightMark -> 6
+        is None -> 7
+    }
+
+    /** The CSS for a `textStyle` mark, or `null` when it carries neither a colour nor a size. */
+    private fun styleOf(mark: TextStyleMark): String? {
+        val declarations = buildList {
+            mark.attrs.color?.takeIf { it.isNotBlank() }?.let { add("color:${escapeAttribute(it)}") }
+            mark.attrs.fontSize.takeIf { it != UNSET_FONT_SIZE }?.let { add("font-size:${it}px") }
+        }
+        return declarations.takeIf { it.isNotEmpty() }?.joinToString(separator = ";")
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private fun tag(name: String, body: String, attributes: String = "") =
+        "<$name$attributes>$body</$name>"
+
+    /** Escapes text content. `&` must be replaced first so the other entities are not double-escaped. */
+    private fun escapeText(value: String): String = value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+
+    private fun escapeAttribute(value: String): String = escapeText(value).replace("\"", "&quot;")
+
+    private companion object {
+        const val DEFAULT_LIST_START = 1
+        const val TASK_LIST_TYPE = "taskList"
+        const val TASK_ITEM_TYPE = "taskItem"
+    }
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/HtmlSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/HtmlSerializer.kt
@@ -51,6 +51,11 @@ import kotlinx.serialization.json.jsonPrimitive
  * Opaque embedded blocks are rendered from the verbatim JSON the editor keeps in [EmbedBlock.raw]:
  * tables become real `<table>` markup and images `<img>`. Inline tokens (mentions, hashtags) keep
  * their identity in `data-*` attributes alongside the visible label.
+ *
+ * The document is user-supplied (loaded from JSON), so values that end up in an attribute the browser
+ * *acts on* — a link `href`, a `textStyle` colour, an `<ol start>` — are validated, not just escaped:
+ * only safe URL schemes ([SAFE_SCHEMES]) keep their link, only a valid hex colour is emitted, and
+ * `start` is clamped. This keeps the exported markup safe to inject into a DOM/WebView.
  */
 internal class HtmlSerializer : DocumentSerializer {
 
@@ -60,29 +65,30 @@ internal class HtmlSerializer : DocumentSerializer {
     // ── Blocks ───────────────────────────────────────────────────────────────
 
     private fun block(paragraph: BaseParagraph): String = when (paragraph) {
-        is Paragraph -> tag("p", inline(paragraph.content))
+        is Paragraph -> tag(Tag.Paragraph, inline(paragraph.content))
 
         is Heading -> {
             val level = paragraph.attrs.level.coerceIn(HeadingLevels.H1, HeadingLevels.H6)
-            tag("h$level", inline(paragraph.content))
+            tag("${Tag.Heading}$level", inline(paragraph.content))
         }
 
-        is BulletedList -> tag("ul", paragraph.content.joinToString(separator = "") { listItem(it) })
+        is BulletedList -> tag(Tag.UnorderedList, paragraph.content.joinToString(separator = "") { listItem(it) })
 
         is OrderedList -> {
-            // `start` is only meaningful when the list does not begin at 1.
-            val start = paragraph.attrs.start
-            val attributes = if (start != DEFAULT_LIST_START) " start=\"$start\"" else ""
-            tag("ol", paragraph.content.joinToString(separator = "") { listItem(it) }, attributes)
+            // A list start must be a positive integer; clamp bad input. `start` is only worth
+            // emitting when the list does not begin at 1.
+            val start = paragraph.attrs.start.coerceAtLeast(MIN_LIST_START)
+            val attributes = if (start != DEFAULT_LIST_START) attr(Attr.Start, start.toString()) else ""
+            tag(Tag.OrderedList, paragraph.content.joinToString(separator = "") { listItem(it) }, attributes)
         }
 
         is TaskList -> tag(
-            name = "ul",
+            name = Tag.UnorderedList,
             body = paragraph.content.joinToString(separator = "") { taskItem(it) },
-            attributes = " data-type=\"$TASK_LIST_TYPE\"",
+            attributes = attr(Attr.DataType, TASK_LIST_TYPE),
         )
 
-        is Blockquote -> tag("blockquote", paragraph.content.joinToString(separator = "") { block(it) })
+        is Blockquote -> tag(Tag.Blockquote, paragraph.content.joinToString(separator = "") { block(it) })
 
         is EmbedBlock -> embed(paragraph)
 
@@ -100,28 +106,28 @@ internal class HtmlSerializer : DocumentSerializer {
         EmbedTypes.Table -> table(block.raw)
         EmbedTypes.Image -> image(block.raw)
         else -> tag(
-            name = "div",
+            name = Tag.Div,
             body = "",
-            attributes = " data-type=\"${escapeAttribute(block.embedType)}\"" +
-                " data-id=\"${escapeAttribute(block.id)}\"",
+            attributes = attr(Attr.DataType, escapeAttribute(block.embedType)) +
+                attr(Attr.DataId, escapeAttribute(block.id)),
         )
     }
 
     private fun table(raw: JsonElement): String {
         val rows = raw.childNodes().joinToString(separator = "") { row ->
-            tag("tr", row.childNodes().joinToString(separator = "") { cell(it) })
+            tag(Tag.TableRow, row.childNodes().joinToString(separator = "") { cell(it) })
         }
-        return tag("table", rows)
+        return tag(Tag.Table, rows)
     }
 
     private fun cell(cell: JsonElement): String {
-        val name = if (cell.nodeType() == TABLE_HEADER_TYPE) "th" else "td"
+        val name = if (cell.nodeType() == TABLE_HEADER_TYPE) Tag.TableHeaderCell else Tag.TableCell
         val attrs = cell.jsonObject["attrs"]?.jsonObject
         // colspan / rowspan default to 1; only emit them when they actually span.
-        val attributes = listOf("colspan", "rowspan")
+        val attributes = listOf(Attr.ColSpan, Attr.RowSpan)
             .mapNotNull { key ->
                 val span = attrs?.get(key)?.jsonPrimitive?.intOrNull ?: DEFAULT_SPAN
-                if (span != DEFAULT_SPAN) " $key=\"$span\"" else null
+                if (span != DEFAULT_SPAN) attr(key, span.toString()) else null
             }
             .joinToString(separator = "")
         return tag(name, cell.blockContent().joinToString(separator = "") { block(it) }, attributes)
@@ -129,9 +135,9 @@ internal class HtmlSerializer : DocumentSerializer {
 
     private fun image(raw: JsonElement): String {
         val attrs = raw.jsonObject["attrs"]?.jsonObject
-        val src = attrs?.get("src")?.jsonPrimitive?.contentOrNull.orEmpty()
-        val alt = attrs?.get("alt")?.jsonPrimitive?.contentOrNull.orEmpty()
-        return "<img src=\"${escapeAttribute(src)}\" alt=\"${escapeAttribute(alt)}\">"
+        val src = attrs?.get(Attr.Src)?.jsonPrimitive?.contentOrNull.orEmpty()
+        val alt = attrs?.get(Attr.Alt)?.jsonPrimitive?.contentOrNull.orEmpty()
+        return "<${Tag.Image}${attr(Attr.Src, escapeAttribute(src))}${attr(Attr.Alt, escapeAttribute(alt))}>"
     }
 
     /** The `"type"` of a raw embed node, or an empty string when absent. */
@@ -156,10 +162,10 @@ internal class HtmlSerializer : DocumentSerializer {
 
     /** A `<li>` of an ordered or bulleted list. Only [ListItem] carries block content. */
     private fun listItem(item: BaseText): String = when (item) {
-        is ListItem -> tag("li", item.content.joinToString(separator = "") { block(it) })
+        is ListItem -> tag(Tag.ListItem, item.content.joinToString(separator = "") { block(it) })
         // A list whose children are not list items is malformed; render the inline content directly
         // rather than dropping it.
-        else -> tag("li", inline(listOf(item)))
+        else -> tag(Tag.ListItem, inline(listOf(item)))
     }
 
     /**
@@ -168,11 +174,11 @@ internal class HtmlSerializer : DocumentSerializer {
      */
     private fun taskItem(item: TaskListItem): String {
         val checked = item.attrs.checked
-        val input = "<input type=\"checkbox\"${if (checked) " checked" else ""}>"
+        val input = "<${Tag.Checkbox}${attr(Attr.Type, CHECKBOX_INPUT_TYPE)}${if (checked) " ${Attr.Checked}" else ""}>"
         return tag(
-            name = "li",
+            name = Tag.ListItem,
             body = input + item.content.joinToString(separator = "") { block(it) },
-            attributes = " data-type=\"$TASK_ITEM_TYPE\" data-checked=\"$checked\"",
+            attributes = attr(Attr.DataType, TASK_ITEM_TYPE) + attr(Attr.DataChecked, checked.toString()),
         )
     }
 
@@ -183,7 +189,7 @@ internal class HtmlSerializer : DocumentSerializer {
 
     private fun text(node: BaseText): String = when (node) {
         is Text -> wrapInMarks(escapeText(node.text), node.marks)
-        is HardBreak -> "<br>"
+        is HardBreak -> "<${Tag.LineBreak}>"
         is Mention -> token(node, MentionType.DEFAULT_MENTION_CHAR)
         is Hashtag -> token(node, HashtagType.DEFAULT_HASHTAG_CHAR)
         // List items are emitted by the list branches above, never as free inline content.
@@ -197,10 +203,10 @@ internal class HtmlSerializer : DocumentSerializer {
     private fun token(node: InlineToken, triggerChar: Char): String {
         val label = escapeText(triggerChar + node.attrs.label.orEmpty())
         val body = tag(
-            name = "span",
+            name = Tag.Span,
             body = label,
-            attributes = " data-type=\"${escapeAttribute(node.type)}\"" +
-                " data-id=\"${escapeAttribute(node.attrs.id)}\"",
+            attributes = attr(Attr.DataType, escapeAttribute(node.type)) +
+                attr(Attr.DataId, escapeAttribute(node.attrs.id)),
         )
         return wrapInMarks(body, node.marks)
     }
@@ -215,13 +221,18 @@ internal class HtmlSerializer : DocumentSerializer {
         marks.sortedBy(::markPriority).foldRight(body) { mark, acc -> wrapInMark(acc, mark) }
 
     private fun wrapInMark(body: String, mark: Mark): String = when (mark) {
-        is LinkMark -> tag("a", body, " href=\"${escapeAttribute(mark.attrs.href)}\"")
-        is TextStyleMark -> styleOf(mark)?.let { tag("span", body, " style=\"$it\"") } ?: body
-        is BoldMark -> tag("strong", body)
-        is ItalicMark -> tag("em", body)
-        is UnderlineMark -> tag("u", body)
-        is StrikeMark -> tag("s", body)
-        is HighlightMark -> tag("mark", body)
+        // An unsafe or non-http(s)/mailto/tel scheme drops the link but keeps the text, so a
+        // `javascript:`/`data:` href can never reach a consumer's DOM.
+        is LinkMark -> safeHref(mark.attrs.href)
+            ?.let { tag(Tag.Anchor, body, attr(Attr.Href, escapeAttribute(it))) }
+            ?: body
+
+        is TextStyleMark -> styleOf(mark)?.let { tag(Tag.Span, body, attr(Attr.Style, it)) } ?: body
+        is BoldMark -> tag(Tag.Bold, body)
+        is ItalicMark -> tag(Tag.Italic, body)
+        is UnderlineMark -> tag(Tag.Underline, body)
+        is StrikeMark -> tag(Tag.Strike, body)
+        is HighlightMark -> tag(Tag.Highlight, body)
         is None -> body
     }
 
@@ -237,19 +248,57 @@ internal class HtmlSerializer : DocumentSerializer {
         is None -> 7
     }
 
-    /** The CSS for a `textStyle` mark, or `null` when it carries neither a colour nor a size. */
+    /**
+     * The CSS for a `textStyle` mark, or `null` when nothing valid is left to emit. The colour is
+     * only emitted when it is a valid hex value ([HEX_COLOR]) and the font size only when it is a
+     * sane positive number — otherwise that declaration is dropped, so nothing user-supplied can
+     * inject extra CSS through the `style` attribute.
+     */
     private fun styleOf(mark: TextStyleMark): String? {
         val declarations = buildList {
-            mark.attrs.color?.takeIf { it.isNotBlank() }?.let { add("color:${escapeAttribute(it)}") }
-            mark.attrs.fontSize.takeIf { it != UNSET_FONT_SIZE }?.let { add("font-size:${it}px") }
+            mark.attrs.color?.let(::safeColor)?.let { add("${Css.Color}:$it") }
+            mark.attrs.fontSize
+                .takeIf { it != UNSET_FONT_SIZE && it in MIN_FONT_SIZE..MAX_FONT_SIZE }
+                ?.let { add("${Css.FontSize}:${it}px") }
         }
         return declarations.takeIf { it.isNotEmpty() }?.joinToString(separator = ";")
     }
+
+    // ── Sanitisation ─────────────────────────────────────────────────────────
+
+    /** Returns [href] when its scheme is safe (or it is a relative URL), otherwise `null`. */
+    private fun safeHref(href: String): String? {
+        val trimmed = href.trim()
+        if (trimmed.isEmpty()) return null
+        val scheme = schemeOf(trimmed) ?: return trimmed // no scheme → relative URL, safe
+        return trimmed.takeIf { scheme in SAFE_SCHEMES }
+    }
+
+    /**
+     * The lower-cased URL scheme of [url] (e.g. `"https"`), or `null` when it has none. A scheme is
+     * the run of letters/digits/`+`/`.`/`-` before the first `:`, and only when no `/`, `?` or `#`
+     * appears first (those mean the `:` belongs to a path/query/fragment, i.e. a relative URL).
+     */
+    private fun schemeOf(url: String): String? {
+        val colon = url.indexOf(':')
+        if (colon <= 0) return null
+        val prefix = url.substring(0, colon)
+        if (prefix.any { it == '/' || it == '?' || it == '#' }) return null
+        if (!prefix.first().isLetter()) return null
+        if (!prefix.all { it.isLetterOrDigit() || it == '+' || it == '.' || it == '-' }) return null
+        return prefix.lowercase()
+    }
+
+    /** Returns [color] when it is a valid `#rgb` / `#rgba` / `#rrggbb` / `#rrggbbaa` hex value. */
+    private fun safeColor(color: String): String? = color.trim().takeIf { HEX_COLOR.matches(it) }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private fun tag(name: String, body: String, attributes: String = "") =
         "<$name$attributes>$body</$name>"
+
+    /** Renders one attribute, e.g. `attr("href", "x")` → ` href="x"`. Escape user values first. */
+    private fun attr(name: String, value: String) = " $name=\"$value\""
 
     /** Escapes text content. `&` must be replaced first so the other entities are not double-escaped. */
     private fun escapeText(value: String): String = value
@@ -259,11 +308,68 @@ internal class HtmlSerializer : DocumentSerializer {
 
     private fun escapeAttribute(value: String): String = escapeText(value).replace("\"", "&quot;")
 
+    /** HTML element names. */
+    private object Tag {
+        const val Paragraph = "p"
+        const val Heading = "h" // suffixed with the level, e.g. "h1"
+        const val UnorderedList = "ul"
+        const val OrderedList = "ol"
+        const val ListItem = "li"
+        const val Blockquote = "blockquote"
+        const val LineBreak = "br"
+        const val Table = "table"
+        const val TableRow = "tr"
+        const val TableHeaderCell = "th"
+        const val TableCell = "td"
+        const val Image = "img"
+        const val Div = "div"
+        const val Span = "span"
+        const val Anchor = "a"
+        const val Bold = "strong"
+        const val Italic = "em"
+        const val Underline = "u"
+        const val Strike = "s"
+        const val Highlight = "mark"
+        const val Checkbox = "input"
+    }
+
+    /** HTML attribute names. */
+    private object Attr {
+        const val Start = "start"
+        const val DataType = "data-type"
+        const val DataId = "data-id"
+        const val DataChecked = "data-checked"
+        const val ColSpan = "colspan"
+        const val RowSpan = "rowspan"
+        const val Href = "href"
+        const val Style = "style"
+        const val Src = "src"
+        const val Alt = "alt"
+        const val Type = "type"
+        const val Checked = "checked"
+    }
+
+    /** CSS property names used in the `style` attribute. */
+    private object Css {
+        const val Color = "color"
+        const val FontSize = "font-size"
+    }
+
     private companion object {
         const val DEFAULT_LIST_START = 1
+        const val MIN_LIST_START = 1
         const val TASK_LIST_TYPE = "taskList"
         const val TASK_ITEM_TYPE = "taskItem"
         const val TABLE_HEADER_TYPE = "tableHeader"
+        const val CHECKBOX_INPUT_TYPE = "checkbox"
         const val DEFAULT_SPAN = 1
+        const val MIN_FONT_SIZE = 1
+        const val MAX_FONT_SIZE = 512
+
+        /** URL schemes safe to keep on an exported link; anything else drops the link. */
+        val SAFE_SCHEMES = setOf("http", "https", "mailto", "tel")
+
+        /** `#rgb`, `#rgba`, `#rrggbb` or `#rrggbbaa`. */
+        val HEX_COLOR = Regex("^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$")
     }
 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/HtmlSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/HtmlSerializer.kt
@@ -6,12 +6,14 @@ import com.jjrodcast.textkit.editor.core.parser.Blockquote
 import com.jjrodcast.textkit.editor.core.parser.BoldMark
 import com.jjrodcast.textkit.editor.core.parser.BulletedList
 import com.jjrodcast.textkit.editor.core.parser.EmbedBlock
+import com.jjrodcast.textkit.editor.core.parser.EmbedTypes
 import com.jjrodcast.textkit.editor.core.parser.HardBreak
 import com.jjrodcast.textkit.editor.core.parser.Hashtag
 import com.jjrodcast.textkit.editor.core.parser.HashtagType
 import com.jjrodcast.textkit.editor.core.parser.Heading
 import com.jjrodcast.textkit.editor.core.parser.HeadingLevels
 import com.jjrodcast.textkit.editor.core.parser.HighlightMark
+import com.jjrodcast.textkit.editor.core.parser.InlineToken
 import com.jjrodcast.textkit.editor.core.parser.ItalicMark
 import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.core.parser.ListItem
@@ -23,6 +25,7 @@ import com.jjrodcast.textkit.editor.core.parser.OrderedList
 import com.jjrodcast.textkit.editor.core.parser.Paragraph
 import com.jjrodcast.textkit.editor.core.parser.ParagraphNone
 import com.jjrodcast.textkit.editor.core.parser.StrikeMark
+import com.jjrodcast.textkit.editor.core.parser.TEXT_EDITOR_JSON
 import com.jjrodcast.textkit.editor.core.parser.TaskList
 import com.jjrodcast.textkit.editor.core.parser.TaskListItem
 import com.jjrodcast.textkit.editor.core.parser.Text
@@ -30,6 +33,13 @@ import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
 import com.jjrodcast.textkit.editor.core.parser.TextStyleAttrs.Companion.UNSET_FONT_SIZE
 import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
 import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Exports a [TextEditorDocument] as semantic HTML.
@@ -38,9 +48,9 @@ import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
  * the only inline style emitted is for `textStyle`, which carries a colour and font size that have no
  * semantic equivalent.
  *
- * Block nodes the editor keeps as opaque embeds (tables, images, …) are not emitted yet — see
- * [EmbedBlock]. Inline tokens (mentions, hashtags) are emitted as their visible label text; carrying
- * their identity in `data-*` attributes is deferred to the same follow-up.
+ * Opaque embedded blocks are rendered from the verbatim JSON the editor keeps in [EmbedBlock.raw]:
+ * tables become real `<table>` markup and images `<img>`. Inline tokens (mentions, hashtags) keep
+ * their identity in `data-*` attributes alongside the visible label.
  */
 internal class HtmlSerializer : DocumentSerializer {
 
@@ -74,10 +84,74 @@ internal class HtmlSerializer : DocumentSerializer {
 
         is Blockquote -> tag("blockquote", paragraph.content.joinToString(separator = "") { block(it) })
 
-        // Opaque embedded blocks (table, image, …) are handled in a follow-up.
-        is EmbedBlock -> ""
+        is EmbedBlock -> embed(paragraph)
 
         is ParagraphNone -> ""
+    }
+
+    // ── Embedded blocks ──────────────────────────────────────────────────────
+
+    /**
+     * An opaque embedded block. The editor keeps the original JSON subtree verbatim in
+     * [EmbedBlock.raw], so the known types are rendered from it. An unrecognised type is emitted as
+     * an empty element carrying its type and id rather than being dropped silently.
+     */
+    private fun embed(block: EmbedBlock): String = when (block.embedType) {
+        EmbedTypes.Table -> table(block.raw)
+        EmbedTypes.Image -> image(block.raw)
+        else -> tag(
+            name = "div",
+            body = "",
+            attributes = " data-type=\"${escapeAttribute(block.embedType)}\"" +
+                " data-id=\"${escapeAttribute(block.id)}\"",
+        )
+    }
+
+    private fun table(raw: JsonElement): String {
+        val rows = raw.childNodes().joinToString(separator = "") { row ->
+            tag("tr", row.childNodes().joinToString(separator = "") { cell(it) })
+        }
+        return tag("table", rows)
+    }
+
+    private fun cell(cell: JsonElement): String {
+        val name = if (cell.nodeType() == TABLE_HEADER_TYPE) "th" else "td"
+        val attrs = cell.jsonObject["attrs"]?.jsonObject
+        // colspan / rowspan default to 1; only emit them when they actually span.
+        val attributes = listOf("colspan", "rowspan")
+            .mapNotNull { key ->
+                val span = attrs?.get(key)?.jsonPrimitive?.intOrNull ?: DEFAULT_SPAN
+                if (span != DEFAULT_SPAN) " $key=\"$span\"" else null
+            }
+            .joinToString(separator = "")
+        return tag(name, cell.blockContent().joinToString(separator = "") { block(it) }, attributes)
+    }
+
+    private fun image(raw: JsonElement): String {
+        val attrs = raw.jsonObject["attrs"]?.jsonObject
+        val src = attrs?.get("src")?.jsonPrimitive?.contentOrNull.orEmpty()
+        val alt = attrs?.get("alt")?.jsonPrimitive?.contentOrNull.orEmpty()
+        return "<img src=\"${escapeAttribute(src)}\" alt=\"${escapeAttribute(alt)}\">"
+    }
+
+    /** The `"type"` of a raw embed node, or an empty string when absent. */
+    private fun JsonElement.nodeType(): String =
+        jsonObject["type"]?.jsonPrimitive?.contentOrNull.orEmpty()
+
+    /** The `"content"` of a raw embed node as a list of raw children. */
+    private fun JsonElement.childNodes(): List<JsonElement> =
+        (jsonObject["content"] as? JsonArray).orEmpty()
+
+    /**
+     * The `"content"` of a raw node decoded as document blocks, so a table cell's paragraphs go
+     * through the same [block] rendering as the rest of the document. Malformed content yields no
+     * blocks rather than failing the whole export.
+     */
+    private fun JsonElement.blockContent(): List<BaseParagraph> {
+        val content = jsonObject["content"] ?: return emptyList()
+        return runCatching {
+            TEXT_EDITOR_JSON.decodeFromJsonElement(ListSerializer(BaseParagraph.serializer()), content)
+        }.getOrDefault(emptyList())
     }
 
     /** A `<li>` of an ordered or bulleted list. Only [ListItem] carries block content. */
@@ -110,18 +184,25 @@ internal class HtmlSerializer : DocumentSerializer {
     private fun text(node: BaseText): String = when (node) {
         is Text -> wrapInMarks(escapeText(node.text), node.marks)
         is HardBreak -> "<br>"
-        // Tokens render as the label the user sees; identity attributes come in the follow-up.
-        is Mention -> wrapInMarks(
-            escapeText(MentionType.DEFAULT_MENTION_CHAR + node.attrs.label.orEmpty()),
-            node.marks,
-        )
-
-        is Hashtag -> wrapInMarks(
-            escapeText(HashtagType.DEFAULT_HASHTAG_CHAR + node.attrs.label.orEmpty()),
-            node.marks,
-        )
+        is Mention -> token(node, MentionType.DEFAULT_MENTION_CHAR)
+        is Hashtag -> token(node, HashtagType.DEFAULT_HASHTAG_CHAR)
         // List items are emitted by the list branches above, never as free inline content.
         is ListItem, is TaskListItem -> ""
+    }
+
+    /**
+     * An atomic inline token (mention, hashtag). The visible text is `<triggerChar><label>`; the
+     * node type and id ride on `data-*` attributes so the token's identity survives the export.
+     */
+    private fun token(node: InlineToken, triggerChar: Char): String {
+        val label = escapeText(triggerChar + node.attrs.label.orEmpty())
+        val body = tag(
+            name = "span",
+            body = label,
+            attributes = " data-type=\"${escapeAttribute(node.type)}\"" +
+                " data-id=\"${escapeAttribute(node.attrs.id)}\"",
+        )
+        return wrapInMarks(body, node.marks)
     }
 
     // ── Marks ────────────────────────────────────────────────────────────────
@@ -182,5 +263,7 @@ internal class HtmlSerializer : DocumentSerializer {
         const val DEFAULT_LIST_START = 1
         const val TASK_LIST_TYPE = "taskList"
         const val TASK_ITEM_TYPE = "taskItem"
+        const val TABLE_HEADER_TYPE = "tableHeader"
+        const val DEFAULT_SPAN = 1
     }
 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
@@ -38,10 +38,17 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
 
     override val json: String
         get() {
-            val document = PieceTableConverter.getNewDocument(pieceTable)
-            return if (document.content.isEmpty()) EMPTY_JSON
-            else TEXT_EDITOR_JSON.encodeToString(TextEditorDocument.serializer(), document)
+            val current = document
+            return if (current.content.isEmpty()) EMPTY_JSON
+            else TEXT_EDITOR_JSON.encodeToString(TextEditorDocument.serializer(), current)
         }
+
+    /**
+     * The current document as a parsed AST. Exposed so export formats other than JSON (see
+     * `editor.core.export.DocumentSerializer`) can walk the same tree the JSON encoder uses.
+     */
+    internal val document: TextEditorDocument
+        get() = PieceTableConverter.getNewDocument(pieceTable)
 
     override fun loadWith(
         initialJson: String,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -380,6 +380,12 @@ class TextKitState(
     fun toJson() = manager.toJson()
 
     /**
+     * Exports the current document as semantic HTML. Export only: the editor is still loaded from,
+     * and persisted as, the JSON produced by [toJson].
+     */
+    fun toHtml() = manager.toHtml()
+
+    /**
      * Receives the editor's latest [TextLayoutResult]; wire it to the text field's `onTextLayout`.
      * It backs coordinate-based lookups such as link hit-testing and [linkBoundingBox], so those
      * return nothing until the first layout pass has run.

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
@@ -253,9 +253,13 @@ class HtmlSerializerTest {
     // ── Inline tokens ────────────────────────────────────────────────────────
 
     @Test
-    fun exports_tokens_as_their_visible_label() {
+    fun exports_tokens_with_their_label_and_identity() {
         assertEquals(
-            "<p>@ada #kotlin</p>",
+            "<p>" +
+                "<span data-type=\"mention\" data-id=\"1\">@ada</span>" +
+                " " +
+                "<span data-type=\"hashtag\" data-id=\"2\">#kotlin</span>" +
+                "</p>",
             html(
                 Paragraph(
                     listOf(
@@ -265,6 +269,110 @@ class HtmlSerializerTest {
                     ),
                 ),
             ),
+        )
+    }
+
+    @Test
+    fun applies_marks_around_a_token() {
+        assertEquals(
+            "<p><strong><span data-type=\"mention\" data-id=\"7\">@ada</span></strong></p>",
+            html(
+                Paragraph(
+                    listOf(Mention(TokenAttrs(id = "7", label = "ada"), marks = setOf(BoldMark()))),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun escapes_a_token_label_and_id() {
+        assertEquals(
+            "<p><span data-type=\"mention\" data-id=\"a&quot;b\">@a&lt;b</span></p>",
+            html(Paragraph(listOf(Mention(TokenAttrs(id = "a\"b", label = "a<b"))))),
+        )
+    }
+
+    // ── Embedded blocks ──────────────────────────────────────────────────────
+
+    @Test
+    fun exports_a_table_with_header_and_body_cells() {
+        val json = """
+            {"type":"doc","content":[
+              {"type":"table","content":[
+                {"type":"tableRow","content":[
+                  {"type":"tableHeader","attrs":{"colspan":1,"rowspan":1,"colwidth":null},
+                   "content":[{"type":"paragraph","content":[{"type":"text","text":"Name"}]}]}
+                ]},
+                {"type":"tableRow","content":[
+                  {"type":"tableCell","attrs":{"colspan":1,"rowspan":1,"colwidth":null},
+                   "content":[{"type":"paragraph","content":[{"type":"text","text":"Juan"}]}]}
+                ]}
+              ]}
+            ]}
+        """
+
+        assertEquals(
+            "<table>" +
+                "<tr><th><p>Name</p></th></tr>" +
+                "<tr><td><p>Juan</p></td></tr>" +
+                "</table>",
+            editorFrom(json).toHtml(),
+        )
+    }
+
+    @Test
+    fun emits_table_cell_spans_only_when_they_span() {
+        val json = """
+            {"type":"doc","content":[
+              {"type":"table","content":[
+                {"type":"tableRow","content":[
+                  {"type":"tableCell","attrs":{"colspan":2,"rowspan":1,"colwidth":null},
+                   "content":[{"type":"paragraph","content":[{"type":"text","text":"wide"}]}]},
+                  {"type":"tableCell","attrs":{"colspan":1,"rowspan":1,"colwidth":null},
+                   "content":[{"type":"paragraph","content":[{"type":"text","text":"narrow"}]}]}
+                ]}
+              ]}
+            ]}
+        """
+
+        assertEquals(
+            "<table><tr>" +
+                "<td colspan=\"2\"><p>wide</p></td>" +
+                "<td><p>narrow</p></td>" +
+                "</tr></table>",
+            editorFrom(json).toHtml(),
+        )
+    }
+
+    @Test
+    fun exports_an_image_with_its_source() {
+        val json = """
+            {"type":"doc","content":[
+              {"type":"image","attrs":{"src":"photo.png","alt":"A photo"}}
+            ]}
+        """
+
+        assertEquals("<img src=\"photo.png\" alt=\"A photo\">", editorFrom(json).toHtml())
+    }
+
+    @Test
+    fun exports_an_image_without_an_alt_as_an_empty_alt() {
+        val json = """{"type":"doc","content":[{"type":"image","attrs":{"src":"x.png"}}]}"""
+
+        assertEquals("<img src=\"x.png\" alt=\"\">", editorFrom(json).toHtml())
+    }
+
+    @Test
+    fun keeps_an_unrecognised_embed_as_an_element_rather_than_dropping_it() {
+        val json = """
+            {"type":"doc","content":[
+              {"type":"document","attrs":{"id":"doc-7"}}
+            ]}
+        """
+
+        assertEquals(
+            "<div data-type=\"document\" data-id=\"doc-7\"></div>",
+            editorFrom(json).toHtml(),
         )
     }
 

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
@@ -1,5 +1,8 @@
 package com.jjrodcast.textkit
 
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.components.TextEditorStyleItem
 import com.jjrodcast.textkit.editor.core.export.HtmlSerializer
 import com.jjrodcast.textkit.editor.core.parser.BaseParagraph
 import com.jjrodcast.textkit.editor.core.parser.Blockquote
@@ -32,6 +35,7 @@ import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * HTML export.
@@ -498,5 +502,64 @@ class HtmlSerializerTest {
     @Test
     fun exports_an_empty_editor_as_an_empty_string() {
         assertEquals("", editorFrom("{}").toHtml())
+    }
+
+    // ── After editing in the editor ──────────────────────────────────────────
+    // toHtml() reads the live document, so exporting after edits must reflect them.
+
+    @Test
+    fun exports_text_typed_into_the_editor() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        editor.typeText(offset = 0, textToAdd = "Say: ")
+
+        assertEquals("<p>Say: Hello world</p>", editor.toHtml())
+    }
+
+    @Test
+    fun exports_a_mark_applied_in_the_editor() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        // Bold the word "Hello".
+        assertTrue(editor.applyStyle(TextRange(0, 5), TextEditorStyleItem.Bold))
+
+        assertEquals("<p><strong>Hello</strong> world</p>", editor.toHtml())
+    }
+
+    @Test
+    fun exports_a_link_added_in_the_editor() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        assertTrue(editor.setLink(editor.rangeOf("world"), "https://test.com"))
+
+        assertEquals(
+            "<p>Hello <a href=\"https://test.com\">world</a></p>",
+            editor.toHtml(),
+        )
+    }
+
+    @Test
+    fun exports_a_list_created_in_the_editor() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        assertTrue(
+            editor.toListItem(
+                TextRange(0, editor.offsetOf("world")),
+                from = TextEditorListItem.None,
+                to = TextEditorListItem.BulletedList,
+            ),
+        )
+
+        assertEquals("<ul><li><p>Hello world</p></li></ul>", editor.toHtml())
+    }
+
+    @Test
+    fun reflects_a_sequence_of_edits_in_the_export() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        editor.typeText(offset = editor.text.length, textToAdd = "!")
+        editor.applyStyle(TextRange(0, 5), TextEditorStyleItem.Italic)
+
+        assertEquals("<p><em>Hello</em> world!</p>", editor.toHtml())
     }
 }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
@@ -1,0 +1,319 @@
+package com.jjrodcast.textkit
+
+import com.jjrodcast.textkit.editor.core.export.HtmlSerializer
+import com.jjrodcast.textkit.editor.core.parser.BaseParagraph
+import com.jjrodcast.textkit.editor.core.parser.Blockquote
+import com.jjrodcast.textkit.editor.core.parser.BoldMark
+import com.jjrodcast.textkit.editor.core.parser.BulletedList
+import com.jjrodcast.textkit.editor.core.parser.HardBreak
+import com.jjrodcast.textkit.editor.core.parser.Hashtag
+import com.jjrodcast.textkit.editor.core.parser.Heading
+import com.jjrodcast.textkit.editor.core.parser.HeadingAttrs
+import com.jjrodcast.textkit.editor.core.parser.HighlightMark
+import com.jjrodcast.textkit.editor.core.parser.ItalicMark
+import com.jjrodcast.textkit.editor.core.parser.LinkAttrs
+import com.jjrodcast.textkit.editor.core.parser.LinkMark
+import com.jjrodcast.textkit.editor.core.parser.ListAttrs
+import com.jjrodcast.textkit.editor.core.parser.ListItem
+import com.jjrodcast.textkit.editor.core.parser.Mark
+import com.jjrodcast.textkit.editor.core.parser.Mention
+import com.jjrodcast.textkit.editor.core.parser.OrderedList
+import com.jjrodcast.textkit.editor.core.parser.Paragraph
+import com.jjrodcast.textkit.editor.core.parser.StrikeMark
+import com.jjrodcast.textkit.editor.core.parser.TaskList
+import com.jjrodcast.textkit.editor.core.parser.TaskListAttrs
+import com.jjrodcast.textkit.editor.core.parser.TaskListItem
+import com.jjrodcast.textkit.editor.core.parser.Text
+import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
+import com.jjrodcast.textkit.editor.core.parser.TextStyleAttrs
+import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
+import com.jjrodcast.textkit.editor.core.parser.TokenAttrs
+import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * HTML export.
+ *
+ * `HtmlSerializer` is a pure function over the parsed document AST, so most cases build a
+ * [TextEditorDocument] directly and assert the exact HTML — that covers every node type, including
+ * the ones a piece-table round-trip does not reproduce (headings and blockquotes are flattened into
+ * styled paragraphs on load; see `PieceTableConverter`). A final group goes through
+ * `TextKitEditorManager.toHtml()` to cover the end-to-end path.
+ *
+ * Mark nesting follows a fixed priority, so exact-string assertions are stable regardless of the
+ * iteration order of the underlying mark `Set`.
+ */
+class HtmlSerializerTest {
+
+    private fun html(vararg blocks: BaseParagraph) =
+        HtmlSerializer().serialize(TextEditorDocument(blocks.toList()))
+
+    private fun paragraphOf(text: String, marks: Set<Mark> = emptySet()) =
+        Paragraph(listOf(Text(text, marks)))
+
+    // ── Blocks ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun exports_a_paragraph() {
+        assertEquals("<p>Hello world</p>", html(paragraphOf("Hello world")))
+    }
+
+    @Test
+    fun exports_each_block_in_document_order() {
+        assertEquals(
+            "<p>first</p><p>second</p>",
+            html(paragraphOf("first"), paragraphOf("second")),
+        )
+    }
+
+    @Test
+    fun exports_an_empty_document_as_an_empty_string() {
+        assertEquals("", HtmlSerializer().serialize(TextEditorDocument()))
+    }
+
+    @Test
+    fun exports_an_empty_paragraph_so_blank_lines_survive() {
+        assertEquals("<p></p>", html(Paragraph()))
+    }
+
+    @Test
+    fun exports_headings_at_their_level() {
+        assertEquals(
+            "<h1>Title</h1><h3>Section</h3>",
+            html(
+                Heading(HeadingAttrs(level = 1), listOf(Text("Title"))),
+                Heading(HeadingAttrs(level = 3), listOf(Text("Section"))),
+            ),
+        )
+    }
+
+    @Test
+    fun clamps_heading_levels_outside_h1_to_h6() {
+        assertEquals(
+            "<h6>too deep</h6><h1>too shallow</h1>",
+            html(
+                Heading(HeadingAttrs(level = 9), listOf(Text("too deep"))),
+                Heading(HeadingAttrs(level = 0), listOf(Text("too shallow"))),
+            ),
+        )
+    }
+
+    @Test
+    fun exports_a_bulleted_list() {
+        assertEquals(
+            "<ul><li><p>one</p></li><li><p>two</p></li></ul>",
+            html(
+                BulletedList(
+                    listOf(
+                        ListItem(listOf(paragraphOf("one"))),
+                        ListItem(listOf(paragraphOf("two"))),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun omits_the_ordered_list_start_attribute_when_it_begins_at_one() {
+        assertEquals(
+            "<ol><li><p>one</p></li></ol>",
+            html(OrderedList(ListAttrs(start = 1), listOf(ListItem(listOf(paragraphOf("one")))))),
+        )
+    }
+
+    @Test
+    fun emits_the_ordered_list_start_attribute_when_it_does_not_begin_at_one() {
+        assertEquals(
+            "<ol start=\"3\"><li><p>three</p></li></ol>",
+            html(OrderedList(ListAttrs(start = 3), listOf(ListItem(listOf(paragraphOf("three")))))),
+        )
+    }
+
+    @Test
+    fun exports_a_task_list_with_interactive_checkboxes() {
+        val output = html(
+            TaskList(
+                listOf(
+                    TaskListItem(TaskListAttrs(checked = false), listOf(paragraphOf("buy milk"))),
+                    TaskListItem(TaskListAttrs(checked = true), listOf(paragraphOf("walk dog"))),
+                ),
+            ),
+        )
+
+        assertEquals(
+            "<ul data-type=\"taskList\">" +
+                "<li data-type=\"taskItem\" data-checked=\"false\">" +
+                "<input type=\"checkbox\"><p>buy milk</p></li>" +
+                "<li data-type=\"taskItem\" data-checked=\"true\">" +
+                "<input type=\"checkbox\" checked><p>walk dog</p></li>" +
+                "</ul>",
+            output,
+        )
+        // The checkbox must stay interactive — never rendered disabled.
+        assertFalse(output.contains("disabled"))
+    }
+
+    @Test
+    fun exports_a_blockquote_wrapping_its_blocks() {
+        assertEquals(
+            "<blockquote><p>quoted</p></blockquote>",
+            html(Blockquote(listOf(paragraphOf("quoted")))),
+        )
+    }
+
+    @Test
+    fun exports_a_hard_break() {
+        assertEquals(
+            "<p>a<br>b</p>",
+            html(Paragraph(listOf(Text("a"), HardBreak(), Text("b")))),
+        )
+    }
+
+    // ── Marks ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun exports_each_simple_mark_with_its_semantic_tag() {
+        val cases = listOf(
+            BoldMark() to "strong",
+            ItalicMark() to "em",
+            UnderlineMark() to "u",
+            StrikeMark() to "s",
+            HighlightMark() to "mark",
+        )
+
+        cases.forEach { (mark, tag) ->
+            assertEquals(
+                "<p><$tag>styled</$tag></p>",
+                html(paragraphOf("styled", setOf(mark))),
+                "mark: ${mark.type}",
+            )
+        }
+    }
+
+    @Test
+    fun exports_a_link_with_its_href() {
+        assertEquals(
+            "<p><a href=\"https://test.com\">visit</a></p>",
+            html(paragraphOf("visit", setOf(LinkMark(LinkAttrs("https://test.com"))))),
+        )
+    }
+
+    @Test
+    fun nests_multiple_marks_in_a_deterministic_order() {
+        assertEquals(
+            "<p><strong><em>both</em></strong></p>",
+            html(paragraphOf("both", setOf(ItalicMark(), BoldMark()))),
+        )
+    }
+
+    @Test
+    fun nests_a_link_outside_the_formatting_marks_it_carries() {
+        assertEquals(
+            "<p><a href=\"https://test.com\"><strong>bold link</strong></a></p>",
+            html(
+                paragraphOf(
+                    "bold link",
+                    setOf(BoldMark(), LinkMark(LinkAttrs("https://test.com"))),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun exports_a_text_style_mark_as_an_inline_style() {
+        assertEquals(
+            "<p><span style=\"color:#FF0000;font-size:18px\">red</span></p>",
+            html(
+                paragraphOf(
+                    "red",
+                    setOf(TextStyleMark(TextStyleAttrs(color = "#FF0000", fontSize = 18))),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun omits_a_text_style_mark_that_carries_neither_colour_nor_size() {
+        assertEquals(
+            "<p>plain</p>",
+            html(paragraphOf("plain", setOf(TextStyleMark(TextStyleAttrs(color = "", fontSize = 0))))),
+        )
+    }
+
+    @Test
+    fun exports_only_the_half_of_a_text_style_mark_that_is_set() {
+        assertEquals(
+            "<p><span style=\"color:#00FF00\">green</span></p>",
+            html(paragraphOf("green", setOf(TextStyleMark(TextStyleAttrs(color = "#00FF00", fontSize = 0))))),
+        )
+    }
+
+    // ── Inline tokens ────────────────────────────────────────────────────────
+
+    @Test
+    fun exports_tokens_as_their_visible_label() {
+        assertEquals(
+            "<p>@ada #kotlin</p>",
+            html(
+                Paragraph(
+                    listOf(
+                        Mention(TokenAttrs(id = "1", label = "ada")),
+                        Text(" "),
+                        Hashtag(TokenAttrs(id = "2", label = "kotlin")),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    // ── Escaping ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun escapes_html_special_characters_in_text() {
+        assertEquals("<p>a &lt; b &amp; c &gt; d</p>", html(paragraphOf("a < b & c > d")))
+    }
+
+    @Test
+    fun escapes_ampersands_once_only() {
+        // The literal text "&lt;" must become "&amp;lt;", not "&amp;amp;lt;".
+        assertEquals("<p>&amp;lt;</p>", html(paragraphOf("&lt;")))
+    }
+
+    @Test
+    fun escapes_quotes_and_ampersands_in_a_link_href() {
+        assertEquals(
+            "<p><a href=\"https://test.com/?q=&quot;x&quot;&amp;y=1\">tricky</a></p>",
+            html(paragraphOf("tricky", setOf(LinkMark(LinkAttrs("https://test.com/?q=\"x\"&y=1"))))),
+        )
+    }
+
+    // ── End to end, through the editor ───────────────────────────────────────
+
+    @Test
+    fun exports_a_loaded_document_through_the_manager() {
+        assertEquals("<p>Hello world</p>", editorFrom(SampleDocuments.SINGLE_PARAGRAPH).toHtml())
+    }
+
+    @Test
+    fun exports_a_loaded_ordered_list_through_the_manager() {
+        assertEquals(
+            "<ol><li><p>one</p></li><li><p>two</p></li></ol>",
+            editorFrom(SampleDocuments.ORDERED_LIST).toHtml(),
+        )
+    }
+
+    @Test
+    fun exports_a_loaded_link_through_the_manager() {
+        assertEquals(
+            "<p>visit <a href=\"https://test.com\">test</a> now</p>",
+            editorFrom(SampleDocuments.PARAGRAPH_WITH_LINK).toHtml(),
+        )
+    }
+
+    @Test
+    fun exports_an_empty_editor_as_an_empty_string() {
+        assertEquals("", editorFrom("{}").toHtml())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
@@ -397,6 +397,81 @@ class HtmlSerializerTest {
         )
     }
 
+    // ── Sanitisation ─────────────────────────────────────────────────────────
+
+    @Test
+    fun keeps_safe_link_schemes() {
+        listOf(
+            "https://test.com",
+            "http://test.com",
+            "mailto:a@b.com",
+            "tel:+123",
+            "/relative/path",
+            "#anchor",
+        ).forEach { href ->
+            assertEquals(
+                "<p><a href=\"$href\">x</a></p>",
+                html(paragraphOf("x", setOf(LinkMark(LinkAttrs(href))))),
+                "href: $href",
+            )
+        }
+    }
+
+    @Test
+    fun drops_a_link_with_an_unsafe_scheme_but_keeps_the_text() {
+        listOf(
+            "javascript:alert(1)",
+            "JavaScript:alert(1)",
+            "data:text/html,<script>",
+            "vbscript:msgbox",
+        ).forEach { href ->
+            assertEquals(
+                "<p>click</p>",
+                html(paragraphOf("click", setOf(LinkMark(LinkAttrs(href))))),
+                "href: $href",
+            )
+        }
+    }
+
+    @Test
+    fun emits_a_valid_hex_colour_but_drops_anything_else() {
+        assertEquals(
+            "<p><span style=\"color:#ABC\">x</span></p>",
+            html(paragraphOf("x", setOf(TextStyleMark(TextStyleAttrs(color = "#ABC", fontSize = 0))))),
+        )
+        // An injection attempt through the colour is not a valid hex value, so it is dropped entirely.
+        assertEquals(
+            "<p>x</p>",
+            html(paragraphOf("x", setOf(TextStyleMark(TextStyleAttrs(color = "#fff;background:url(x)", fontSize = 0))))),
+        )
+        assertEquals(
+            "<p>x</p>",
+            html(paragraphOf("x", setOf(TextStyleMark(TextStyleAttrs(color = "red", fontSize = 0))))),
+        )
+    }
+
+    @Test
+    fun drops_a_non_positive_or_absurd_font_size() {
+        assertEquals(
+            "<p>x</p>",
+            html(paragraphOf("x", setOf(TextStyleMark(TextStyleAttrs(color = "", fontSize = -4))))),
+        )
+        assertEquals(
+            "<p>x</p>",
+            html(paragraphOf("x", setOf(TextStyleMark(TextStyleAttrs(color = "", fontSize = 100_000))))),
+        )
+    }
+
+    @Test
+    fun clamps_a_non_positive_ordered_list_start() {
+        val zeroStart = OrderedList(ListAttrs(start = 0), listOf(ListItem(listOf(paragraphOf("a")))))
+        val negativeStart = OrderedList(ListAttrs(start = -3), listOf(ListItem(listOf(paragraphOf("a")))))
+
+        // Clamped to 1, which is the default, so no start attribute is emitted (never `start="0"`).
+        assertEquals("<ol><li><p>a</p></li></ol>", html(zeroStart))
+        assertEquals("<ol><li><p>a</p></li></ol>", html(negativeStart))
+    }
+
     // ── End to end, through the editor ───────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Closes #24.

## What

Adds semantic HTML export. Per the decisions on #24: export only (JSON → HTML),
semantic tags, `toHtml` as the API name, and the conversion isolated in its own
package behind a visitor layer.

### Design

New package `editor/core/export/`:

- **`DocumentSerializer`** — the visitor interface. The parsed document is already
  an AST (`TextEditorDocument` → `BaseParagraph` → `BaseText`, all sealed), so an
  implementation is an exhaustive `when` per node level with no piece-table
  knowledge. Keeping the format behind the interface means another output can be
  added later without touching call sites.
- **`HtmlSerializer`** — the first implementation.

`toHtml()` sits on `TextKitEditorManager` and `TextKitState`, mirroring `toJson()`.
`TextEditorTransaction.document` exposes the AST so an exporter can walk the same
tree the JSON encoder uses. **The existing JSON path is untouched.**

### Mapping

| Node / mark | HTML |
|---|---|
| paragraph / heading 1–6 | `<p>` / `<h1>`…`<h6>` (level clamped) |
| bulletList / orderedList | `<ul>` / `<ol>` (`start` only when ≠ 1) |
| taskList / taskItem | `<ul data-type="taskList">` + `<li data-type="taskItem" data-checked="…">` with a real enabled `<input type="checkbox">` |
| blockquote / hardBreak | `<blockquote>` / `<br>` |
| bold / italic / underline / strike / highlight | `<strong>` / `<em>` / `<u>` / `<s>` / `<mark>` |
| link | `<a href="…">` |
| textStyle | `<span style="color:…;font-size:…px">` |
| mention / hashtag | `<span data-type="mention" data-id="…">@label</span>` |
| table | `<table>` / `<tr>` / `<th>` / `<td>`, `colspan`/`rowspan` only when spanning |
| image | `<img src="…" alt="…">` |

Text is escaped for `&`, `<`, `>`; attribute values also for `"`. Marks nest in a
fixed priority order so output is deterministic regardless of the mark `Set`'s
iteration order.

Tables and images are rendered from the verbatim JSON kept in `EmbedBlock.raw`,
and table cell content is decoded back into document blocks so it goes through the
same rendering as the rest of the document. An unrecognised embed type is emitted
as an empty element carrying its type and id rather than being dropped silently.

## A finding worth flagging

Headings and blockquotes **cannot** be reached through a loaded document today:
`toJson()` already converts `heading` level 1 into a paragraph carrying a
`textStyle` `fontSize: 24` mark, and flattens `blockquote` into plain paragraphs —
in both editor and viewer mode. So `PieceTableConverter` does not reconstruct those
node types, and `toHtml()` faithfully mirrors whatever `toJson()` produces.

`HtmlSerializer` handles both node types correctly when given them, so the export
is ready if that round-trip is ever restored. Happy to open a separate issue for it
if it's not already known — it seemed out of scope here.

## Tests

27 tests, suite green at **213**.

`HtmlSerializer` is a pure function over the AST, so most cases build a document
directly and assert the exact HTML — that covers every node type including headings
and blockquotes, which the round-trip above cannot produce. A final group goes
through `TextKitEditorManager.toHtml()` end to end, and tables/images are covered
that way since embeds do survive the round-trip.

Verified on `jvmTest`, `jsTest` and `wasmJsTest` locally (no Xcode/Android SDK here,
so iOS and Android host are left to CI).

I also mutation-tested the suite: deliberately breaking mark-nesting order, escape
order, `<ol start>` suppression, `<th>` detection, `colspan` emission, token
`data-id` and image `alt` each failed the corresponding test, so they are real
guards rather than snapshots.

## Docs

`toHtml()` documented in the README next to `toJson()`.

## One open question

List items render as `<li><p>text</p></li>` (ProseMirror/Tiptap convention) rather
than `<li>text</li>`. The nested form handles nested lists, blockquotes and
multi-paragraph items for free; the flat form reads better but needs an "exactly one
paragraph" special case, so the output shape becomes conditional. Happy to switch —
worth settling now since changing exported markup later is breaking.
