### PR TITLE
fix: tag task list items with their type on export

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/TextEditorConverter.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/TextEditorConverter.kt
@@ -197,13 +197,14 @@ internal object TextEditorConverter {
             }
 
             is TaskList -> {
-                this.content.fastForEach { text ->
+                val taskItems = this.items
+                taskItems.fastForEach { text ->
                     items.addAll(
                         text.getTextContentWithMarkers(
                             TextDecoratorModel.TaskDecoratorModel(
                                 checked = text.attrs.checked,
                                 level = decorator?.level ?: 0,
-                                nestedCount = content.size
+                                nestedCount = taskItems.size
                             ),
                             configuration
                         )

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/HtmlSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/HtmlSerializer.kt
@@ -84,7 +84,7 @@ internal class HtmlSerializer : DocumentSerializer {
 
         is TaskList -> tag(
             name = Tag.UnorderedList,
-            body = paragraph.content.joinToString(separator = "") { taskItem(it) },
+            body = paragraph.items.joinToString(separator = "") { taskItem(it) },
             attributes = attr(Attr.DataType, TASK_LIST_TYPE),
         )
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/MarkdownSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/MarkdownSerializer.kt
@@ -87,7 +87,7 @@ internal class MarkdownSerializer : DocumentSerializer {
                 .joinToString(separator = "\n")
         }
 
-        is TaskList -> paragraph.content.joinToString(separator = "\n") { taskRow(it) }
+        is TaskList -> paragraph.items.joinToString(separator = "\n") { taskRow(it) }
 
         is Blockquote -> blockquote(paragraph.content)
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/Lists.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/Lists.kt
@@ -6,8 +6,11 @@ import kotlinx.serialization.Transient
 
 @Serializable
 @SerialName(ListTypes.TaskList)
-internal data class TaskList(val content: List<TaskListItem> = emptyList()) : BaseParagraph() {
+internal data class TaskList(val content: List<BaseText> = emptyList()) : BaseParagraph() {
     override val type: String = ListTypes.TaskList
+
+    /** The task items — the only kind of node the editor puts in a task list. */
+    val items: List<TaskListItem> get() = content.filterIsInstance<TaskListItem>()
 }
 
 @Serializable

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/TaskListSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/TaskListSerializationTest.kt
@@ -1,0 +1,51 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Task list items must export with their `type: "taskItem"` tag, the same as `listItem`/`paragraph`
+ * carry theirs — so `toJson()` stays a well-formed ProseMirror document. Regression cover for the bug
+ * where a task item serialized with only its `attrs`/`content` and no node type (issue #51).
+ */
+class TaskListSerializationTest {
+
+    private fun String.count(sub: String) = split(sub).size - 1
+
+    @Test
+    fun loaded_task_items_export_with_their_type() {
+        val json = editorFrom(SampleDocuments.TASK_LIST).toJson()
+
+        assertEquals(2, json.count("\"type\":\"taskItem\""))
+        assertTrue(json.contains("\"type\":\"taskList\""))
+    }
+
+    @Test
+    fun task_item_checked_state_survives_the_export() {
+        val json = editorFrom(SampleDocuments.TASK_LIST).toJson()
+
+        assertEquals(1, json.count("\"checked\":true"))
+        assertEquals(1, json.count("\"checked\":false"))
+    }
+
+    @Test
+    fun a_task_list_round_trips_through_json() {
+        val once = editorFrom(SampleDocuments.TASK_LIST).toJson()
+        val twice = editorFrom(once).toJson()
+
+        assertEquals(once, twice)
+        assertEquals(2, twice.count("\"type\":\"taskItem\""))
+    }
+
+    @Test
+    fun a_task_list_created_by_toggle_also_tags_its_items() {
+        val editor = editorFrom(SampleDocuments.TWO_PARAGRAPHS)
+
+        editor.toListItem(TextRange(0, Int.MAX_VALUE), TextEditorListItem.None, TextEditorListItem.CheckList)
+
+        assertEquals(2, editor.toJson().count("\"type\":\"taskItem\""))
+    }
+}


### PR DESCRIPTION
Fixes #51. @jjrodcast 

**Problem**

`toJson()` exported task items with only `attrs`/`content` and **no node type**, while ordered/bulleted items and paragraphs all carry theirs. That made the export a non-conformant ProseMirror document for external consumers (it round-tripped fine inside TextKit). Always reproduced — a task list loaded from JSON that already had `"type":"taskItem"` lost it on re-export.

**Why it happened**

`TaskList.content` was a concrete `List<TaskListItem>`, so the serializer emitted no class discriminator. Ordered/bulleted items live in a polymorphic `List<BaseText>`, which is why they get `"type":"listItem"`.

A `type` property **can't** just be added to `TaskListItem`: it's a sealed `BaseText` subclass whose polymorphic discriminator is already `"type"`, so kotlinx forbids a colliding property. (`Paragraph` gets away with it only because `BaseParagraph` uses a custom content-based serializer with no discriminator.)

**Fix**

Make `TaskList.content` a polymorphic `List<BaseText>` so the discriminator emits `"type":"taskItem"` — the same mechanism ordered/bulleted items already use. A `TaskList.items` getter (`filterIsInstance<TaskListItem>()`) preserves the typed access the converter and exporters need. Minimal ripple: three call sites switch from `.content` to `.items`.

**Tests**

`TaskListSerializationTest` — loaded task items export with their type, checked state survives, the list round-trips idempotently, and a toggle-created task list also tags its items. Full `:shared:jvmTest` green; JS + Wasm compile.