### PR TITLE
feat: export block alignment to HTML and Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ val markdown: String = state.toMarkdown()
 `toHtml()` is **export only** — the editor is still loaded from, and persisted as, the JSON produced
 by `toJson()`. It emits semantic markup (`<strong>`, `<em>`, `<blockquote>`, …) rather than inline
 styles; the one exception is a text style (colour + font size), which has no semantic equivalent and
-becomes a `<span style="…">`. Task items keep a real, enabled `<input type="checkbox">` so the
-exported markup stays interactive, and inline tokens carry their identity on `data-type` / `data-id`:
+becomes a `<span style="…">`. Paragraph alignment is emitted as `style="text-align:…"` on the block
+(only when it is not the default `left`). Task items keep a real, enabled `<input type="checkbox">` so
+the exported markup stays interactive, and inline tokens carry their identity on `data-type` / `data-id`:
 
 ```html
 <p>Hi <span data-type="mention" data-id="42">@ada</span></p>
@@ -130,9 +131,10 @@ exported markup stays interactive, and inline tokens carry their identity on `da
 
 `toMarkdown()` is **export only** too, and targets **GitHub Flavored Markdown** — task lists, tables
 and `~~strikethrough~~` are all native. It is deliberately **lossy**: marks GFM has no syntax for
-(underline, highlight, a colour/size text style) fall back to inline HTML (`<u>`, `<mark>`,
-`<span style="…">`), inline tokens become plain `@label` / `#label` text (their `data-id` identity is
-dropped), and a blank paragraph has no Markdown form. Keep `toJson()` for a lossless round-trip;
+(underline, highlight, a colour/size text style, paragraph alignment) fall back to inline HTML (`<u>`,
+`<mark>`, `<span style="…">`, `<p style="text-align:…">`), inline tokens become plain `@label` /
+`#label` text (their `data-id` identity is dropped), and a blank paragraph has no Markdown form. Keep
+`toJson()` for a lossless round-trip;
 reach for `toMarkdown()` when sharing to a Markdown surface (READMEs, chat, notes).
 
 ```markdown

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/ExportHtml.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/ExportHtml.kt
@@ -1,5 +1,6 @@
 package com.jjrodcast.textkit.editor.core.export
 
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.parser.TextStyleAttrs.Companion.UNSET_FONT_SIZE
 import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
 
@@ -65,8 +66,21 @@ internal object ExportHtml {
         return prefix.lowercase()
     }
 
+    /**
+     * The `text-align` CSS for a block's alignment, or `null` for the default [TextAlign.Left] (which
+     * is never emitted — an unaligned block stays bare). The enum values are the CSS keywords, so both
+     * exporters render the same `text-align:<value>`.
+     */
+    fun textAlignCss(align: TextAlign): String? = when (align) {
+        TextAlign.Left -> null
+        TextAlign.Center -> "$TEXT_ALIGN:center"
+        TextAlign.Right -> "$TEXT_ALIGN:right"
+        TextAlign.Justify -> "$TEXT_ALIGN:justify"
+    }
+
     const val COLOR = "color"
     const val FONT_SIZE = "font-size"
+    const val TEXT_ALIGN = "text-align"
 
     private const val MIN_FONT_SIZE = 1
     private const val MAX_FONT_SIZE = 512

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/HtmlSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/HtmlSerializer.kt
@@ -29,6 +29,7 @@ import com.jjrodcast.textkit.editor.core.parser.TEXT_EDITOR_JSON
 import com.jjrodcast.textkit.editor.core.parser.TaskList
 import com.jjrodcast.textkit.editor.core.parser.TaskListItem
 import com.jjrodcast.textkit.editor.core.parser.Text
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
 import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
 import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
@@ -64,11 +65,11 @@ internal class HtmlSerializer : DocumentSerializer {
     // ── Blocks ───────────────────────────────────────────────────────────────
 
     private fun block(paragraph: BaseParagraph): String = when (paragraph) {
-        is Paragraph -> tag(Tag.Paragraph, inline(paragraph.content))
+        is Paragraph -> tag(Tag.Paragraph, inline(paragraph.content), alignment(paragraph.attrs.textAlign))
 
         is Heading -> {
             val level = paragraph.attrs.level.coerceIn(HeadingLevels.H1, HeadingLevels.H6)
-            tag("${Tag.Heading}$level", inline(paragraph.content))
+            tag("${Tag.Heading}$level", inline(paragraph.content), alignment(paragraph.attrs.textAlign))
         }
 
         is BulletedList -> tag(Tag.UnorderedList, paragraph.content.joinToString(separator = "") { listItem(it) })
@@ -254,6 +255,10 @@ internal class HtmlSerializer : DocumentSerializer {
 
     /** Renders one attribute, e.g. `attr("href", "x")` → ` href="x"`. Escape user values first. */
     private fun attr(name: String, value: String) = " $name=\"$value\""
+
+    /** A `style="text-align:…"` attribute for a non-default block alignment, or `""` for the default. */
+    private fun alignment(align: TextAlign): String =
+        ExportHtml.textAlignCss(align)?.let { attr(Attr.Style, it) } ?: ""
 
     /** HTML element names. */
     private object Tag {

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/MarkdownSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/MarkdownSerializer.kt
@@ -29,6 +29,7 @@ import com.jjrodcast.textkit.editor.core.parser.TEXT_EDITOR_JSON
 import com.jjrodcast.textkit.editor.core.parser.TaskList
 import com.jjrodcast.textkit.editor.core.parser.TaskListItem
 import com.jjrodcast.textkit.editor.core.parser.Text
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
 import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
 import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
@@ -66,11 +67,16 @@ internal class MarkdownSerializer : DocumentSerializer {
     // ── Blocks ───────────────────────────────────────────────────────────────
 
     private fun block(paragraph: BaseParagraph): String = when (paragraph) {
-        is Paragraph -> inline(paragraph.content)
+        is Paragraph -> {
+            val body = inline(paragraph.content)
+            aligned(body, Html.Paragraph, paragraph.attrs.textAlign) ?: body
+        }
 
         is Heading -> {
             val level = paragraph.attrs.level.coerceIn(HeadingLevels.H1, HeadingLevels.H6)
-            "${Md.Heading.repeat(level)} ${inline(paragraph.content)}"
+            val body = inline(paragraph.content)
+            aligned(body, "${Html.Heading}$level", paragraph.attrs.textAlign)
+                ?: "${Md.Heading.repeat(level)} $body"
         }
 
         is BulletedList -> paragraph.content.joinToString(separator = "\n") { listRow(Md.Bullet, it) }
@@ -123,7 +129,8 @@ internal class MarkdownSerializer : DocumentSerializer {
      */
     private fun itemBody(blocks: List<BaseParagraph>): String {
         val first = blocks.firstOrNull()
-        val lead = (first as? Paragraph)?.let { inline(it.content) } ?: ""
+        // block() (not inline()) so an aligned lead paragraph still emits its HTML wrapper.
+        val lead = (first as? Paragraph)?.let { block(it) } ?: ""
         val rest = if (first is Paragraph) blocks.drop(1) else blocks
         val builder = StringBuilder(lead)
         rest.forEach { child ->
@@ -267,6 +274,15 @@ internal class MarkdownSerializer : DocumentSerializer {
 
     private fun htmlTag(name: String, body: String): String = "<$name>$body</$name>"
 
+    /**
+     * Wraps [body] in an aligned inline-HTML block ([tag]) when [align] is non-default; returns `null`
+     * for the default [TextAlign.Left] so the caller keeps the plain Markdown form. GFM has no
+     * paragraph alignment, so this HTML passthrough is the only way to carry it — the same fallback
+     * strategy the marks use.
+     */
+    private fun aligned(body: String, tag: String, align: TextAlign): String? =
+        ExportHtml.textAlignCss(align)?.let { "<$tag${htmlAttr(Html.Style, it)}>$body</$tag>" }
+
     /** One inline-HTML attribute, e.g. ` style="color:#fff"`, with the value attribute-escaped. */
     private fun htmlAttr(name: String, value: String): String = " $name=\"${ExportHtml.escapeAttribute(value)}\""
 
@@ -317,8 +333,10 @@ internal class MarkdownSerializer : DocumentSerializer {
         const val TableDelimiter = "---"
     }
 
-    /** Inline-HTML tag and attribute names used for the marks GFM cannot express. */
+    /** Inline-HTML tag and attribute names used for the marks and alignment GFM cannot express. */
     private object Html {
+        const val Paragraph = "p"
+        const val Heading = "h" // suffixed with the level, e.g. "h1"
         const val Underline = "u"
         const val Highlight = "mark"
         const val Span = "span"

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlSerializerTest.kt
@@ -22,11 +22,13 @@ import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.parser.Mention
 import com.jjrodcast.textkit.editor.core.parser.OrderedList
 import com.jjrodcast.textkit.editor.core.parser.Paragraph
+import com.jjrodcast.textkit.editor.core.parser.ParagraphAttrs
 import com.jjrodcast.textkit.editor.core.parser.StrikeMark
 import com.jjrodcast.textkit.editor.core.parser.TaskList
 import com.jjrodcast.textkit.editor.core.parser.TaskListAttrs
 import com.jjrodcast.textkit.editor.core.parser.TaskListItem
 import com.jjrodcast.textkit.editor.core.parser.Text
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
 import com.jjrodcast.textkit.editor.core.parser.TextStyleAttrs
 import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
@@ -100,6 +102,50 @@ class HtmlSerializerTest {
             html(
                 Heading(HeadingAttrs(level = 9), listOf(Text("too deep"))),
                 Heading(HeadingAttrs(level = 0), listOf(Text("too shallow"))),
+            ),
+        )
+    }
+
+    @Test
+    fun exports_paragraph_alignment_as_a_text_align_style() {
+        assertEquals(
+            "<p style=\"text-align:center\">centered</p>",
+            html(Paragraph(ParagraphAttrs(TextAlign.Center), listOf(Text("centered")))),
+        )
+        assertEquals(
+            "<p style=\"text-align:right\">right</p>",
+            html(Paragraph(ParagraphAttrs(TextAlign.Right), listOf(Text("right")))),
+        )
+        assertEquals(
+            "<p style=\"text-align:justify\">justified</p>",
+            html(Paragraph(ParagraphAttrs(TextAlign.Justify), listOf(Text("justified")))),
+        )
+    }
+
+    @Test
+    fun omits_the_style_for_the_default_left_alignment() {
+        assertEquals(
+            "<p>plain</p>",
+            html(Paragraph(ParagraphAttrs(TextAlign.Left), listOf(Text("plain")))),
+        )
+    }
+
+    @Test
+    fun exports_heading_alignment() {
+        assertEquals(
+            "<h2 style=\"text-align:center\">Title</h2>",
+            html(Heading(HeadingAttrs(level = 2, textAlign = TextAlign.Center), listOf(Text("Title")))),
+        )
+    }
+
+    @Test
+    fun exports_alignment_on_a_list_item_paragraph() {
+        assertEquals(
+            "<ul><li><p style=\"text-align:right\">x</p></li></ul>",
+            html(
+                BulletedList(
+                    listOf(ListItem(listOf(Paragraph(ParagraphAttrs(TextAlign.Right), listOf(Text("x")))))),
+                ),
             ),
         )
     }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MarkdownSerializerTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MarkdownSerializerTest.kt
@@ -20,11 +20,13 @@ import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.parser.Mention
 import com.jjrodcast.textkit.editor.core.parser.OrderedList
 import com.jjrodcast.textkit.editor.core.parser.Paragraph
+import com.jjrodcast.textkit.editor.core.parser.ParagraphAttrs
 import com.jjrodcast.textkit.editor.core.parser.StrikeMark
 import com.jjrodcast.textkit.editor.core.parser.TaskList
 import com.jjrodcast.textkit.editor.core.parser.TaskListAttrs
 import com.jjrodcast.textkit.editor.core.parser.TaskListItem
 import com.jjrodcast.textkit.editor.core.parser.Text
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
 import com.jjrodcast.textkit.editor.core.parser.TextStyleAttrs
 import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
@@ -162,6 +164,58 @@ class MarkdownSerializerTest {
         assertEquals(
             "- A\n\n    B",
             md(BulletedList(listOf(ListItem(listOf(paragraphOf("A"), paragraphOf("B")))))),
+        )
+    }
+
+    // ── Alignment ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun falls_back_to_html_for_paragraph_alignment() {
+        // GFM has no paragraph alignment, so it rides an inline-HTML block — same as the HTML export.
+        assertEquals(
+            "<p style=\"text-align:center\">centered</p>",
+            md(Paragraph(ParagraphAttrs(TextAlign.Center), listOf(Text("centered")))),
+        )
+        assertEquals(
+            "<p style=\"text-align:right\">right</p>",
+            md(Paragraph(ParagraphAttrs(TextAlign.Right), listOf(Text("right")))),
+        )
+        assertEquals(
+            "<p style=\"text-align:justify\">justified</p>",
+            md(Paragraph(ParagraphAttrs(TextAlign.Justify), listOf(Text("justified")))),
+        )
+    }
+
+    @Test
+    fun keeps_the_plain_markdown_form_for_the_default_alignment() {
+        assertEquals("plain", md(Paragraph(ParagraphAttrs(TextAlign.Left), listOf(Text("plain")))))
+    }
+
+    @Test
+    fun falls_back_to_html_for_heading_alignment() {
+        assertEquals(
+            "<h1 style=\"text-align:center\">Title</h1>",
+            md(Heading(HeadingAttrs(level = 1, textAlign = TextAlign.Center), listOf(Text("Title")))),
+        )
+    }
+
+    @Test
+    fun keeps_the_hash_form_for_a_default_aligned_heading() {
+        assertEquals(
+            "# Title",
+            md(Heading(HeadingAttrs(level = 1, textAlign = TextAlign.Left), listOf(Text("Title")))),
+        )
+    }
+
+    @Test
+    fun emits_alignment_on_a_list_item_paragraph() {
+        assertEquals(
+            "- <p style=\"text-align:right\">x</p>",
+            md(
+                BulletedList(
+                    listOf(ListItem(listOf(Paragraph(ParagraphAttrs(TextAlign.Right), listOf(Text("x")))))),
+                ),
+            ),
         )
     }
 


### PR DESCRIPTION
Closes #43.

Text alignment (#19) added a `textAlign` attr to paragraphs and headings, but neither exporter emitted it. This wires it into both, per the call on the issue (HTML fallback for Markdown).

**HTML**

Alignment rides as `style="text-align:…"` on the block, emitted only when it isn't the default `left`:

```html
<p style="text-align:center">centered</p>
<h2 style="text-align:right">title</h2>
```

Both `Paragraph` and `Heading` carry `textAlign`, so both are handled. The list-item path already renders inner paragraphs through the same branch, so alignment on a list item's paragraph rides along for free.

**Markdown**

GFM has no paragraph alignment, so a non-default aligned block falls back to the same inline-HTML `<p style="text-align:…">` / `<h1 style="text-align:…">` — consistent with how underline/highlight/text-style already fall back, and with what the HTML export writes. Default `left` keeps the plain form (`# heading`, bare paragraph).

The `text-align` mapping lives once in `ExportHtml.textAlignCss()`, shared by both exporters.

**Markdown fidelity**

Two limits worth knowing, both inherent to alignment-in-Markdown:

1. In strict CommonMark, markdown *inside* a block-level HTML element isn't re-parsed, so inner `**bold**` in an aligned paragraph can render literally.
2. GitHub's sanitizer strips `style`, so alignment may not visually apply there.

So it's a best-effort, lossy fallback (JSON stays the lossless format). I kept it simple and consistent with the HTML export rather than reaching for the `<div align="center">` + blank-line trick — that preserves inner markdown on GitHub but breaks inside list items and changes block structure. If you'd prefer richer Markdown fidelity over consistency let me know.

**Testing**

10 deterministic `jvmTest`s across the two serializers: each alignment value, `left` omitted, headings, and a list-item paragraph. Full `:shared:jvmTest` green; JS + Wasm compile locally.