### PR TITLE
fix: split a multi-line paste into paragraphs

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransaction.kt
@@ -2,10 +2,13 @@ package com.jjrodcast.textkit.editor.core.transactions.text
 
 import androidx.compose.ui.text.TextRange
 import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.transactions.TextEditorTransaction
 import com.jjrodcast.textkit.editor.core.transactions.lists.models.TextEditorDecoratorTransactionType
 import com.jjrodcast.textkit.editor.core.transactions.lists.models.TextEditorListItemTransaction
 import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorAction
+import com.jjrodcast.textkit.editor.utils.LINE_BREAK
+import com.jjrodcast.textkit.editor.utils.isLineBreak
 
 /**
  * This class manage the list item editting using the keyboard.
@@ -16,6 +19,38 @@ object TextTransaction {
         actionModel: TextEditorAction,
         manager: TextKitEditorManager
     ): Pair<Boolean, TextRange> {
+        // A single insert that carries line breaks amid other text (a paste) must become one
+        // paragraph per break — the per-transaction logic below only splits a *lone* line break, and
+        // would otherwise leave the breaks embedded in one text node. Replay it as the discrete
+        // inserts the same text produces when typed, each through the normal path.
+        when (actionModel) {
+            is TextEditorAction.TextAdded ->
+                if (actionModel.text.hasInnerLineBreak()) {
+                    return insertMultiline(actionModel.offset, actionModel.text, actionModel.marks, manager)
+                }
+
+            is TextEditorAction.TextUpdated ->
+                if (actionModel.text.hasInnerLineBreak()) {
+                    // Apply the replacement's removal first, then insert at wherever the removal left
+                    // the caret (it can shift the effective offset, e.g. a partially selected
+                    // decorator). The paste inherits the marks at that point, matching how the normal
+                    // replace path continues the surrounding formatting.
+                    var insertOffset = actionModel.offset
+                    if (actionModel.removeLength > 0) {
+                        val removal = TextEditorAction.TextRemoved(
+                            offset = actionModel.offset,
+                            length = actionModel.removeLength,
+                            selection = TextRange(actionModel.offset),
+                        )
+                        insertOffset = onTextUpdated(removal, manager).second.end
+                    }
+                    val marks = manager.getSearchMarkType(TextRange(insertOffset)).marks
+                    return insertMultiline(insertOffset, actionModel.text, marks, manager)
+                }
+
+            else -> Unit
+        }
+
         val (selection, transactions) = when (actionModel) {
             is TextEditorAction.TextAdded -> {
                 val lines = manager.transaction.getLineContentWithNeighborParagraphs(actionModel.offset, actionModel.offset)
@@ -44,6 +79,58 @@ object TextTransaction {
 
         return Pair(true, selection)
     }
+
+    /**
+     * Replays [text] as the discrete inserts it would produce when typed: each run of ordinary text
+     * and each line break is inserted on its own, in order, through [onTextUpdated] — so every break
+     * splits a paragraph the way a lone typed break already does. The offset advances by each
+     * segment's length; the caret ends where the final segment lands.
+     */
+    private fun insertMultiline(
+        startOffset: Int,
+        text: String,
+        marks: Set<Mark>,
+        manager: TextKitEditorManager
+    ): Pair<Boolean, TextRange> {
+        var offset = startOffset
+        var changed = false
+        var selection = TextRange(startOffset)
+        segmentsOf(text).forEach { segment ->
+            val action = TextEditorAction.TextAdded(
+                text = segment,
+                marks = marks,
+                offset = offset,
+                selection = TextRange(offset + segment.length),
+            )
+            val (applied, resultSelection) = onTextUpdated(action, manager)
+            changed = changed || applied
+            selection = resultSelection
+            // Advance to where the engine actually left the caret rather than assuming
+            // `offset + length`: a break split or a decorator conversion can move it.
+            offset = resultSelection.end
+        }
+        return Pair(changed, selection)
+    }
+
+    /** Splits [text] into alternating ordinary-text runs and lone line breaks, in order. */
+    private fun segmentsOf(text: String): List<String> = buildList {
+        val run = StringBuilder()
+        text.forEach { char ->
+            if (char.isLineBreak()) {
+                if (run.isNotEmpty()) {
+                    add(run.toString())
+                    run.clear()
+                }
+                add(LINE_BREAK.toString())
+            } else {
+                run.append(char)
+            }
+        }
+        if (run.isNotEmpty()) add(run.toString())
+    }
+
+    /** True when [this] carries a line break alongside other content — i.e. not a lone break. */
+    private fun String.hasInnerLineBreak(): Boolean = contains(LINE_BREAK) && !isLineBreak()
 
     private fun TextEditorTransaction.commitChanges(transactions: List<TextEditorListItemTransaction>): Boolean {
         transactions

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MultilineInsertTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MultilineInsertTest.kt
@@ -1,0 +1,81 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * A single multi-character insert that carries line breaks — i.e. a paste of multi-line text — must
+ * split into a paragraph per break, the same as typing those breaks one at a time. Regression cover
+ * for the bug where the breaks stayed embedded inside one text node (issue #48).
+ *
+ * Driven through the same [com.jjrodcast.textkit.editor.core.transactions.text.TextTransaction] path
+ * the Compose text field uses (see [TextKitTestSupport]).
+ */
+class MultilineInsertTest {
+
+    @Test
+    fun pasting_multi_line_text_splits_into_paragraphs() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        editor.typeText(offset = editor.text.length, textToAdd = "\nline2\nline3")
+
+        assertEquals("Hello world\nline2\nline3", editor.text)
+        assertEquals(3, editor.getParagraphs().size)
+        // No line break is left embedded inside a text node.
+        assertFalse(editor.toJson().contains("line2\\nline3"), "newlines must not stay inside a text node")
+    }
+
+    @Test
+    fun pasting_in_the_middle_of_a_paragraph_splits_it() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        editor.typeText(offset = editor.offsetOf("world"), textToAdd = "A\nB\n")
+
+        assertEquals("Hello A\nB\nworld", editor.text)
+        assertEquals(3, editor.getParagraphs().size)
+    }
+
+    @Test
+    fun pasted_paragraphs_survive_a_json_round_trip() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        editor.typeText(offset = editor.text.length, textToAdd = "\nline2\nline3")
+
+        val reloaded = editorFrom(editor.toJson())
+
+        assertEquals(editor.text, reloaded.text)
+        assertEquals(3, reloaded.getParagraphs().size)
+    }
+
+    @Test
+    fun pasting_multi_line_text_over_a_selection_replaces_and_splits() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        val range = editor.rangeOf("world")
+
+        // Replace the selection with multi-line text (a paste over a selection → TextUpdated).
+        editor.replaceText(offset = range.start, removeLength = range.length, textToAdd = "A\nB")
+
+        assertEquals("Hello A\nB", editor.text)
+        assertEquals(2, editor.getParagraphs().size)
+    }
+
+    @Test
+    fun a_lone_line_break_still_splits_one_paragraph_into_two() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        editor.typeText(offset = editor.offsetOf("world"), textToAdd = "\n")
+
+        assertEquals("Hello \nworld", editor.text)
+        assertEquals(2, editor.getParagraphs().size)
+    }
+
+    @Test
+    fun plain_text_without_breaks_is_unchanged() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        editor.typeText(offset = editor.text.length, textToAdd = " again")
+
+        assertEquals("Hello world again", editor.text)
+        assertEquals(1, editor.getParagraphs().size)
+    }
+}


### PR DESCRIPTION
Fixes #48.

**Problem**

A single insert carrying line breaks amid other text — a paste of multi-line text — left the breaks embedded inside one text node instead of splitting into paragraphs. Only a *lone* line break (typing Enter) was handled; a multi-char insert fell through to a plain text insert. The result was a malformed document: `toJson()` emitted a text node whose value contained `\n`, and `toHtml()`/`toMarkdown()` put the newlines inside a single block.

**Fix**

`TextTransaction.onTextUpdated` now detects an insert that carries a line break alongside other content and **replays it as the discrete inserts the same text produces when typed** — each ordinary-text run and each lone break inserted in order, through the existing (correct) path. So every break splits a paragraph exactly as a typed Enter already does, without touching the intricate per-transaction list/decorator logic. A paste over a selection (`TextUpdated`) is handled the same way, after applying its removal.

**Tests**

`MultilineInsertTest` — paste splitting into paragraphs, paste in the middle of a paragraph, JSON round-trip of pasted paragraphs, and two guards that a lone break and plain text are unchanged. Full `:shared:jvmTest` green; JS + Wasm compile.