### PR TITLE
Add paragraph text alignment (left / center / right / justify)  

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="document_text">Document</string>
     <string name="ordered_list_text">Ordered list</string>
     <string name="bulleted_list_text">Bulleted list</string>
+    <string name="align_text">Align</string>
     <string name="undo_text">Undo</string>
     <string name="redo_text">Redo</string>
     <string name="text_color_text">Text color</string>
@@ -20,6 +21,10 @@
     <string name="url_label">Url</string>
     <string name="edit_label">Edit</string>
     <string name="remove_label">Remove</string>
+    <string name="left_align_text">Left align</string>
+    <string name="center_align_text">Center align</string>
+    <string name="right_align_text">Right align</string>
+    <string name="justify_align_text">Justify align</string>
 
     <string name="table_merge_cells_text">Merge cells</string>
     <string name="table_split_cell_text">Split cell</string>

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -8,6 +8,7 @@ import com.jjrodcast.textkit.editor.core.parser.EmbedTokenType
 import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.parser.MentionType
 import com.jjrodcast.textkit.editor.core.parser.TEXT_EDITOR_JSON
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.parser.TextStyleAttrs
 import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
 import com.jjrodcast.textkit.editor.core.parser.TokenAttrs
@@ -113,6 +114,10 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
         transactionType: TextEditorTransactionType = TextEditorTransactionType.Format
     ): Pair<Boolean, TextRange> = when (transactionType) {
         is TextEditorTransactionType.Color -> updateColor(selection, transactionType.color)
+        is TextEditorTransactionType.Alignment -> {
+            updateTextAlignment(selection, transactionType.textAlign)
+        }
+
         else -> transaction.updateDocument(
             prevMarks = prevSelectedMark.marks,
             currMarks = currSelectedMark.marks,
@@ -122,6 +127,27 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
             transactionType = transactionType
         )
     }
+
+    /**
+     * Sets the paragraph horizontal [textAlign] over every paragraph the [selection] touches.
+     * Delegates straight to the transaction (which retags whole paragraphs), so it applies to whole
+     * paragraphs — a mark change would only affect the selected characters — and works with a
+     * collapsed caret. Called from [updateDocument]'s [TextEditorTransactionType.Alignment] branch;
+     * marks are irrelevant for alignment.
+     *
+     * @return whether the document changed, plus the resulting selection (unchanged by an alignment).
+     */
+    private fun updateTextAlignment(
+        selection: TextRange,
+        textAlign: TextAlign
+    ): Pair<Boolean, TextRange> = transaction.updateDocument(
+        prevMarks = emptySet(),
+        currMarks = emptySet(),
+        prevListItem = TextEditorSelectedMark.NONE.listItemSelected,
+        currListItem = TextEditorSelectedMark.NONE.listItemSelected,
+        range = selection,
+        transactionType = TextEditorTransactionType.Alignment(textAlign)
+    )
 
     private fun updateColor(
         selection: TextRange,
@@ -190,11 +216,19 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
         val model = TextEditorModel.create(
             text = text,
             marks = marks,
-            token = nodeType?.let { RichToken(type = it, attrs = TokenAttrs(id = id, label = label)) }
+            token = nodeType?.let {
+                RichToken(
+                    type = it,
+                    attrs = TokenAttrs(id = id, label = label)
+                )
+            }
         )
         val start = replaceRange.min
         val length = replaceRange.length
-        if (length > 0) transaction.update(start, length, model) else transaction.insert(model, start)
+        if (length > 0) transaction.update(start, length, model) else transaction.insert(
+            model,
+            start
+        )
         return TextRange(start + text.length)
     }
 
@@ -253,7 +287,8 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
         // Terminate the embed's own paragraph with a line break, unless the right side already starts
         // one (avoids an extra empty line) or we're at the end of the document.
         val rightChar = fullText.getOrNull(start)
-        val placeholderText = if (rightChar != null && rightChar != '\n') label + LINE_BREAK else label
+        val placeholderText =
+            if (rightChar != null && rightChar != '\n') label + LINE_BREAK else label
         val model = TextEditorModel.create(
             text = placeholderText,
             token = RichToken(

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/InlineNodeMapper.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/InlineNodeMapper.kt
@@ -20,11 +20,8 @@ import com.jjrodcast.textkit.editor.utils.removeLineBreakSuffix
  */
 internal fun TextEditorModel.toInlineNode(): BaseText {
     val token = piece.token
-    return if (token != null) {
-        token.toInlineNode(piece.marks.toSet())
-    } else {
-        Text(text = text.removeLineBreakSuffix(), marks = piece.marks.toSet())
-    }
+    return token?.toInlineNode(piece.marks.toSet())
+        ?: Text(text = text.removeLineBreakSuffix(), marks = piece.marks.toSet())
 }
 
 /** Rebuilds the concrete inline node for [RichToken.type]; unknown types fall back to a [Mention]. */

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
@@ -17,7 +17,9 @@ import com.jjrodcast.textkit.editor.core.parser.ListAttrs
 import com.jjrodcast.textkit.editor.core.parser.ListItem
 import com.jjrodcast.textkit.editor.core.parser.OrderedList
 import com.jjrodcast.textkit.editor.core.parser.Paragraph
+import com.jjrodcast.textkit.editor.core.parser.ParagraphAttrs
 import com.jjrodcast.textkit.editor.core.parser.TaskList
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.parser.TaskListAttrs
 import com.jjrodcast.textkit.editor.core.parser.TaskListItem
 import com.jjrodcast.textkit.editor.core.parser.Text
@@ -307,7 +309,10 @@ internal object PieceTableConverter {
                 else -> EmptyParagraph
             }
         } else {
-            Paragraph(item.getParagraphContent())
+            Paragraph(
+                attrs = ParagraphAttrs(textAlign = item.textStyled.resolveTextAlign()),
+                content = item.getParagraphContent()
+            )
         }
     }
 
@@ -528,6 +533,7 @@ internal object PieceTableConverter {
 
         // 2. Return the list of paragraphs
         return internalParagraphs.fastMap { paragraph ->
+            val textAlign = paragraph.styledText.resolveTextAlign()
             val texts = paragraph.styledText
                 .mapNotNull { if (it.isDecorator) null else it }
                 .fastMap { it.toInlineNode() }
@@ -537,11 +543,20 @@ internal object PieceTableConverter {
                 1 -> { // When the text doesn't have content
                     val first = texts.first()
                     if (first is Text && first.text.isEmpty()) EmptyParagraph
-                    else Paragraph(content = texts)
+                    else Paragraph(attrs = ParagraphAttrs(textAlign = textAlign), content = texts)
                 }
 
-                else -> Paragraph(content = texts)
+                else -> Paragraph(attrs = ParagraphAttrs(textAlign = textAlign), content = texts)
             }
         }
     }
+
+    /**
+     * Resolves a paragraph's alignment from its pieces. Alignment is a block attribute stamped onto
+     * every piece of the paragraph (see [com.jjrodcast.textkit.editor.core.piecetable.models.RichPiece.textAlign]),
+     * but an edit can leave a freshly typed piece at the default while its neighbours keep the
+     * paragraph's value — so the first non-default value wins, falling back to [TextAlign.Left].
+     */
+    private fun List<TextEditorModel>.resolveTextAlign(): TextAlign =
+        firstOrNull { it.piece.textAlign != TextAlign.Left }?.piece?.textAlign ?: TextAlign.Left
 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/TextEditorConverter.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/TextEditorConverter.kt
@@ -24,6 +24,7 @@ import com.jjrodcast.textkit.editor.core.parser.Paragraph
 import com.jjrodcast.textkit.editor.core.parser.ParagraphNone
 import com.jjrodcast.textkit.editor.core.parser.TaskList
 import com.jjrodcast.textkit.editor.core.parser.TaskListItem
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.parser.Text
 import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
 import com.jjrodcast.textkit.editor.core.parser.TokenAttrs
@@ -142,6 +143,7 @@ internal object TextEditorConverter {
                         )
                     }
                 }
+                items.applyTextAlign(attrs.textAlign)
                 when (decorator) {
                     is TextDecoratorModel.BlockquoteDecorator -> items.postProcessBlockquotes()
                     else -> items.postProcessParagraph(decorator)
@@ -161,6 +163,7 @@ internal object TextEditorConverter {
                         )
                     }
                 }
+                items.applyTextAlign(attrs.textAlign)
                 items.postProcessParagraph(decorator)
             }
 
@@ -226,6 +229,19 @@ internal object TextEditorConverter {
             ParagraphNone -> emptyList<TextEditorModel>()
         }
         return items
+    }
+
+    /**
+     * Stamps the paragraph-level [textAlign] onto every piece produced for a paragraph/heading so it
+     * survives the piece-table round-trip (see [RichPiece.textAlign]). No-op for the default
+     * [TextAlign.Left] to avoid touching pieces of the (overwhelmingly common) left-aligned case.
+     */
+    private fun ArrayList<TextEditorModel>.applyTextAlign(textAlign: TextAlign) {
+        if (textAlign == TextAlign.Left) return
+        for (i in indices) {
+            val model = this[i]
+            this[i] = model.copy(piece = model.piece.copy(textAlign = textAlign))
+        }
     }
 
     private fun ArrayList<TextEditorModel>.postProcessParagraph(decorator: TextDecoratorModel?) {

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/models/PositionalParagraph.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/models/PositionalParagraph.kt
@@ -27,8 +27,6 @@ internal data class PositionalParagraph(
     val textStyled: List<TextEditorModel> = emptyList(),
     val positionalParagraphs: ArrayList<PositionalParagraph> = arrayListOf()
 ) {
-    var isVisited: Boolean = false
-
     internal fun getParagraphContent(): List<BaseText> {
         return if (textStyled.any { it.text.isNotEmpty() }) {
             textStyled.mapNotNull {

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/MultiPieceParagraph.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/MultiPieceParagraph.kt
@@ -25,7 +25,11 @@ internal data class MultiPieceParagraph(
     val lastParagraph get() = paragraphs.last()
 
     val paragraphsInSelectedRange by lazy {
-        paragraphs.filter { intersect(start, end, it.start, it.end) }
+        paragraphs.filter {
+            val paragraphStart = it.startOffset
+            val paragraphEnd = it.endOffset + it.endPiece.length
+            end == paragraphEnd || intersect(start, end, paragraphStart, paragraphEnd)
+        }
     }
 
     val selectedParagraphIndices: List<Int> by lazy {
@@ -245,6 +249,9 @@ internal data class MultiPieceParagraph(
     internal fun getMarksWithType(configuration: TextKitConfiguration): MarkSearchType {
         val range = TextRange(start, end)
         val data = getAllModelsInRange()
+        // Alignment common to every paragraph the selection touches; null means a "mixed" selection
+        // (paragraphs with differing alignment) so a toolbar can show nothing as active.
+        val textAlign = paragraphsInSelectedRange.map { it.textAlign }.toSet().singleOrNull()
         return when {
             data.isEmpty() -> MarkSearchType()
             // When the size is 2 and the range is collapsed means that the cursor is in the middle of 2 pieces,
@@ -266,7 +273,8 @@ internal data class MultiPieceParagraph(
                         marks = piece.marks,
                         listItem = element.paragraphType,
                         range = newRange,
-                        text = element.text.removeLineBreakSuffix()
+                        text = element.text.removeLineBreakSuffix(),
+                        textAlign = textAlign
                     )
                 } else {
                     val textStart = start - element.offsetInDocument
@@ -275,7 +283,8 @@ internal data class MultiPieceParagraph(
                         marks = element.piece.marks,
                         listItem = element.paragraphType,
                         range = range,
-                        text = text
+                        text = text,
+                        textAlign = textAlign
                     )
                 }
             }
@@ -291,7 +300,7 @@ internal data class MultiPieceParagraph(
                     if (it is TextStyleMark && TextStyleMark.isDefault(it, configuration)) null
                     else it
                 }.toSet()
-                MarkSearchType(filteredMarks, listItemType, range, text)
+                MarkSearchType(filteredMarks, listItemType, range, text, textAlign)
             }
         }
     }
@@ -301,7 +310,8 @@ internal data class MultiPieceParagraph(
         // Decorator pieces (list bullets/numbers/checkboxes) and pure line-break pieces carry no
         // marks; counting them would dilute the intersection to empty for multi-paragraph or list
         // selections whose text actually shares the same marks.
-        val content = data.filter { !it.isDecorator && it.text.removeLineBreakSuffix().isNotEmpty() }
+        val content =
+            data.filter { !it.isDecorator && it.text.removeLineBreakSuffix().isNotEmpty() }
         if (content.isEmpty()) return emptySet()
 
         // Single pass over all marks: count total occurrences per key and keep the first

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/PieceParagraph.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/PieceParagraph.kt
@@ -1,5 +1,6 @@
 package com.jjrodcast.textkit.editor.core.models
 
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.piecetable.models.RichPiece
 import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel.Companion.toTextEditorListItem
 import com.jjrodcast.textkit.editor.utils.intersect
@@ -51,6 +52,15 @@ internal data class PieceParagraph(
     val isListItem get() = startPiece.decorator != null
 
     val paragraphType get() = startPiece.decorator.toTextEditorListItem()
+
+    /**
+     * Paragraph-level alignment resolved from its pieces: the first non-default value wins (an edit
+     * can leave a freshly typed piece at [TextAlign.Left] while its neighbours keep the paragraph's
+     * value), falling back to [TextAlign.Left]. See [RichPiece.textAlign].
+     */
+    val textAlign: TextAlign
+        get() = pieces.firstOrNull { it.piece.textAlign != TextAlign.Left }?.piece?.textAlign
+            ?: TextAlign.Left
 
     fun findPiecesInRange(start: Int, end: Int): List<TextEditorModel> {
         return pieces

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/Attributes.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/Attributes.kt
@@ -1,5 +1,6 @@
 package com.jjrodcast.textkit.editor.core.parser
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -12,7 +13,44 @@ data class TaskListAttrs(val checked: Boolean = false)
 data class ListAttrs(val start: Int = 1)
 
 @Serializable
-data class HeadingAttrs(val level: Int = HeadingLevels.H4)
+data class HeadingAttrs(
+    val level: Int = HeadingLevels.H4,
+    val textAlign: TextAlign = TextAlign.Left
+)
+
+/**
+ * Attributes for a plain [Paragraph]. Carries the ProseMirror/TipTap `textAlign` attr so paragraph
+ * alignment round-trips through the parser.
+ */
+@Serializable
+data class ParagraphAttrs(val textAlign: TextAlign = TextAlign.Left)
+
+/**
+ * Horizontal alignment for block nodes (`paragraph`, `heading`), serialized as the
+ * ProseMirror/TipTap `textAlign` attr string. Only the four values below are supported; any other
+ * value in a loaded document coerces to [Left] thanks to [TEXT_EDITOR_JSON]'s `coerceInputValues`.
+ */
+@Serializable
+enum class TextAlign {
+    @SerialName(TextAlignValues.Left)
+    Left,
+
+    @SerialName(TextAlignValues.Center)
+    Center,
+
+    @SerialName(TextAlignValues.Right)
+    Right,
+
+    @SerialName(TextAlignValues.Justify)
+    Justify
+}
+
+internal object TextAlignValues {
+    const val Left = "left"
+    const val Center = "center"
+    const val Right = "right"
+    const val Justify = "justify"
+}
 
 @Serializable
 data class TextStyleAttrs(val color: String? = "", val fontSize: Int = UNSET_FONT_SIZE) {

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/Paragraphs.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/Paragraphs.kt
@@ -21,7 +21,10 @@ internal sealed class BaseParagraph {
 
 @Serializable
 @SerialName(ParagraphTypes.Paragraph)
-internal data class Paragraph(val content: List<BaseText> = emptyList()) : BaseParagraph() {
+internal data class Paragraph(
+    val attrs: ParagraphAttrs = ParagraphAttrs(),
+    val content: List<BaseText> = emptyList()
+) : BaseParagraph() {
     override val type: String = ParagraphTypes.Paragraph
 }
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorBasePieceTable.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorBasePieceTable.kt
@@ -6,6 +6,7 @@ import com.jjrodcast.textkit.editor.core.models.PieceParagraph
 import com.jjrodcast.textkit.editor.core.models.TextEditorDocumentModel
 import com.jjrodcast.textkit.editor.core.models.TextEditorModel
 import com.jjrodcast.textkit.editor.core.parser.Mark
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.piecetable.models.RichPiece
 import com.jjrodcast.textkit.editor.core.piecetable.models.RichPieceTransaction
 import com.jjrodcast.textkit.editor.core.piecetable.models.Source
@@ -384,6 +385,31 @@ internal abstract class RichTextEditorBasePieceTable :
         return rope.findFirstLineBreakEndFrom(endPieceIndex)
     }
 
+    /**
+     * Sets the paragraph-level [textAlign] on every piece of each paragraph that intersects
+     * [[start], [end]]. Alignment is a block attribute stored per-piece (see [RichPiece.textAlign]),
+     * so applying it means retagging the *whole* paragraph — not just the selected characters —
+     * which also makes it work with a collapsed caret.
+     *
+     * Each affected piece is swapped in-place via [PieceRope.replaceAt] with a same-length
+     * `copy(textAlign = …)`; the character buffers and offsets are untouched, so the text cache stays
+     * valid (mirrors [updateDecorator]). O(R log P) for R affected pieces. Returns whether any piece
+     * changed.
+     */
+    internal fun updateTextAlign(start: Int, end: Int, textAlign: TextAlign): Boolean {
+        var changed = false
+        getLineContent(start, end).paragraphsInSelectedRange.fastForEach { paragraph ->
+            paragraph.pieces.fastForEach { model ->
+                if (model.piece.textAlign == textAlign) return@fastForEach
+                val index = getIndexOf(model)
+                if (index < 0) return@fastForEach
+                rope.replaceAt(index, model.piece.copy(textAlign = textAlign))
+                changed = true
+            }
+        }
+        return changed
+    }
+
     internal fun updateDecorator(model: TextEditorModel): Boolean {
         val piece = model.piece
         return when (val decorator = piece.decorator) {
@@ -451,6 +477,7 @@ internal abstract class RichTextEditorBasePieceTable :
                         marks = model.piece.marks,
                         decorator = model.piece.decorator,
                         token = model.piece.token,
+                        textAlign = model.piece.textAlign,
                         isLineBreak = pieceText.isLineBreak(),
                         endsWithLineBreak = pieceText.endsWithLineBreak()
                     )

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorPieceTable.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorPieceTable.kt
@@ -1,6 +1,7 @@
 package com.jjrodcast.textkit.editor.core.piecetable
 
 import com.jjrodcast.textkit.editor.core.models.TextEditorModel
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.piecetable.models.RichPiece
 import com.jjrodcast.textkit.editor.core.piecetable.models.Source
 import com.jjrodcast.textkit.editor.utils.endsWithLineBreak
@@ -49,6 +50,7 @@ internal class RichTextEditorPieceTable : RichTextEditorBasePieceTable() {
                 // headLength is either 0 (dropped) or its full length, so carrying the token here is
                 // safe.
                 token = newOriginalPiece.token,
+                textAlign = newOriginalPiece.textAlign,
                 isLineBreak = newOriginalPiece.isLineBreak,
                 endsWithLineBreak = charAtEndIsLineBreak(newOriginalPiece.source, newOriginalPiece.offset, headLength)
             )
@@ -61,6 +63,10 @@ internal class RichTextEditorPieceTable : RichTextEditorBasePieceTable() {
                     marks = model.piece.marks,
                     decorator = model.piece.decorator,
                     token = model.piece.token,
+                    // New text typed inside a paragraph inherits that paragraph's alignment: the
+                    // surrounding split pieces already carry it, so prefer theirs over the model's
+                    // default when this piece lands between them.
+                    textAlign = if (model.piece.textAlign != TextAlign.Left) model.piece.textAlign else newOriginalPiece.textAlign,
                     isLineBreak = model.text.isLineBreak(),
                     endsWithLineBreak = model.text.endsWithLineBreak()
                 )
@@ -124,6 +130,7 @@ internal class RichTextEditorPieceTable : RichTextEditorBasePieceTable() {
                 marks = initialPiece.marks,
                 decorator = initialPiece.decorator,
                 token = initialPiece.token,
+                textAlign = initialPiece.textAlign,
                 isLineBreak = leftLength > 0 && initialPiece.isLineBreak,
                 endsWithLineBreak = charAtEndIsLineBreak(initialPiece.source, initialPiece.offset, leftLength)
             )
@@ -136,6 +143,7 @@ internal class RichTextEditorPieceTable : RichTextEditorBasePieceTable() {
                 marks = finalPiece.marks,
                 decorator = finalPiece.decorator,
                 token = finalPiece.token,
+                textAlign = finalPiece.textAlign,
                 isLineBreak = rightLength > 0 && finalPiece.isLineBreak,
                 // Right piece shares the same buffer end as finalPiece.
                 endsWithLineBreak = rightLength > 0 && finalPiece.endsWithLineBreak
@@ -188,6 +196,7 @@ internal class RichTextEditorPieceTable : RichTextEditorBasePieceTable() {
             marks = remainingMarks,
             decorator = originalPiece.decorator,
             token = originalPiece.token,
+            textAlign = originalPiece.textAlign,
             isLineBreak = remainingText.isLineBreak(),
             endsWithLineBreak = remainingText.endsWithLineBreak()
         )

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/models/RichPiece.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/models/RichPiece.kt
@@ -1,6 +1,7 @@
 package com.jjrodcast.textkit.editor.core.piecetable.models
 
 import com.jjrodcast.textkit.editor.core.parser.Mark
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.utils.intersect
 import kotlinx.serialization.Serializable
 
@@ -11,6 +12,11 @@ internal data class RichPiece(
     override val length: Int,
     override val decorator: TextDecoratorModel? = null,
     val marks: Set<Mark> = emptySet(),
+    // Paragraph-level horizontal alignment carried on every piece of the paragraph. It is a block
+    // attribute (all pieces of a paragraph share the same value), stored per-piece so it survives the
+    // rope's split/merge/splice operations via `copy()`. Read back on serialization from the
+    // paragraph's pieces (see PieceTableConverter).
+    val textAlign: TextAlign = TextAlign.Left,
     // When non-null this piece is an atomic trigger token (mention, hashtag, …): its visible text is
     // "<triggerKey><label>" and its identity (type + id + label) lives here so it survives the
     // piece-table round-trip and can be serialized back to the right inline node. Selection/editing

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
@@ -205,7 +205,7 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
 
     internal fun getLineContent(start: Int, end: Int) = pieceTable.getLineContent(start, end)
 
-    internal fun getLineContentWithNeigborParagraphs(start: Int, end: Int) =
+    internal fun getLineContentWithNeighborParagraphs(start: Int, end: Int) =
         pieceTable.getLineContentWithNeighborListItems(start, end)
 
     override fun updateDocument(
@@ -216,6 +216,11 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
         range: TextRange,
         transactionType: TextEditorTransactionType
     ) = when {
+        transactionType is TextEditorTransactionType.Alignment -> {
+            // Paragraph-level: retags whole paragraphs, so it runs even for a collapsed caret.
+            pieceTable.updateTextAlign(range.min, range.max, transactionType.textAlign) to range
+        }
+
         prevListItem != currListItem -> {
             ListItemTransaction.toggleParagraphsToListItems(this, prevListItem, currListItem, range)
         }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
@@ -39,7 +39,7 @@ internal object ListItemTransaction {
         listItem: TextEditorDecoratorItem,
         range: TextRange
     ): Pair<Boolean, TextRange> {
-        val originalLines = transaction.getLineContentWithNeigborParagraphs(range.min, range.max)
+        val originalLines = transaction.getLineContentWithNeighborParagraphs(range.min, range.max)
 
         val lines = MultiPieceParagraph(paragraphs = originalLines.paragraphs, start = originalLines.start, end = originalLines.end)
         val selectedParagraphs = originalLines.paragraphsInSelectedRange.size

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/marks/FormatTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/marks/FormatTransaction.kt
@@ -79,6 +79,8 @@ internal object FormatTransaction {
         return when (transactionType) {
             TextEditorTransactionType.Format -> this
             is TextEditorTransactionType.Color -> this
+            // Alignment is handled upstream in TextEditorTransaction and never routed here.
+            is TextEditorTransactionType.Alignment -> this
             is TextEditorTransactionType.Link -> {
                 if (item.piece.marks.any { it is LinkMark }) TextRange(
                     item.pieceStart,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/models/TextEditorParagraph.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/models/TextEditorParagraph.kt
@@ -4,10 +4,20 @@ import com.jjrodcast.textkit.editor.core.models.TextEditorModel
 import com.jjrodcast.textkit.editor.core.parser.EmbedTokenType
 import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.parser.MentionType
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.piecetable.models.RichToken
 import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel
 
-class TextEditorParagraph(val children: List<TextEditorItem>)
+class TextEditorParagraph(val children: List<TextEditorItem>) {
+    /**
+     * Horizontal alignment of the paragraph, resolved from its children: the first non-default value
+     * wins (an edit can leave a freshly typed piece at [TextAlign.Left] while its neighbours keep the
+     * paragraph's value), falling back to [TextAlign.Left]. Use it to build the paragraph's
+     * `ParagraphStyle` when rendering.
+     */
+    val textAlign: TextAlign
+        get() = children.firstOrNull { it.textAlign != TextAlign.Left }?.textAlign ?: TextAlign.Left
+}
 
 class TextEditorItem internal constructor(
     val text: String,
@@ -15,7 +25,8 @@ class TextEditorItem internal constructor(
     val end: Int,
     val decorator: TextDecoratorModel? = null,
     internal val token: RichToken? = null,
-    val marks: List<Mark>
+    val marks: List<Mark>,
+    val textAlign: TextAlign = TextAlign.Left
 ) {
     /** True for any atomic trigger token (mention, hashtag, …). */
     val isToken get() = token != null
@@ -42,7 +53,8 @@ class TextEditorItem internal constructor(
             token = model.piece.token,
             start = model.offsetInDocument,
             end = model.offsetInDocument + model.piece.length,
-            marks = model.piece.marks.toList()
+            marks = model.piece.marks.toList(),
+            textAlign = model.piece.textAlign
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/models/TextEditorTransactionType.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/models/TextEditorTransactionType.kt
@@ -3,6 +3,7 @@ package com.jjrodcast.textkit.editor.core.transactions.models
 import com.jjrodcast.textkit.editor.core.parser.LinkAttrs
 import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.core.parser.Mark
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 
 sealed class TextEditorTransactionType {
     data object Format : TextEditorTransactionType() {
@@ -15,6 +16,15 @@ sealed class TextEditorTransactionType {
     }
 
     data class Color(val color: String?) : TextEditorTransactionType() {
+        override val marks: Set<Mark> = emptySet()
+    }
+
+    /**
+     * Paragraph-level horizontal alignment change. Unlike [Format] this is not a mark: it retags the
+     * pieces of every paragraph the selection touches (see the piece table's `updateTextAlign`) and
+     * so applies to whole paragraphs even with a collapsed caret. Carries no [marks].
+     */
+    data class Alignment(val textAlign: TextAlign) : TextEditorTransactionType() {
         override val marks: Set<Mark> = emptySet()
     }
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
@@ -195,7 +195,7 @@ internal object TextDeletedTransaction {
 
         if (paragraphType != nextParagraphType) return emptyList()
 
-        val mergedParagraphs = getLineContentWithNeigborParagraphs(paragraphOffset, nextParagraphOffset)
+        val mergedParagraphs = getLineContentWithNeighborParagraphs(paragraphOffset, nextParagraphOffset)
         val listParagraphs = mergedParagraphs.paragraphs.filter { it.paragraphType == paragraphType }
         val positionalItems = ListsConverter.fromPieceMultiParagraph(MultiPieceParagraph(listParagraphs, lines.start, lines.end))
         val reorderedItems = PositionalListItemUtils.reorderItems(positionalItems)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransaction.kt
@@ -18,19 +18,19 @@ object TextTransaction {
     ): Pair<Boolean, TextRange> {
         val (selection, transactions) = when (actionModel) {
             is TextEditorAction.TextAdded -> {
-                val lines = manager.transaction.getLineContentWithNeigborParagraphs(actionModel.offset, actionModel.offset)
+                val lines = manager.transaction.getLineContentWithNeighborParagraphs(actionModel.offset, actionModel.offset)
                 TextInsertedTransaction.addText(lines, actionModel)
             }
 
             is TextEditorAction.TextRemoved -> {
                 val lines =
-                    manager.transaction.getLineContentWithNeigborParagraphs(actionModel.offset, actionModel.offset + actionModel.length)
+                    manager.transaction.getLineContentWithNeighborParagraphs(actionModel.offset, actionModel.offset + actionModel.length)
                 TextDeletedTransaction.deleteText(lines, actionModel, manager)
             }
 
             is TextEditorAction.TextUpdated -> {
                 val lines =
-                    manager.transaction.getLineContentWithNeigborParagraphs(
+                    manager.transaction.getLineContentWithNeighborParagraphs(
                         actionModel.offset,
                         actionModel.offset + actionModel.removeLength
                     )

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/models/MarkSearchType.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/models/MarkSearchType.kt
@@ -5,12 +5,16 @@ import com.jjrodcast.textkit.editor.components.TextEditorDecoratorItem
 import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.core.parser.Mark
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 
 data class MarkSearchType(
     val marks: Set<Mark> = emptySet(),
     val listItem: TextEditorDecoratorItem = TextEditorListItem.None,
     val range: TextRange = TextRange.Zero,
-    val text: String = ""
+    val text: String = "",
+    // Alignment shared by the paragraph(s) the selection touches, or null when it spans paragraphs
+    // with differing alignment (a "mixed" selection) or there is nothing selected.
+    val textAlign: TextAlign? = null
 ) {
     val hasLink get() = marks.any { it is LinkMark }
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
@@ -31,6 +31,7 @@ import com.jjrodcast.textkit.editor.models.TextKitTrigger
 import com.jjrodcast.textkit.editor.models.createTextKitConfiguration
 import com.jjrodcast.textkit.editor.utils.DocumentUtils
 import com.jjrodcast.textkit.theme.TextKitTheme
+import com.jjrodcast.textkit.ui.TextKitAlignPopup
 import com.jjrodcast.textkit.ui.TextKitColorsPopup
 import com.jjrodcast.textkit.ui.TextKitEditor
 import com.jjrodcast.textkit.ui.TextKitEmbedPopup
@@ -147,6 +148,7 @@ fun TextKitSample() {
                 onTextAndColorClick = { state.openColorPicker(it) },
                 onOrderedListClick = state::toggleOrderedList,
                 onBulletedListClick = state::toggleUnorderedList,
+                onTextAlignClick = { state.openAlignPicker(it) },
                 onUndoClick = { state.undo() },
                 onRedoClick = { state.redo() },
                 canUndo = state.canUndo,
@@ -166,6 +168,7 @@ fun TextKitSample() {
                     state = state,
                     colors = barState.colors
                 )
+                TextKitAlignPopup(state = state)
                 TextKitLinkPopup(
                     state = state,
                     onEdit = { link ->
@@ -248,6 +251,7 @@ fun TextKitSampleNonMobile(
                 onTextAndColorClick = { state.openColorPicker(it) },
                 onOrderedListClick = state::toggleOrderedList,
                 onBulletedListClick = state::toggleUnorderedList,
+                onTextAlignClick = { state.openAlignPicker(it) },
                 onUndoClick = { state.undo() },
                 onRedoClick = { state.redo() },
                 canUndo = state.canUndo,
@@ -267,6 +271,7 @@ fun TextKitSampleNonMobile(
                     state = state,
                     colors = barState.colors
                 )
+                TextKitAlignPopup(state = state)
                 TextKitLinkPopup(
                     state = state,
                     onEdit = { link ->

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitAlignPopup.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitAlignPopup.kt
@@ -1,0 +1,97 @@
+package com.jjrodcast.textkit.ui
+
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.FormatAlignLeft
+import androidx.compose.material.icons.automirrored.rounded.FormatAlignRight
+import androidx.compose.material.icons.rounded.AlignHorizontalCenter
+import androidx.compose.material.icons.rounded.FormatAlignJustify
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
+import com.jjrodcast.textkit.theme.TextKitTheme
+import com.jjrodcast.textkit.ui.state.TextKitState
+import com.jjrodcast.textkit.ui.utils.TextKitPopupAnchorProvider
+import org.jetbrains.compose.resources.stringResource
+import textkit.shared.generated.resources.Res
+import textkit.shared.generated.resources.center_align_text
+import textkit.shared.generated.resources.justify_align_text
+import textkit.shared.generated.resources.left_align_text
+import textkit.shared.generated.resources.right_align_text
+
+@Composable
+fun TextKitAlignPopup(
+    state: TextKitState,
+    modifier: Modifier = Modifier,
+    selectedColor: Color = TextKitTheme.colors.primary.copy(alpha = 0.45f),
+    onTextAlignmentSelected: (TextAlign) -> Unit = { textAlign ->
+        state.applyTextAlignment(textAlign)
+        state.dismissAlignPicker()
+    },
+    onClose: () -> Unit = { state.dismissAlignPicker() }
+) {
+    val anchor = state.activeAlignAnchor ?: return
+
+    Popup(
+        popupPositionProvider = TextKitPopupAnchorProvider.positionProvider(anchor),
+        onDismissRequest = onClose,
+        properties = PopupProperties(focusable = true)
+    ) {
+        Card(
+            modifier = modifier.widthIn(min = 64.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = TextKitTheme.colors.surface,
+                contentColor = TextKitTheme.colors.onSurface
+            ),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 6.dp)
+        ) {
+            Row(
+                modifier = Modifier.height(IntrinsicSize.Min)
+                    .padding(horizontal = 4.dp, vertical = 4.dp)
+            ) {
+                TextKitTooltipFormattingItem(
+                    tooltipText = stringResource(Res.string.left_align_text),
+                    painter = rememberVectorPainter(Icons.AutoMirrored.Rounded.FormatAlignLeft),
+                    value = state.currentTextAlign == TextAlign.Left,
+                    onClick = { onTextAlignmentSelected(TextAlign.Left) },
+                    backgroundColor = selectedColor
+                )
+                TextKitFormattingSeparator()
+                TextKitTooltipFormattingItem(
+                    tooltipText = stringResource(Res.string.center_align_text),
+                    painter = rememberVectorPainter(Icons.Rounded.AlignHorizontalCenter),
+                    value = state.currentTextAlign == TextAlign.Center,
+                    onClick = { onTextAlignmentSelected(TextAlign.Center) },
+                    backgroundColor = selectedColor
+                )
+                TextKitFormattingSeparator()
+                TextKitTooltipFormattingItem(
+                    tooltipText = stringResource(Res.string.right_align_text),
+                    painter = rememberVectorPainter(Icons.AutoMirrored.Rounded.FormatAlignRight),
+                    value = state.currentTextAlign == TextAlign.Right,
+                    onClick = { onTextAlignmentSelected(TextAlign.Right) },
+                    backgroundColor = selectedColor
+                )
+                TextKitFormattingSeparator()
+                TextKitTooltipFormattingItem(
+                    tooltipText = stringResource(Res.string.justify_align_text),
+                    painter = rememberVectorPainter(Icons.Rounded.FormatAlignJustify),
+                    value = state.currentTextAlign == TextAlign.Justify,
+                    onClick = { onTextAlignmentSelected(TextAlign.Justify) },
+                    backgroundColor = selectedColor
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditableTable.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditableTable.kt
@@ -1,0 +1,762 @@
+package com.jjrodcast.textkit.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.CallMerge
+import androidx.compose.material.icons.rounded.CallSplit
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Sync
+import androidx.compose.material.icons.rounded.Title
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.ParentDataModifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.jjrodcast.textkit.theme.TextKitTheme
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * An **editable**, Notion-style rich table for a `table` embed.
+ *
+ * Where [TextKitEmbedPopup]'s `TableView` renders a table read-only, this component lets the user
+ * mutate one: add/remove rows and columns, merge and split cells (true `colspan`/`rowspan`), toggle
+ * header cells (styled with a more prominent color), and edit cell text inline. Nothing leaves the
+ * component until the user taps **Sincronizar**, at which point [onSync] receives the table
+ * serialized back to the same ProseMirror JSON shape carried by the embed's `rawJson`.
+ *
+ * The whole UI is themed through [TextKitTheme] so it adapts to light/dark automatically.
+ *
+ * @param rawJson The ProseMirror `table` JSON from the embed model (`EmbedInfo.rawJson`). A fresh
+ *   editable state is built whenever this value changes. Malformed input falls back to a starter 3×3.
+ * @param onSync Called with the updated ProseMirror `table` JSON when the user syncs their changes.
+ * @param modifier Layout modifier for the root column.
+ */
+@Composable
+fun TextKitEditableTable(
+    rawJson: String,
+    onSync: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state = remember(rawJson) { EditableTableState.from(rawJson) }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        TableToolbar(state = state, onSync = onSync)
+
+        Box(
+            modifier = Modifier
+                .border(
+                    BorderStroke(1.dp, TextKitTheme.colors.outlineVariant),
+                    shape = RoundedCornerShape(10.dp),
+                )
+                .padding(1.dp),
+        ) {
+            TableGrid(state = state)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Toolbar
+// ---------------------------------------------------------------------------------------------
+
+@Composable
+private fun TableToolbar(state: EditableTableState, onSync: (String) -> Unit) {
+    // Read the structural version + selection so the toolbar re-evaluates enabled states.
+    @Suppress("UNUSED_VARIABLE") val version = state.version
+    val selectionCount = state.selected.size
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TableActionButton(Icons.Rounded.Add, "Fila") { state.addRowRelative() }
+            TableActionButton(Icons.Rounded.Add, "Columna") { state.addColumnRelative() }
+            TableActionButton(
+                icon = Icons.Rounded.Delete,
+                label = "Eliminar fila",
+                enabled = selectionCount > 0,
+            ) { state.deleteSelectedRows() }
+            TableActionButton(
+                icon = Icons.Rounded.Delete,
+                label = "Eliminar columna",
+                enabled = selectionCount > 0,
+            ) { state.deleteSelectedColumns() }
+            TableActionButton(
+                icon = Icons.Rounded.CallMerge,
+                label = "Fusionar",
+                enabled = state.canMerge(),
+            ) { state.mergeSelection() }
+            TableActionButton(
+                icon = Icons.Rounded.CallSplit,
+                label = "Dividir",
+                enabled = state.canSplit(),
+            ) { state.splitSelection() }
+            TableActionButton(
+                icon = Icons.Rounded.Title,
+                label = "Encabezado",
+                enabled = selectionCount > 0,
+            ) { state.toggleHeaderSelected() }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = if (selectionCount == 0) {
+                    "Toca la barra superior de una celda para seleccionarla"
+                } else {
+                    "$selectionCount celda(s) seleccionada(s)"
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = TextKitTheme.colors.onSurfaceVariant,
+            )
+            Button(
+                onClick = { onSync(state.toProseMirrorJson()) },
+                colors = androidx.compose.material3.ButtonDefaults.buttonColors(
+                    containerColor = TextKitTheme.colors.primary,
+                    contentColor = TextKitTheme.colors.onPrimary,
+                ),
+            ) {
+                Icon(Icons.Rounded.Sync, contentDescription = null, modifier = Modifier.size(18.dp))
+                Text(
+                    text = "Sincronizar",
+                    modifier = Modifier.padding(start = 6.dp),
+                        style = MaterialTheme.typography.labelLarge,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TableActionButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        enabled = enabled,
+        shape = RoundedCornerShape(8.dp),
+        color = TextKitTheme.colors.surfaceVariant,
+        contentColor = if (enabled) {
+            TextKitTheme.colors.onSurfaceVariant
+        } else {
+            TextKitTheme.colors.onSurfaceVariant.copy(alpha = 0.4f)
+        },
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(16.dp))
+            Text(label, style = MaterialTheme.typography.labelMedium)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Grid rendering (custom Layout so merged cells span multiple rows/columns correctly)
+// ---------------------------------------------------------------------------------------------
+
+private val ColumnWidth: Dp = 150.dp
+private val MinRowHeight: Dp = 46.dp
+
+@Composable
+private fun TableGrid(state: EditableTableState, modifier: Modifier = Modifier) {
+    // Read `version` so structural mutations trigger a recomposition + re-measure.
+    @Suppress("UNUSED_VARIABLE") val version = state.version
+    val anchors = state.anchors()
+    val rowCount = state.rows()
+    val colCount = state.cols()
+
+    Layout(
+        modifier = modifier.horizontalScroll(rememberScrollState()),
+        content = {
+            anchors.forEach { anchor ->
+                key(anchor.id) {
+                    Box(
+                        Modifier.cellSpan(
+                            CellSpan(anchor.row, anchor.col, anchor.rowSpan, anchor.colSpan),
+                        ),
+                    ) {
+                        TableCellView(state = state, id = anchor.id)
+                    }
+                }
+            }
+        },
+    ) { measurables, _ ->
+        val colPx = ColumnWidth.roundToPx()
+        val minRowPx = MinRowHeight.roundToPx()
+        val spans = measurables.map { it.parentData as CellSpan }
+
+        // Pass 1: measure each cell at its final width with natural (unbounded) height.
+        val natural = measurables.mapIndexed { i, m ->
+            val s = spans[i]
+            m.measure(Constraints(minWidth = s.colSpan * colPx, maxWidth = s.colSpan * colPx))
+        }
+
+        // Row heights: single-row cells set them, multi-row cells grow the last spanned row.
+        val rowH = IntArray(rowCount) { minRowPx }
+        natural.forEachIndexed { i, p ->
+            val s = spans[i]
+            if (s.rowSpan == 1) rowH[s.row] = maxOf(rowH[s.row], p.height)
+        }
+        natural.forEachIndexed { i, p ->
+            val s = spans[i]
+            if (s.rowSpan > 1) {
+                val have = (s.row until s.row + s.rowSpan).sumOf { rowH[it] }
+                if (p.height > have) rowH[s.row + s.rowSpan - 1] += p.height - have
+            }
+        }
+
+        val rowY = IntArray(rowCount)
+        for (r in 1 until rowCount) rowY[r] = rowY[r - 1] + rowH[r - 1]
+
+        // Pass 2: re-measure each cell at the exact spanned size so backgrounds/borders fill it.
+        val placeables = measurables.mapIndexed { i, m ->
+            val s = spans[i]
+            val h = (s.row until s.row + s.rowSpan).sumOf { rowH[it] }
+            m.measure(Constraints.fixed(s.colSpan * colPx, h))
+        }
+
+        val totalW = colCount * colPx
+        val totalH = rowH.sum()
+        layout(totalW, totalH) {
+            placeables.forEachIndexed { i, p ->
+                val s = spans[i]
+                p.place(s.col * colPx, rowY[s.row])
+            }
+        }
+    }
+}
+
+@Composable
+private fun TableCellView(state: EditableTableState, id: Long) {
+    val content = state.cells[id] ?: return
+    val isSelected = id in state.selected
+    val isHeader = content.isHeader
+
+    val background = if (isHeader) TextKitTheme.colors.primaryContainer else TextKitTheme.colors.surface
+    val textColor = if (isHeader) TextKitTheme.colors.onPrimaryContainer else TextKitTheme.colors.onSurface
+    val border = if (isSelected) {
+        BorderStroke(2.dp, TextKitTheme.colors.primary)
+    } else {
+        BorderStroke(1.dp, TextKitTheme.colors.outlineVariant)
+    }
+    val handleColor = when {
+        isSelected -> TextKitTheme.colors.primary
+        isHeader -> TextKitTheme.colors.onPrimaryContainer.copy(alpha = 0.18f)
+        else -> TextKitTheme.colors.surfaceVariant
+    }
+
+    Column(modifier = Modifier.background(background).border(border)) {
+        // Selection handle: a slim, always-available bar so selecting never fights with editing text.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(18.dp)
+                .background(handleColor)
+                .clickable { state.toggleSelect(id) },
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "•  •  •",
+                style = MaterialTheme.typography.labelSmall,
+                color = if (isSelected) TextKitTheme.colors.onPrimary else TextKitTheme.colors.onSurfaceVariant,
+            )
+        }
+        HorizontalDivider(color = TextKitTheme.colors.outlineVariant)
+        BasicTextField(
+            value = content.text,
+            onValueChange = { content.text = it },
+            textStyle = MaterialTheme.typography.bodyMedium.copy(
+                color = textColor,
+                fontWeight = if (isHeader) FontWeight.SemiBold else FontWeight.Normal,
+            ),
+            cursorBrush = SolidColor(TextKitTheme.colors.primary),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 10.dp, vertical = 8.dp),
+        )
+    }
+}
+
+/** Parent data attaching a cell's grid position + span so the [Layout] can place/size it. */
+private data class CellSpan(val row: Int, val col: Int, val rowSpan: Int, val colSpan: Int)
+
+private class CellSpanModifier(private val span: CellSpan) : ParentDataModifier {
+    override fun Density.modifyParentData(parentData: Any?): Any = span
+}
+
+private fun Modifier.cellSpan(span: CellSpan): Modifier = this.then(CellSpanModifier(span))
+
+// ---------------------------------------------------------------------------------------------
+// Editable model — the grid of anchor ids is the single source of truth; spans are derived.
+// ---------------------------------------------------------------------------------------------
+
+/** Mutable content of one cell. Text/header are Compose state so edits recompose only that cell. */
+private class CellContent(text: String, isHeader: Boolean) {
+    var text by mutableStateOf(text)
+    var isHeader by mutableStateOf(isHeader)
+}
+
+/** A cell's top-left position and how many rows/columns it spans (derived from the grid). */
+private data class Anchor(
+    val id: Long,
+    val row: Int,
+    val col: Int,
+    val rowSpan: Int,
+    val colSpan: Int,
+)
+
+/**
+ * Holds the editable table. `grid[r][c]` stores the id of the cell occupying that logical slot; a
+ * merged cell simply has its id in every slot it covers. Spans are always *derived* from the grid
+ * (see [anchors]), which keeps every mutation (add/remove/merge/split) a simple grid edit that can't
+ * leave the model inconsistent. The rectangle is kept dense (all rows share the same width).
+ */
+private class EditableTableState(
+    private val grid: MutableList<MutableList<Long>>,
+    val cells: MutableMap<Long, CellContent>,
+    startId: Long,
+) {
+    private var nextId = startId
+
+    /** Bumped on structural changes (rows/cols/spans) to invalidate the grid layout. */
+    var version by mutableIntStateOf(0)
+        private set
+
+    /** Currently selected cell ids (for merge/split/delete/header actions). */
+    val selected = mutableStateListOf<Long>()
+
+    private fun newId(): Long = nextId++
+    private fun bump() { version++ }
+
+    fun rows(): Int = grid.size
+    fun cols(): Int = grid.firstOrNull()?.size ?: 0
+
+    /** Derive every anchor (top-left + span) from the grid, sorted row-major for stable rendering. */
+    fun anchors(): List<Anchor> {
+        val box = HashMap<Long, IntArray>() // id -> [minR, minC, maxR, maxC]
+        for (r in grid.indices) {
+            val row = grid[r]
+            for (c in row.indices) {
+                val id = row[c]
+                val b = box[id]
+                if (b == null) {
+                    box[id] = intArrayOf(r, c, r, c)
+                } else {
+                    if (r < b[0]) b[0] = r
+                    if (c < b[1]) b[1] = c
+                    if (r > b[2]) b[2] = r
+                    if (c > b[3]) b[3] = c
+                }
+            }
+        }
+        return box.entries
+            .map { (id, b) -> Anchor(id, b[0], b[1], b[2] - b[0] + 1, b[3] - b[1] + 1) }
+            .sortedWith(compareBy({ it.row }, { it.col }))
+    }
+
+    fun toggleSelect(id: Long) {
+        if (id in selected) selected.remove(id) else selected.add(id)
+    }
+
+    // --- structural mutations ---------------------------------------------------------------
+
+    private fun addRow(at: Int) {
+        val n = cols()
+        val newRow = ArrayList<Long>(n)
+        for (c in 0 until n) {
+            val above = if (at > 0) grid[at - 1][c] else -1L
+            val below = if (at < grid.size) grid[at][c] else -1L
+            // Inserting *inside* a vertically-merged cell grows that cell (Notion behavior);
+            // otherwise the new slot is a fresh empty single cell.
+            if (at in 1 until grid.size && above == below) {
+                newRow.add(above)
+            } else {
+                val id = newId()
+                cells[id] = CellContent("", false)
+                newRow.add(id)
+            }
+        }
+        grid.add(at, newRow)
+        bump()
+    }
+
+    private fun addColumn(at: Int) {
+        for (row in grid) {
+            val left = if (at > 0) row[at - 1] else -1L
+            val right = if (at < row.size) row[at] else -1L
+            if (at in 1 until row.size && left == right) {
+                row.add(at, left) // grow a horizontally-merged cell
+            } else {
+                val id = newId()
+                cells[id] = CellContent("", false)
+                row.add(at, id)
+            }
+        }
+        bump()
+    }
+
+    fun deleteRows(indices: List<Int>) {
+        val distinct = indices.distinct()
+        if (rows() - distinct.size < 1) return // always keep at least one row
+        distinct.sortedDescending().forEach { if (it in grid.indices) grid.removeAt(it) }
+        purge()
+        selected.clear()
+        bump()
+    }
+
+    fun deleteColumns(indices: List<Int>) {
+        val distinct = indices.distinct()
+        if (cols() - distinct.size < 1) return // always keep at least one column
+        val desc = distinct.sortedDescending()
+        for (row in grid) for (c in desc) if (c < row.size) row.removeAt(c)
+        purge()
+        selected.clear()
+        bump()
+    }
+
+    // --- merge / split ----------------------------------------------------------------------
+
+    /** The bounding box of the current selection if it forms a fully-covered rectangle, else null. */
+    private fun mergeBox(): IntArray? {
+        if (selected.size < 2) return null
+        val picked = anchors().filter { it.id in selected }
+        if (picked.isEmpty()) return null
+        val minR = picked.minOf { it.row }
+        val minC = picked.minOf { it.col }
+        val maxR = picked.maxOf { it.row + it.rowSpan - 1 }
+        val maxC = picked.maxOf { it.col + it.colSpan - 1 }
+        for (r in minR..maxR) for (c in minC..maxC) {
+            if (grid[r][c] !in selected) return null
+        }
+        return intArrayOf(minR, minC, maxR, maxC)
+    }
+
+    fun canMerge(): Boolean = mergeBox() != null
+
+    fun mergeSelection() {
+        val b = mergeBox() ?: return
+        val target = grid[b[0]][b[1]] // keep the top-left cell's content
+        for (r in b[0]..b[2]) for (c in b[1]..b[3]) grid[r][c] = target
+        purge()
+        selected.clear()
+        selected.add(target)
+        bump()
+    }
+
+    fun canSplit(): Boolean {
+        val id = selected.singleOrNull() ?: return false
+        val a = anchors().firstOrNull { it.id == id } ?: return false
+        return a.rowSpan > 1 || a.colSpan > 1
+    }
+
+    fun splitSelection() {
+        val id = selected.singleOrNull() ?: return
+        val a = anchors().firstOrNull { it.id == id } ?: return
+        val header = cells[id]?.isHeader == true
+        var first = true
+        for (r in a.row until a.row + a.rowSpan) for (c in a.col until a.col + a.colSpan) {
+            if (first) { first = false; continue } // top-left keeps the id + content
+            val nid = newId()
+            cells[nid] = CellContent("", header)
+            grid[r][c] = nid
+        }
+        bump()
+    }
+
+    // --- selection-relative helpers ---------------------------------------------------------
+
+    private fun selectedAnchors(): List<Anchor> = anchors().filter { it.id in selected }
+    private fun selectedRows(): List<Int> =
+        selectedAnchors().flatMap { it.row until it.row + it.rowSpan }.distinct()
+    private fun selectedCols(): List<Int> =
+        selectedAnchors().flatMap { it.col until it.col + it.colSpan }.distinct()
+
+    fun addRowRelative() = addRow((selectedRows().maxOrNull()?.plus(1)) ?: rows())
+    fun addColumnRelative() = addColumn((selectedCols().maxOrNull()?.plus(1)) ?: cols())
+    fun deleteSelectedRows() { if (selected.isNotEmpty()) deleteRows(selectedRows()) }
+    fun deleteSelectedColumns() { if (selected.isNotEmpty()) deleteColumns(selectedCols()) }
+
+    fun toggleHeaderSelected() {
+        if (selected.isEmpty()) return
+        val allHeader = selected.all { cells[it]?.isHeader == true }
+        selected.forEach { cells[it]?.isHeader = !allHeader }
+    }
+
+    private fun purge() {
+        val live = grid.flatten().toHashSet()
+        cells.keys.retainAll(live)
+        selected.removeAll { it !in live }
+    }
+
+    // --- serialization ----------------------------------------------------------------------
+
+    /** Serialize back to the ProseMirror `table` JSON shape carried by the embed's `rawJson`. */
+    fun toProseMirrorJson(): String {
+        val anchorMap = anchors().associateBy { it.id }
+        val root = buildJsonObject {
+            put("type", "table")
+            putJsonArray("content") {
+                for (r in 0 until rows()) {
+                    add(
+                        buildJsonObject {
+                            put("type", "tableRow")
+                            putJsonArray("content") {
+                                for (c in 0 until cols()) {
+                                    val id = grid[r][c]
+                                    val a = anchorMap[id] ?: continue
+                                    if (a.row != r || a.col != c) continue // emit only the anchor slot
+                                    val content = cells[id] ?: continue
+                                    add(
+                                        buildJsonObject {
+                                            put("type", if (content.isHeader) "tableHeader" else "tableCell")
+                                            putJsonObject("attrs") {
+                                                put("colspan", a.colSpan)
+                                                put("rowspan", a.rowSpan)
+                                                put("colwidth", JsonNull)
+                                            }
+                                            putJsonArray("content") { add(paragraphJson(content.text)) }
+                                        },
+                                    )
+                                }
+                            }
+                        },
+                    )
+                }
+            }
+        }
+        return root.toString()
+    }
+
+    companion object {
+        private val json = Json { ignoreUnknownKeys = true }
+
+        fun from(rawJson: String): EditableTableState =
+            runCatching { parse(rawJson) }.getOrNull() ?: default()
+
+        private fun default(): EditableTableState {
+            val grid = MutableList(3) { r -> MutableList(3) { c -> (r * 3 + c).toLong() } }
+            val cells = HashMap<Long, CellContent>()
+            for (r in 0..2) for (c in 0..2) {
+                val id = (r * 3 + c).toLong()
+                cells[id] = CellContent(if (r == 0) "Encabezado ${c + 1}" else "", r == 0)
+            }
+            return EditableTableState(grid, cells, 9L)
+        }
+
+        private fun parse(rawJson: String): EditableTableState {
+            val obj = json.parseToJsonElement(rawJson).jsonObject
+            require(obj["type"]?.jsonPrimitive?.content == "table")
+            val rowsJson = obj["content"]?.jsonArray ?: JsonArray(emptyList())
+
+            val grid: MutableList<MutableList<Long>> = ArrayList()
+            val cells = HashMap<Long, CellContent>()
+            var nextId = 0L
+
+            fun ensure(r: Int, c: Int) {
+                while (grid.size <= r) grid.add(ArrayList())
+                val row = grid[r]
+                while (row.size <= c) row.add(-1L)
+            }
+
+            fun get(r: Int, c: Int): Long {
+                if (r >= grid.size) return -1L
+                val row = grid[r]
+                if (c >= row.size) return -1L
+                return row[c]
+            }
+
+            fun set(r: Int, c: Int, id: Long) { ensure(r, c); grid[r][c] = id }
+
+            rowsJson.forEachIndexed { r, rowEl ->
+                ensure(r, 0)
+                val cs = rowEl.jsonObject["content"]?.jsonArray ?: JsonArray(emptyList())
+                var c = 0
+                cs.forEach { cellEl ->
+                    val cell = cellEl.jsonObject
+                    while (get(r, c) != -1L) c++
+                    val attrs = cell["attrs"]?.jsonObject
+                    val colspan = attrs?.get("colspan")?.jsonPrimitive?.content?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+                    val rowspan = attrs?.get("rowspan")?.jsonPrimitive?.content?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+                    val isHeader = cell["type"]?.jsonPrimitive?.content == "tableHeader"
+                    val id = nextId++
+                    cells[id] = CellContent(cellText(cell["content"]?.jsonArray), isHeader)
+                    for (dr in 0 until rowspan) for (dc in 0 until colspan) set(r + dr, c + dc, id)
+                    c += colspan
+                }
+            }
+
+            require(grid.isNotEmpty())
+            // Rectangularize: pad every row to the widest and fill any holes with fresh single cells.
+            val cols = grid.maxOf { it.size }.coerceAtLeast(1)
+            for (r in grid.indices) {
+                ensure(r, cols - 1)
+                val row = grid[r]
+                for (c in 0 until cols) {
+                    if (row[c] == -1L) {
+                        val id = nextId++
+                        cells[id] = CellContent("", false)
+                        row[c] = id
+                    }
+                }
+            }
+            return EditableTableState(grid, cells, nextId)
+        }
+    }
+}
+
+/** Concatenates all `text` leaves inside a cell's paragraph content. */
+private fun cellText(paragraphs: JsonArray?): String {
+    if (paragraphs == null) return ""
+    val builder = StringBuilder()
+    paragraphs.forEach { paragraph ->
+        paragraph.jsonObject["content"]?.jsonArray?.forEach { inline ->
+            inline.jsonObject["text"]?.jsonPrimitive?.content?.let { builder.append(it) }
+        }
+    }
+    return builder.toString()
+}
+
+private fun paragraphJson(text: String): JsonObject = buildJsonObject {
+    put("type", "paragraph")
+    putJsonArray("content") {
+        if (text.isNotEmpty()) {
+            add(buildJsonObject { put("type", "text"); put("text", text) })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Previews
+// ---------------------------------------------------------------------------------------------
+
+private const val SampleTableJson = """
+{
+  "type": "table",
+  "content": [
+    { "type": "tableRow", "content": [
+      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Producto"}]}] },
+      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Región"}]}] },
+      { "type": "tableHeader", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Ventas"}]}] }
+    ]},
+    { "type": "tableRow", "content": [
+      { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Laptop"}]}] },
+      { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Norte"}]}] },
+      { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"1200"}]}] }
+    ]},
+    { "type": "tableRow", "content": [
+      { "type": "tableCell", "attrs": {"colspan": 2, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"Total parcial"}]}] },
+      { "type": "tableCell", "attrs": {"colspan": 1, "rowspan": 1, "colwidth": null}, "content": [{"type":"paragraph","content":[{"type":"text","text":"1200"}]}] }
+    ]}
+  ]
+}
+"""
+
+@Preview(showBackground = true, backgroundColor = 0xFFF5FBF7, widthDp = 560, heightDp = 620)
+@Composable
+private fun TextKitEditableTablePreview() {
+    var synced by remember { mutableStateOf("") }
+
+    TextKitTheme(darkTheme = false) {
+        Column(
+            modifier = Modifier
+                .background(TextKitTheme.colors.background)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            TextKitEditableTable(
+                rawJson = SampleTableJson,
+                onSync = { synced = it },
+            )
+            if (synced.isNotEmpty()) {
+                HorizontalDivider(color = TextKitTheme.colors.outlineVariant)
+                Text(
+                    text = "JSON sincronizado",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = TextKitTheme.colors.onBackground,
+                )
+                Text(
+                    text = synced,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextKitTheme.colors.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF0E1513, widthDp = 560, heightDp = 460)
+@Composable
+private fun TextKitEditableTableDarkPreview() {
+    TextKitTheme(darkTheme = true) {
+        Column(
+            modifier = Modifier
+                .background(TextKitTheme.colors.background)
+                .padding(16.dp),
+        ) {
+            TextKitEditableTable(rawJson = SampleTableJson, onSync = {})
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitFormatting.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitFormatting.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Article
+import androidx.compose.material.icons.automirrored.rounded.FormatAlignLeft
 import androidx.compose.material.icons.automirrored.rounded.FormatListBulleted
 import androidx.compose.material.icons.automirrored.rounded.Redo
 import androidx.compose.material.icons.automirrored.rounded.Undo
@@ -68,6 +69,7 @@ import com.jjrodcast.textkit.ui.state.rememberTextKitFormattingBarState
 import com.jjrodcast.textkit.ui.utils.TextKitPickerPallete
 import org.jetbrains.compose.resources.stringResource
 import textkit.shared.generated.resources.Res
+import textkit.shared.generated.resources.align_text
 import textkit.shared.generated.resources.bold_text
 import textkit.shared.generated.resources.bulleted_list_text
 import textkit.shared.generated.resources.document_text
@@ -120,6 +122,7 @@ fun TextKitFormattingBar(
     onDocumentClick: (Boolean) -> Unit = {},
     onOrderedListClick: (Boolean) -> Unit = {},
     onBulletedListClick: (Boolean) -> Unit = {},
+    onTextAlignClick: (Rect) -> Unit = {},
     onTextAndColorClick: (Rect) -> Unit = {},
     onUndoClick: () -> Unit = {},
     onRedoClick: () -> Unit = {},
@@ -141,6 +144,7 @@ fun TextKitFormattingBar(
         onDocumentClick = onDocumentClick,
         onOrderedListClick = onOrderedListClick,
         onBulletedListClick = onBulletedListClick,
+        onTextAlignClick = onTextAlignClick,
         onUndoClick = onUndoClick,
         onRedoClick = onRedoClick,
         canUndo = canUndo,
@@ -165,12 +169,14 @@ fun TextKitFormattingBarInternal(
     onDocumentClick: (Boolean) -> Unit = {},
     onOrderedListClick: (Boolean) -> Unit = {},
     onBulletedListClick: (Boolean) -> Unit = {},
+    onTextAlignClick: (Rect) -> Unit = {},
     onUndoClick: () -> Unit = {},
     onRedoClick: () -> Unit = {},
     canUndo: Boolean = false,
     canRedo: Boolean = false
 ) {
     var textSizeAndColorBounds by remember { mutableStateOf(Rect.Zero) }
+    var textAlignBounds by remember { mutableStateOf(Rect.Zero) }
 
     Card(
         modifier = modifier.padding(4.dp),
@@ -260,6 +266,17 @@ fun TextKitFormattingBarInternal(
                 onClick = onBulletedListClick,
                 value = barState.isBulletedList,
                 backgroundColor = selectedColor
+            )
+            TextKitFormattingSeparator()
+            TextKitTooltipFormattingItem(
+                tooltipText = stringResource(Res.string.align_text),
+                rememberVectorPainter(Icons.AutoMirrored.Rounded.FormatAlignLeft),
+                value = false,
+                isExpandable = true,
+                onClick = { onTextAlignClick(textAlignBounds) },
+                modifier = Modifier.onGloballyPositioned {
+                    textAlignBounds = it.boundsInWindow()
+                }
             )
             TextKitFormattingSeparator()
             TextKitFormattingDivider()
@@ -419,7 +436,7 @@ fun TextKitFormattingDivider(
 }
 
 @Composable
-private fun TextKitFormattingSeparator(
+internal fun TextKitFormattingSeparator(
     modifier: Modifier = Modifier
 ) {
     Spacer(

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitFormatting.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitFormatting.kt
@@ -210,7 +210,7 @@ fun TextKitFormattingBarInternal(
             TextKitFormattingSeparator()
             TextKitTooltipFormattingItem(
                 tooltipText = stringResource(Res.string.underline_text),
-                rememberVectorPainter(Icons.Rounded.FormatUnderlined),
+                painter = rememberVectorPainter(Icons.Rounded.FormatUnderlined),
                 onClick = onUnderlineClick,
                 value = barState.isUnderline,
                 backgroundColor = selectedColor
@@ -218,7 +218,7 @@ fun TextKitFormattingBarInternal(
             TextKitFormattingSeparator()
             TextKitTooltipFormattingItem(
                 tooltipText = stringResource(Res.string.strikethrough_text),
-                rememberVectorPainter(Icons.Rounded.FormatStrikethrough),
+                painter = rememberVectorPainter(Icons.Rounded.FormatStrikethrough),
                 onClick = onStrikeThroughClick,
                 value = barState.isStrikethrough,
                 backgroundColor = selectedColor
@@ -226,7 +226,7 @@ fun TextKitFormattingBarInternal(
             TextKitFormattingSeparator()
             TextKitTooltipFormattingItem(
                 tooltipText = stringResource(Res.string.highlight_text),
-                rememberVectorPainter(Icons.Rounded.FormatColorFill),
+                painter = rememberVectorPainter(Icons.Rounded.FormatColorFill),
                 onClick = onHighlightClick,
                 value = barState.isHighlight,
                 backgroundColor = selectedColor
@@ -234,7 +234,7 @@ fun TextKitFormattingBarInternal(
             TextKitFormattingSeparator()
             TextKitTooltipFormattingItem(
                 tooltipText = stringResource(Res.string.text_color_text),
-                rememberVectorPainter(Icons.Outlined.Palette),
+                painter = rememberVectorPainter(Icons.Outlined.Palette),
                 value = false,
                 isExpandable = true,
                 onClick = { onSizeAndColorClick(textSizeAndColorBounds) },
@@ -246,7 +246,7 @@ fun TextKitFormattingBarInternal(
             TextKitFormattingSeparator()
             TextKitTooltipFormattingItem(
                 tooltipText = stringResource(Res.string.link_text),
-                rememberVectorPainter(Icons.Rounded.Link),
+                painter = rememberVectorPainter(Icons.Rounded.Link),
                 onClick = onLinkClick,
                 value = barState.isLink,
                 backgroundColor = selectedColor
@@ -254,7 +254,7 @@ fun TextKitFormattingBarInternal(
             TextKitFormattingSeparator()
             TextKitTooltipFormattingItem(
                 tooltipText = stringResource(Res.string.ordered_list_text),
-                rememberVectorPainter(Icons.Rounded.FormatListNumbered),
+                painter = rememberVectorPainter(Icons.Rounded.FormatListNumbered),
                 onClick = onOrderedListClick,
                 value = barState.isNumberedList,
                 backgroundColor = selectedColor
@@ -262,7 +262,7 @@ fun TextKitFormattingBarInternal(
             TextKitFormattingSeparator()
             TextKitTooltipFormattingItem(
                 tooltipText = stringResource(Res.string.bulleted_list_text),
-                rememberVectorPainter(Icons.AutoMirrored.Rounded.FormatListBulleted),
+                painter = rememberVectorPainter(Icons.AutoMirrored.Rounded.FormatListBulleted),
                 onClick = onBulletedListClick,
                 value = barState.isBulletedList,
                 backgroundColor = selectedColor
@@ -270,7 +270,7 @@ fun TextKitFormattingBarInternal(
             TextKitFormattingSeparator()
             TextKitTooltipFormattingItem(
                 tooltipText = stringResource(Res.string.align_text),
-                rememberVectorPainter(Icons.AutoMirrored.Rounded.FormatAlignLeft),
+                painter = rememberVectorPainter(Icons.AutoMirrored.Rounded.FormatAlignLeft),
                 value = false,
                 isExpandable = true,
                 onClick = { onTextAlignClick(textAlignBounds) },
@@ -308,7 +308,7 @@ fun TextKitFormattingBarInternal(
             TextKitFormattingDivider()
             TextKitTooltipFormattingItem(
                 tooltipText = stringResource(Res.string.undo_text),
-                rememberVectorPainter(Icons.AutoMirrored.Rounded.Undo),
+                painter = rememberVectorPainter(Icons.AutoMirrored.Rounded.Undo),
                 onClick = { onUndoClick() },
                 value = false,
                 backgroundColor = selectedColor,
@@ -317,7 +317,7 @@ fun TextKitFormattingBarInternal(
             TextKitFormattingSeparator()
             TextKitTooltipFormattingItem(
                 tooltipText = stringResource(Res.string.redo_text),
-                rememberVectorPainter(Icons.AutoMirrored.Rounded.Redo),
+                painter = rememberVectorPainter(Icons.AutoMirrored.Rounded.Redo),
                 onClick = { onRedoClick() },
                 value = false,
                 backgroundColor = selectedColor,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -1165,11 +1165,6 @@ class TextKitState(
 
     private fun updateAnnotatedString(selection: TextRange) {
         annotatedString = defaultAnnotatedStringFormatting().withLinkHighlight()
-        // The field text keeps the real '\n' (the piece table / offsets / selection are indexed by
-        // it). The displayed string renders each '\n' as a zero-width space of the SAME length (see
-        // [defaultAnnotatedStringFormatting]), so OffsetMapping stays Identity — cursor and piece-table
-        // offsets line up 1:1 — while the per-paragraph ParagraphStyle boundary provides the line break
-        // without an extra empty gap line.
         val text = manager.text
         val coerced = TextRange(
             start = selection.start.coerceIn(0, text.length),

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -53,12 +53,14 @@ import com.jjrodcast.textkit.editor.core.parser.LinkAttrs
 import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.parser.StrikeMark
+import com.jjrodcast.textkit.editor.core.parser.TextAlign as TextKitTextAlign
 import com.jjrodcast.textkit.editor.core.parser.TextStyleAttrs
 import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
 import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
 import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel
 import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel.Companion.createDecoratorString
 import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorAction
+import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorItem
 import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorSelectedMark
 import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorTransactionType
 import com.jjrodcast.textkit.editor.core.transactions.text.TextTransaction
@@ -169,6 +171,14 @@ class TextKitState(
             ?.let { runCatching { Color(it.toColorInt()) }.getOrNull() }
 
     /**
+     * Horizontal alignment of the paragraph(s) at the caret/selection, captured alongside [lastMarks]
+     * when the selection moves. `null` means a "mixed" selection (paragraphs with differing
+     * alignment). Observe it to mark the active alignment button in the formatting bar.
+     */
+    var currentTextAlign by mutableStateOf<TextKitTextAlign?>(TextKitTextAlign.Left)
+        private set
+
+    /**
      * Window-coordinate bounds the colors popup is anchored to while open, or null when it is closed.
      * Mirrors the [activeLink] pattern: observe it to show
      * [com.jjrodcast.textkit.ui.TextKitColorsPopup], which reads [currentTextColor] to mark the active
@@ -177,7 +187,10 @@ class TextKitState(
     var activeColorAnchor by mutableStateOf<Rect?>(null)
         private set
 
-    /** Opens the colors popup anchored at [anchor] (e.g. the formatting bar's palette button bounds). */
+    var activeAlignAnchor by mutableStateOf<Rect?>(null)
+        private set
+
+    /** Opens the colors popup anchored at [activeColorAnchor] (e.g. the formatting bar's palette button bounds). */
     fun openColorPicker(anchor: Rect) {
         activeColorAnchor = anchor
     }
@@ -185,6 +198,16 @@ class TextKitState(
     /** Closes the colors popup. */
     fun dismissColorPicker() {
         activeColorAnchor = null
+    }
+
+    /** Opens the alignment popup anchored at [activeAlignAnchor] (e.g. the formatting bar's alignment button bounds). */
+    fun openAlignPicker(anchor: Rect) {
+        activeAlignAnchor = anchor
+    }
+
+    /** Closes the align popup */
+    fun dismissAlignPicker() {
+        activeAlignAnchor = null
     }
 
     internal var textLayoutResult: TextLayoutResult? by mutableStateOf(null)
@@ -450,7 +473,7 @@ class TextKitState(
             val size = (lastMarks.firstOrNull { it is TextStyleMark } as? TextStyleMark)
                 ?.attrs?.fontSize ?: configuration.fontSize
             lastMarks = lastMarks.filterNotTo(mutableSetOf()) { it is TextStyleMark } +
-                TextStyleMark(TextStyleAttrs(color = color, fontSize = size))
+                    TextStyleMark(TextStyleAttrs(color = color, fontSize = size))
             return true
         }
         // The Color transaction resolves the marks from the selection itself (preserving font size),
@@ -482,6 +505,19 @@ class TextKitState(
         }
         return applyTextStyle(fontSize = fontSize, color = null)
     }
+
+    /**
+     * Sets the horizontal [textAlign] of the paragraph(s) the current selection touches. Routed as an
+     * alignment change (not a mark), so it applies to whole paragraphs even with a collapsed caret.
+     * Returns whether the document changed.
+     */
+    fun applyTextAlignment(textAlign: TextKitTextAlign): Boolean =
+        updateDocument(
+            selection,
+            TextEditorSelectedMark.NONE,
+            TextEditorSelectedMark.NONE,
+            TextEditorTransactionType.Alignment(textAlign)
+        )
 
     /**
      * Toggles an ordered (numbered) list over the paragraph(s) the current selection touches,
@@ -765,6 +801,7 @@ class TextKitState(
         val searchType = getSelectedMarksWithType()
         lastMarks = searchType.marks
         lastListItem = searchType.listItem
+        currentTextAlign = searchType.textAlign
         lastEmbedType = embedTypeAtCaret()
         updateLinkHighlight(searchType)
         notifyLinkAtSelection(searchType)
@@ -1128,11 +1165,12 @@ class TextKitState(
 
     private fun updateAnnotatedString(selection: TextRange) {
         annotatedString = defaultAnnotatedStringFormatting().withLinkHighlight()
-        val text = annotatedString.text
-        // Build the field value with the NEW text and the selection together so the selection is
-        // validated against the new length. Applying it via `copy(selection = …)` on the old (shorter)
-        // value clamps it to the OLD length first — e.g. after adding list decorators the selection
-        // would stop short of the new end instead of covering the whole (now longer) document.
+        // The field text keeps the real '\n' (the piece table / offsets / selection are indexed by
+        // it). The displayed string renders each '\n' as a zero-width space of the SAME length (see
+        // [defaultAnnotatedStringFormatting]), so OffsetMapping stays Identity — cursor and piece-table
+        // offsets line up 1:1 — while the per-paragraph ParagraphStyle boundary provides the line break
+        // without an extra empty gap line.
+        val text = manager.text
         val coerced = TextRange(
             start = selection.start.coerceIn(0, text.length),
             end = selection.end.coerceIn(0, text.length),
@@ -1145,6 +1183,7 @@ class TextKitState(
     /**
      * Paints the active [linkSelectionRange] as a translucent background so a tapped link reads
      * like a highlight (no selection handles). Returns the string unchanged when no link is active.
+     * Offsets are identity (display length == field length), so the field range is used directly.
      */
     private fun AnnotatedString.withLinkHighlight(): AnnotatedString {
         val range = linkSelectionRange ?: return this
@@ -1160,24 +1199,17 @@ class TextKitState(
     }
 
     private fun defaultAnnotatedStringFormatting(): AnnotatedString {
+        val fieldLength = manager.text.length
         return buildAnnotatedString {
-            // A single ParagraphStyle wraps the whole document. Wrapping each paragraph in its own
-            // ParagraphStyle turned every trailing '\n' into a full-height empty line (visible as
-            // large gaps between paragraphs); keeping one paragraph block makes the '\n' plain line
-            // breaks (single spacing) while every character — and thus the offset mapping — is kept.
-            withStyle(DefaultParagraphStyle) {
-                paragraphs.forEach { paragraph ->
+            // One ParagraphStyle per paragraph so each can carry its own horizontal alignment —
+            // `textAlign` is a ParagraphStyle-only property in Compose, so per-paragraph alignment is
+            // impossible with a single document-wide block. See [displayTextOf] for how the separating
+            // '\n' is rendered so there is no gap line and the caret behaves correctly.
+            paragraphs.forEach { paragraph ->
+                withStyle(DefaultParagraphStyle.copy(textAlign = paragraph.textAlign.toComposeTextAlign())) {
                     paragraph.children.forEach { child ->
-                        if (child.text.endsWith(lineBreak)) {
-                            val text = child.text.dropLast(1)
-                            withStyle(child.createStyle(manager.configuration, highlightColor)) {
-                                append(text)
-                            }
-                            append(lineBreak)
-                        } else {
-                            withStyle(child.createStyle(manager.configuration, highlightColor)) {
-                                append(child.text)
-                            }
+                        withStyle(child.createStyle(manager.configuration, highlightColor)) {
+                            append(displayTextOf(child, fieldLength))
                         }
                     }
                 }
@@ -1185,16 +1217,26 @@ class TextKitState(
         }
     }
 
+    /** Maps the engine's paragraph [TextKitTextAlign] to Compose's [TextAlign] for a [ParagraphStyle]. */
+    private fun TextKitTextAlign.toComposeTextAlign(): TextAlign = when (this) {
+        TextKitTextAlign.Left -> TextAlign.Left
+        TextKitTextAlign.Center -> TextAlign.Center
+        TextKitTextAlign.Right -> TextAlign.Right
+        TextKitTextAlign.Justify -> TextAlign.Justify
+    }
+
     private fun createViewerAnnotatedString(): Pair<AnnotatedString, Map<String, InlineTextContent>> {
         val inlineContent = mutableMapOf<String, InlineTextContent>()
+        val fieldLength = manager.text.length
         val annotatedString = buildAnnotatedString {
-            withStyle(DefaultParagraphStyle) {
-                paragraphs.forEach { paragraph ->
+            // Same per-paragraph pattern as edit mode: one aligned ParagraphStyle per paragraph, with
+            // the separating '\n' rendered per [displayTextOf] (no gap line). The viewer is read-only
+            // (no TextField / OffsetMapping), so styles are applied to the appended run via
+            // withStyle/withLink instead of by field offsets.
+            paragraphs.forEach { paragraph ->
+                withStyle(DefaultParagraphStyle.copy(textAlign = paragraph.textAlign.toComposeTextAlign())) {
                     paragraph.children.forEach { child ->
                         val id = "${child.start}-${child.end}"
-                        val text = if (child.text.endsWith(lineBreak)) {
-                            child.text
-                        } else child.text
                         if (child.decorator is TextDecoratorModel.TaskDecoratorModel) {
                             val taskDecorator = child.decorator
                             appendInlineContent(id, taskDecorator.createDecoratorString())
@@ -1214,13 +1256,19 @@ class TextKitState(
                                 }
                             }
                         } else {
-                            pushStringAnnotation(id, text)
+                            val content = displayTextOf(child, fieldLength)
+                            pushStringAnnotation(id, content)
                             if (child.marks.any { it is LinkMark }) {
                                 withLink(
                                     link = LinkAnnotation.Url(
                                         url = child.marks.filterIsInstance<LinkMark>()
                                             .first().attrs.href,
-                                        styles = TextLinkStyles(child.createStyle(manager.configuration, highlightColor)),
+                                        styles = TextLinkStyles(
+                                            child.createStyle(
+                                                manager.configuration,
+                                                highlightColor
+                                            )
+                                        ),
                                         linkInteractionListener = {
                                             val url = (it as LinkAnnotation.Url).url
                                             onUrlClicked?.invoke(
@@ -1231,15 +1279,12 @@ class TextKitState(
                                         }
                                     )
                                 ) {
-                                    append(text)
+                                    append(content)
                                 }
                             } else {
-                                append(text)
-                                addStyle(
-                                    style = child.createStyle(manager.configuration, highlightColor),
-                                    start = child.start,
-                                    end = child.end
-                                )
+                                withStyle(child.createStyle(manager.configuration, highlightColor)) {
+                                    append(content)
+                                }
                             }
                             pop()
                         }
@@ -1384,5 +1429,38 @@ class TextKitState(
         )
     }
 
-    private val lineBreak = "\n"
+    /**
+     * The text a [child] contributes to the DISPLAY string.
+     *
+     * Every paragraph-separating '\n' becomes a [PARAGRAPH_SEPARATOR_CHAR] (a space), EXCEPT a '\n'
+     * that is the very last character of the document: that one is kept real so a trailing empty
+     * paragraph still renders as a blank line the caret can land on. (A space is not a line break, so
+     * converting the final '\n' would drop that trailing blank line.) All replacements are 1:1 in
+     * length, so the display length equals the field text and [OffsetMapping.Identity] stays valid.
+     */
+    private fun displayTextOf(child: TextEditorItem, fieldLength: Int): String {
+        val endsDocument = child.end == fieldLength && child.text.endsWith(LINE_BREAK_CHAR)
+        return if (endsDocument) {
+            child.text.dropLast(1).replace(LINE_BREAK_CHAR, PARAGRAPH_SEPARATOR_CHAR) + LINE_BREAK_CHAR
+        } else {
+            child.text.replace(LINE_BREAK_CHAR, PARAGRAPH_SEPARATOR_CHAR)
+        }
+    }
+
+    private val LINE_BREAK_CHAR = '\n'
+
+    /**
+     * The paragraph-separating '\n' is shown in the DISPLAY as a regular space. A space:
+     *  - is NOT a line break, so the per-paragraph ParagraphStyle boundary is the only break — no
+     *    extra empty "gap" line between paragraphs;
+     *  - HAS width, so the caret at the end of a paragraph (before the space) is a distinct target
+     *    from the start of the next paragraph (after it). A zero-width char collapses both to the same
+     *    x, so Compose resolved the end of a line to the next paragraph (the caret jumped down); the
+     *    width also makes empty-paragraph lines clickable;
+     *  - is one character, so the display length equals the field text (which keeps the real '\n'),
+     *    so OffsetMapping.Identity stays valid and every offset maps 1:1 to the piece table.
+     *
+     * A trailing space at a line end is not painted, so it stays visually invisible.
+     */
+    private val PARAGRAPH_SEPARATOR_CHAR = ' '
 }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/CurrentTextAlignTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/CurrentTextAlignTest.kt
@@ -1,0 +1,139 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.style.TextAlign as ComposeTextAlign
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
+import com.jjrodcast.textkit.editor.models.createTextKitConfiguration
+import com.jjrodcast.textkit.ui.state.TextKitState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CurrentTextAlignTest {
+
+    private fun stateWith(json: String): TextKitState =
+        TextKitState(json, createTextKitConfiguration()).apply { setup() }
+
+    private fun TextKitState.caretAt(offset: Int) =
+        onTextFieldChange(textFieldValue.copy(selection = TextRange(offset)))
+
+    private fun TextKitState.selectAll() =
+        onTextFieldChange(textFieldValue.copy(selection = TextRange(0, textFieldValue.text.length)))
+
+    private fun docWithAlign(align: String) = """
+        {"type":"doc","content":[
+          {"type":"paragraph","attrs":{"textAlign":"$align"},"content":[{"type":"text","text":"Hello world"}]}
+        ]}
+    """
+
+    private val mixedAlignments = """
+        {"type":"doc","content":[
+          {"type":"paragraph","attrs":{"textAlign":"left"},"content":[{"type":"text","text":"left one"}]},
+          {"type":"paragraph","attrs":{"textAlign":"center"},"content":[{"type":"text","text":"center two"}]}
+        ]}
+    """
+
+    @Test
+    fun reflectsCenterAlignmentAtCaret() {
+        val state = stateWith(docWithAlign("center"))
+        state.caretAt(3)
+        assertEquals(TextAlign.Center, state.currentTextAlign)
+    }
+
+    @Test
+    fun plainParagraphReadsAsLeft() {
+        val state = stateWith(SampleDocuments.SINGLE_PARAGRAPH)
+        state.caretAt(3)
+        assertEquals(TextAlign.Left, state.currentTextAlign)
+    }
+
+    @Test
+    fun mixedSelectionReadsAsNull() {
+        val state = stateWith(mixedAlignments)
+        state.selectAll()
+        assertNull(state.currentTextAlign, "a selection spanning differing alignments is mixed")
+    }
+
+    @Test
+    fun updatesAfterApplyingAlignment() {
+        val state = stateWith(SampleDocuments.SINGLE_PARAGRAPH)
+        state.caretAt(3)
+        assertEquals(TextAlign.Left, state.currentTextAlign)
+
+        state.applyTextAlignment(TextAlign.Right)
+
+        assertEquals(TextAlign.Right, state.currentTextAlign)
+    }
+
+    @Test
+    fun displayRendersNewlineAsSpaceKeepingIdentityOffsets() {
+        val state = stateWith(SampleDocuments.TWO_PARAGRAPHS)
+        val fieldText = state.textFieldValue.text
+        assertTrue(fieldText.contains("\n"), "field text keeps the paragraph separator: \"$fieldText\"")
+
+        val transformed = state.visualTransformation.filter(AnnotatedString(fieldText))
+
+        // The '\n' is shown as a (width-having, but visually invisible) space, so there is no gap line
+        // and the caret can distinguish end-of-paragraph from start-of-next. Same length as the field,
+        // so OffsetMapping stays Identity: every offset maps 1:1 to the piece table.
+        assertEquals(fieldText.replace('\n', ' '), transformed.text.text)
+        assertEquals(fieldText.length, transformed.text.length)
+        val nl = fieldText.indexOf('\n')
+        assertEquals(nl, transformed.offsetMapping.originalToTransformed(nl))
+        assertEquals(nl + 1, transformed.offsetMapping.transformedToOriginal(nl + 1))
+        assertEquals(fieldText.length, transformed.offsetMapping.originalToTransformed(fieldText.length))
+    }
+
+    @Test
+    fun emptyParagraphGetsClickableLine() {
+        val doc = """
+            {"type":"doc","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"A"}]},
+              {"type":"paragraph"},
+              {"type":"paragraph","content":[{"type":"text","text":"B"}]}
+            ]}
+        """
+        val state = stateWith(doc)
+        val fieldText = state.textFieldValue.text // "A\n\nB"
+        val display = state.visualTransformation.filter(AnnotatedString(fieldText)).text.text
+
+        assertEquals(fieldText.length, display.length) // identity preserved
+        // Every '\n' \u2014 the paragraph boundaries and the empty paragraph \u2014 becomes a clickable space.
+        assertEquals("A  B", display)
+    }
+
+    @Test
+    fun trailingEmptyParagraphKeepsRealNewline() {
+        val doc = """
+            {"type":"doc","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"A"}]},
+              {"type":"paragraph"}
+            ]}
+        """
+        val state = stateWith(doc)
+        val fieldText = state.textFieldValue.text
+        val display = state.visualTransformation.filter(AnnotatedString(fieldText)).text.text
+
+        assertEquals(fieldText.length, display.length) // identity preserved
+        // A '\n' at the very end of the document stays a real newline so the trailing empty paragraph
+        // renders as a blank line the caret can land on (a space would not create that line).
+        assertTrue(fieldText.endsWith('\n'), "field text: \"$fieldText\"")
+        assertTrue(display.endsWith('\n'), "display: \"$display\"")
+    }
+
+    @Test
+    fun viewerAppliesPerParagraphAlignment() {
+        val state = stateWith(mixedAlignments)
+        val (annotated, _) = state.viewerTextValue
+
+        // Read-only view also shows '\n' as a space (no gap line), length preserved.
+        assertEquals(state.textFieldValue.text.replace('\n', ' '), annotated.text)
+
+        // Each paragraph gets its own ParagraphStyle; the second one is centered.
+        val aligns = annotated.paragraphStyles.map { it.item.textAlign }
+        assertTrue(aligns.contains(ComposeTextAlign.Center), "expected a centered paragraph: $aligns")
+        assertTrue(aligns.contains(ComposeTextAlign.Left), "expected a left paragraph: $aligns")
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
@@ -55,7 +55,7 @@ class HtmlSerializerTest {
         HtmlSerializer().serialize(TextEditorDocument(blocks.toList()))
 
     private fun paragraphOf(text: String, marks: Set<Mark> = emptySet()) =
-        Paragraph(listOf(Text(text, marks)))
+        Paragraph(content = listOf(Text(text, marks)))
 
     // ── Blocks ───────────────────────────────────────────────────────────────
 
@@ -148,11 +148,11 @@ class HtmlSerializerTest {
 
         assertEquals(
             "<ul data-type=\"taskList\">" +
-                "<li data-type=\"taskItem\" data-checked=\"false\">" +
-                "<input type=\"checkbox\"><p>buy milk</p></li>" +
-                "<li data-type=\"taskItem\" data-checked=\"true\">" +
-                "<input type=\"checkbox\" checked><p>walk dog</p></li>" +
-                "</ul>",
+                    "<li data-type=\"taskItem\" data-checked=\"false\">" +
+                    "<input type=\"checkbox\"><p>buy milk</p></li>" +
+                    "<li data-type=\"taskItem\" data-checked=\"true\">" +
+                    "<input type=\"checkbox\" checked><p>walk dog</p></li>" +
+                    "</ul>",
             output,
         )
         // The checkbox must stay interactive — never rendered disabled.
@@ -171,7 +171,7 @@ class HtmlSerializerTest {
     fun exports_a_hard_break() {
         assertEquals(
             "<p>a<br>b</p>",
-            html(Paragraph(listOf(Text("a"), HardBreak(), Text("b")))),
+            html(Paragraph(content = listOf(Text("a"), HardBreak(), Text("b")))),
         )
     }
 
@@ -242,7 +242,12 @@ class HtmlSerializerTest {
     fun omits_a_text_style_mark_that_carries_neither_colour_nor_size() {
         assertEquals(
             "<p>plain</p>",
-            html(paragraphOf("plain", setOf(TextStyleMark(TextStyleAttrs(color = "", fontSize = 0))))),
+            html(
+                paragraphOf(
+                    "plain",
+                    setOf(TextStyleMark(TextStyleAttrs(color = "", fontSize = 0)))
+                )
+            ),
         )
     }
 
@@ -250,7 +255,12 @@ class HtmlSerializerTest {
     fun exports_only_the_half_of_a_text_style_mark_that_is_set() {
         assertEquals(
             "<p><span style=\"color:#00FF00\">green</span></p>",
-            html(paragraphOf("green", setOf(TextStyleMark(TextStyleAttrs(color = "#00FF00", fontSize = 0))))),
+            html(
+                paragraphOf(
+                    "green",
+                    setOf(TextStyleMark(TextStyleAttrs(color = "#00FF00", fontSize = 0)))
+                )
+            ),
         )
     }
 
@@ -260,13 +270,13 @@ class HtmlSerializerTest {
     fun exports_tokens_with_their_label_and_identity() {
         assertEquals(
             "<p>" +
-                "<span data-type=\"mention\" data-id=\"1\">@ada</span>" +
-                " " +
-                "<span data-type=\"hashtag\" data-id=\"2\">#kotlin</span>" +
-                "</p>",
+                    "<span data-type=\"mention\" data-id=\"1\">@ada</span>" +
+                    " " +
+                    "<span data-type=\"hashtag\" data-id=\"2\">#kotlin</span>" +
+                    "</p>",
             html(
                 Paragraph(
-                    listOf(
+                    content = listOf(
                         Mention(TokenAttrs(id = "1", label = "ada")),
                         Text(" "),
                         Hashtag(TokenAttrs(id = "2", label = "kotlin")),
@@ -282,7 +292,12 @@ class HtmlSerializerTest {
             "<p><strong><span data-type=\"mention\" data-id=\"7\">@ada</span></strong></p>",
             html(
                 Paragraph(
-                    listOf(Mention(TokenAttrs(id = "7", label = "ada"), marks = setOf(BoldMark()))),
+                    content = listOf(
+                        Mention(
+                            TokenAttrs(id = "7", label = "ada"),
+                            marks = setOf(BoldMark())
+                        )
+                    ),
                 ),
             ),
         )
@@ -292,7 +307,7 @@ class HtmlSerializerTest {
     fun escapes_a_token_label_and_id() {
         assertEquals(
             "<p><span data-type=\"mention\" data-id=\"a&quot;b\">@a&lt;b</span></p>",
-            html(Paragraph(listOf(Mention(TokenAttrs(id = "a\"b", label = "a<b"))))),
+            html(Paragraph(content = listOf(Mention(TokenAttrs(id = "a\"b", label = "a<b"))))),
         )
     }
 
@@ -317,9 +332,9 @@ class HtmlSerializerTest {
 
         assertEquals(
             "<table>" +
-                "<tr><th><p>Name</p></th></tr>" +
-                "<tr><td><p>Juan</p></td></tr>" +
-                "</table>",
+                    "<tr><th><p>Name</p></th></tr>" +
+                    "<tr><td><p>Juan</p></td></tr>" +
+                    "</table>",
             editorFrom(json).toHtml(),
         )
     }
@@ -341,9 +356,9 @@ class HtmlSerializerTest {
 
         assertEquals(
             "<table><tr>" +
-                "<td colspan=\"2\"><p>wide</p></td>" +
-                "<td><p>narrow</p></td>" +
-                "</tr></table>",
+                    "<td colspan=\"2\"><p>wide</p></td>" +
+                    "<td><p>narrow</p></td>" +
+                    "</tr></table>",
             editorFrom(json).toHtml(),
         )
     }
@@ -397,7 +412,12 @@ class HtmlSerializerTest {
     fun escapes_quotes_and_ampersands_in_a_link_href() {
         assertEquals(
             "<p><a href=\"https://test.com/?q=&quot;x&quot;&amp;y=1\">tricky</a></p>",
-            html(paragraphOf("tricky", setOf(LinkMark(LinkAttrs("https://test.com/?q=\"x\"&y=1"))))),
+            html(
+                paragraphOf(
+                    "tricky",
+                    setOf(LinkMark(LinkAttrs("https://test.com/?q=\"x\"&y=1")))
+                )
+            ),
         )
     }
 
@@ -441,16 +461,38 @@ class HtmlSerializerTest {
     fun emits_a_valid_hex_colour_but_drops_anything_else() {
         assertEquals(
             "<p><span style=\"color:#ABC\">x</span></p>",
-            html(paragraphOf("x", setOf(TextStyleMark(TextStyleAttrs(color = "#ABC", fontSize = 0))))),
+            html(
+                paragraphOf(
+                    "x",
+                    setOf(TextStyleMark(TextStyleAttrs(color = "#ABC", fontSize = 0)))
+                )
+            ),
         )
         // An injection attempt through the colour is not a valid hex value, so it is dropped entirely.
         assertEquals(
             "<p>x</p>",
-            html(paragraphOf("x", setOf(TextStyleMark(TextStyleAttrs(color = "#fff;background:url(x)", fontSize = 0))))),
+            html(
+                paragraphOf(
+                    "x",
+                    setOf(
+                        TextStyleMark(
+                            TextStyleAttrs(
+                                color = "#fff;background:url(x)",
+                                fontSize = 0
+                            )
+                        )
+                    )
+                )
+            ),
         )
         assertEquals(
             "<p>x</p>",
-            html(paragraphOf("x", setOf(TextStyleMark(TextStyleAttrs(color = "red", fontSize = 0))))),
+            html(
+                paragraphOf(
+                    "x",
+                    setOf(TextStyleMark(TextStyleAttrs(color = "red", fontSize = 0)))
+                )
+            ),
         )
     }
 
@@ -462,14 +504,21 @@ class HtmlSerializerTest {
         )
         assertEquals(
             "<p>x</p>",
-            html(paragraphOf("x", setOf(TextStyleMark(TextStyleAttrs(color = "", fontSize = 100_000))))),
+            html(
+                paragraphOf(
+                    "x",
+                    setOf(TextStyleMark(TextStyleAttrs(color = "", fontSize = 100_000)))
+                )
+            ),
         )
     }
 
     @Test
     fun clamps_a_non_positive_ordered_list_start() {
-        val zeroStart = OrderedList(ListAttrs(start = 0), listOf(ListItem(listOf(paragraphOf("a")))))
-        val negativeStart = OrderedList(ListAttrs(start = -3), listOf(ListItem(listOf(paragraphOf("a")))))
+        val zeroStart =
+            OrderedList(ListAttrs(start = 0), listOf(ListItem(listOf(paragraphOf("a")))))
+        val negativeStart =
+            OrderedList(ListAttrs(start = -3), listOf(ListItem(listOf(paragraphOf("a")))))
 
         // Clamped to 1, which is the default, so no start attribute is emitted (never `start="0"`).
         assertEquals("<ol><li><p>a</p></li></ol>", html(zeroStart))

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/TextAlignTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/TextAlignTest.kt
@@ -1,0 +1,101 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TextAlignTest {
+
+    private fun docWithAlign(align: String) = """
+        {"type":"doc","content":[
+          {"type":"paragraph","attrs":{"textAlign":"$align"},"content":[{"type":"text","text":"Hello"}]}
+        ]}
+    """
+
+    @Test
+    fun centerAlignmentSurvivesRoundTrip() {
+        val json = editorFrom(docWithAlign("center")).toJson()
+        assertTrue(json.contains("\"textAlign\":\"center\""), "expected center in: $json")
+    }
+
+    @Test
+    fun rightAlignmentSurvivesRoundTrip() {
+        val json = editorFrom(docWithAlign("right")).toJson()
+        assertTrue(json.contains("\"textAlign\":\"right\""), "expected right in: $json")
+    }
+
+    @Test
+    fun justifyAlignmentSurvivesRoundTrip() {
+        val json = editorFrom(docWithAlign("justify")).toJson()
+        assertTrue(json.contains("\"textAlign\":\"justify\""), "expected justify in: $json")
+    }
+
+    @Test
+    fun alignmentSurvivesEditing() {
+        val editor = editorFrom(docWithAlign("center"))
+        editor.typeText(editor.offsetOf("Hello") + "Hello".length, " world")
+        val json = editor.toJson()
+        assertTrue(editor.text.contains("Hello world"), "text: ${editor.text}")
+        assertTrue(json.contains("\"textAlign\":\"center\""), "expected center after edit in: $json")
+    }
+
+    @Test
+    fun unknownAlignmentCoercesToLeft() {
+        val json = editorFrom(docWithAlign("wobble")).toJson()
+        assertTrue(json.contains("\"textAlign\":\"left\""), "expected left fallback in: $json")
+    }
+
+    @Test
+    fun updateTextAlignmentAppliesOverSelection() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        val (changed, _) = editor.setTextAlign(editor.rangeOf("Hello world"), TextAlign.Center)
+        assertTrue(changed, "expected the alignment change to apply")
+        assertTrue(editor.toJson().contains("\"textAlign\":\"center\""), "json: ${editor.toJson()}")
+    }
+
+    @Test
+    fun updateTextAlignmentWorksWithCollapsedCaret() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        // Collapsed caret inside the paragraph — alignment is paragraph-level, so it still applies.
+        val (changed, _) = editor.setTextAlign(TextRange(2), TextAlign.Right)
+        assertTrue(changed, "expected collapsed-caret alignment to apply")
+        assertTrue(editor.toJson().contains("\"textAlign\":\"right\""), "json: ${editor.toJson()}")
+    }
+
+    @Test
+    fun updateTextAlignmentOnlyTargetsTouchedParagraph() {
+        val editor = editorFrom(SampleDocuments.TWO_PARAGRAPHS)
+        editor.setTextAlign(editor.rangeOf("First paragraph"), TextAlign.Center)
+        val json = editor.toJson()
+        // Only the first paragraph is centered; the second stays left-aligned.
+        assertTrue(json.contains("\"textAlign\":\"center\""), "json: $json")
+        assertTrue(json.contains("\"textAlign\":\"left\""), "second paragraph should remain left: $json")
+    }
+
+    @Test
+    fun reapplyingSameAlignmentIsNoOp() {
+        val editor = editorFrom(docWithAlign("center"))
+        val (changed, _) = editor.setTextAlign(editor.rangeOf("Hello"), TextAlign.Center)
+        assertFalse(changed, "re-applying the existing alignment should report no change")
+    }
+
+    @Test
+    fun getParagraphsExposesAlignmentForRendering() {
+        val editor = editorFrom(docWithAlign("right"))
+        val paragraph = editor.getParagraphs().first()
+        // The renderer reads paragraph.textAlign to build the paragraph's ParagraphStyle.
+        assertEquals(TextAlign.Right, paragraph.textAlign)
+    }
+
+    @Test
+    fun getParagraphsReportsPerParagraphAlignment() {
+        val editor = editorFrom(SampleDocuments.TWO_PARAGRAPHS)
+        editor.setTextAlign(editor.rangeOf("First paragraph"), TextAlign.Center)
+        val paragraphs = editor.getParagraphs()
+        assertEquals(TextAlign.Center, paragraphs[0].textAlign)
+        assertEquals(TextAlign.Left, paragraphs[1].textAlign)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/TextKitTestSupport.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/TextKitTestSupport.kt
@@ -7,6 +7,7 @@ import com.jjrodcast.textkit.editor.core.TextKitEditorManager
 import com.jjrodcast.textkit.editor.core.parser.LinkAttrs
 import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.core.parser.Mark
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorAction
 import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorSelectedMark
 import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorTransactionType
@@ -96,6 +97,17 @@ internal fun TextKitEditorManager.toListItem(
     prevSelectedMark = TextEditorSelectedMark(listItemSelectedValue = from),
     currSelectedMark = TextEditorSelectedMark(listItemSelectedValue = to),
 ).first
+
+/** Set the paragraph alignment over [range] (applies to every paragraph the range touches). */
+internal fun TextKitEditorManager.setTextAlign(
+    range: TextRange,
+    textAlign: TextAlign
+): Pair<Boolean, TextRange> = updateDocument(
+    selection = range,
+    prevSelectedMark = TextEditorSelectedMark.NONE,
+    currSelectedMark = TextEditorSelectedMark.NONE,
+    transactionType = TextEditorTransactionType.Alignment(textAlign)
+)
 
 /** Set (or clear, with `null`) the text color over [range]. */
 internal fun TextKitEditorManager.setColor(range: TextRange, color: String?): Boolean =


### PR DESCRIPTION
## Overview

Adds block-level horizontal alignment to the editor. Alignment is a paragraph attribute (not a character mark): applying it retags every paragraph the selection touches — so it works with a collapsed caret and always affects whole paragraphs. Round-trips through the ProseMirror/TipTap textAlign attr, matching the persisted document format.

## Data model & persistence
- TextAlign enum (Left, Center, Right, Justify) in parser/Attributes.kt, serialized as the textAlign string; unknown values coerce to Left.
- ParagraphAttrs added; Paragraph and HeadingAttrs now carry textAlign so alignment survives (de)serialization.
- RichPiece.textAlign — alignment is stamped on every piece of a paragraph so it survives the rope's split/merge/splice via copy(). All RichTextEditorPieceTable split/insert paths propagate it; newly typed text inherits the surrounding paragraph's alignment.

## Conversion (round-trip)
- TextEditorConverter.applyTextAlign stamps the parsed alignment onto a paragraph's pieces on load (no-op for the default Left).
- PieceTableConverter.resolveTextAlign reads it back on save — first non-default piece wins (handles a freshly typed default piece among aligned neighbours).

## Edit pipeline
- New TextEditorTransactionType.Alignment transaction type (carries no marks).
- TextEditorManager.updateTextAlignment → TextEditorTransaction.updateDocument routes Alignment to the piece table's new updateTextAlign(start, end, align), which retags whole paragraphs in-place (O(R log P), text cache untouched). FormatTransaction explicitly ignores it.
- MarkSearchType.textAlign surfaces the alignment shared by the selected paragraph(s) to the toolbar; null = mixed selection or nothing selected.

## Bug fix — paragraphsInSelectedRange
PieceParagraph.start/end are selection markers copied into every paragraph, not the paragraph's own bounds, so the old intersect(start, end, it.start, it.end) filter was effectively always-true and pulled in the boundary-adjacent previous paragraph. Symptom: selecting one paragraph start-to-end also aligned the previous one. Now filters on the real document span [startOffset, endOffset + endPiece.length] using the same end == paragraphEnd || intersect(...) rule as getAllModelsInRange (so caret-at-paragraph/document-end still resolves correctly). Verified against all 8 callers — no crash/regression risk; the list-toggle selectedParagraphs == 1 branch is now correctly counted.

## UI
- TextKitAlignPopup alignment picker, wired through TextKitFormatting / TextKitState, with sample integration and localized strings.

## Tests
- TextAlignTest — apply/toggle alignment, whole-paragraph behavior, round-trip.
- CurrentTextAlignTest — resolving the active alignment for a selection (including mixed).
- TextKitTestSupport helpers.