### PR TITLE
fix: clamp a replace window that starts inside a list decorator

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextUpdateTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextUpdateTransaction.kt
@@ -43,9 +43,11 @@ internal object TextUpdateTransaction {
         var length = actionModel.removeLength
 
         if (firstParagraphIncludesDecorator) {
-            val remainingDecoratorOffset = getOffsetAfterDecorator(firstParagraph, actionModel.offset)
+            // Same clamping as the single-paragraph path: the window start moves past the first
+            // item's decorator and the length loses the covered part, never inverting below zero.
+            val remainingDecoratorOffset = maxOf(getOffsetAfterDecorator(firstParagraph, actionModel.offset), 0)
             offset += remainingDecoratorOffset
-            length -= remainingDecoratorOffset
+            length = maxOf(length - remainingDecoratorOffset, 0)
         }
 
         if (isLastDecoratorPartiallySelected) {
@@ -54,7 +56,7 @@ internal object TextUpdateTransaction {
             length += remainingDecoratorOffset
         }
 
-        val marks = getTextAt(offset).piece.marks
+        val marks = marksAtOrEmpty(offset)
         val model = TextEditorModel.create(text = actionModel.text, marks = marks, decorator = null)
         val deleteTransaction = updateTransaction(offset, model, length)
         transactions.add(deleteTransaction)
@@ -65,6 +67,13 @@ internal object TextUpdateTransaction {
 
         return Pair(TextRange(offset + actionModel.text.length), transactions)
     }
+
+    /**
+     * Marks of the piece at [offset], or none when [offset] sits at the document end (a clamped
+     * window on an empty list item lands there — nothing to inherit marks from).
+     */
+    private fun TextEditorTransaction.marksAtOrEmpty(offset: Int) =
+        if (offset < text.length) getTextAt(offset).piece.marks else emptySet()
 
     private fun TextEditorTransaction.updateOnSingleParagraph(
         paragraph: PieceParagraph,
@@ -83,12 +92,16 @@ internal object TextUpdateTransaction {
         var length = actionModel.removeLength
 
         if (selectionIncludesDecorator) {
-            val remainingDecoratorOffset = getOffsetAfterDecorator(paragraph, actionModel.offset)
-            offset += maxOf(remainingDecoratorOffset, 0)
-            length -= maxOf(remainingDecoratorOffset, 0)
+            // The decorator is presentation-only and atomic, so the replace window is clamped to the
+            // item's content: the start moves past the decorator and the length loses the part that
+            // lay inside it — never below zero, or the window inverts (a window fully inside the
+            // decorator becomes a plain insert at the content start).
+            val remainingDecoratorOffset = maxOf(getOffsetAfterDecorator(paragraph, actionModel.offset), 0)
+            offset += remainingDecoratorOffset
+            length = maxOf(length - remainingDecoratorOffset, 0)
         }
 
-        val marks = this.getTextAt(offset).piece.marks
+        val marks = this.marksAtOrEmpty(offset)
         val model = TextEditorModel.create(text = actionModel.text, marks = marks, decorator = null)
         val updateTransaction = updateTransaction(offset, model, length)
 

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ReplaceInListItemTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ReplaceInListItemTest.kt
@@ -1,0 +1,128 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * A replace (`TextUpdated` — IME composition, autocorrect, paste-over-selection) whose window starts
+ * inside a list item's decorator region must not touch the decorator: the window is clamped to the
+ * item's content, so the decorator survives, the text lands at the content start, and nothing
+ * presentation-only leaks into the exported document. Regression cover for issues #57 and #58.
+ */
+class ReplaceInListItemTest {
+
+    private val BULLETED_LIST = """
+        {"type":"doc","content":[
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"one"}]}]}
+          ]}
+        ]}
+    """
+
+    /** The export must never contain decorator artifacts (tabs, "1. ", "-[ ]" markers). */
+    private fun assertNoDecoratorLeak(json: String) {
+        assertFalse(json.contains("\\t"), "decorator text leaked into the export: $json")
+    }
+
+    private fun assertIdempotent(editor: com.jjrodcast.textkit.editor.core.TextKitEditorManager) {
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    // ── #57: the empty-item crash ─────────────────────────────────────────────
+
+    @Test
+    fun replace_inside_an_empty_task_items_decorator_does_not_crash() {
+        val editor = editorFrom("{}")
+        editor.toListItem(TextRange(0, 0), TextEditorListItem.None, TextEditorListItem.CheckList)
+
+        editor.replaceText(offset = 1, removeLength = 1, textToAdd = "be")
+
+        assertTrue(editor.text.contains("be"))
+        assertTrue(editor.toJson().contains("taskList"))
+        assertNoDecoratorLeak(editor.toJson())
+        assertIdempotent(editor)
+    }
+
+    @Test
+    fun replace_inside_an_empty_ordered_items_decorator_does_not_crash() {
+        val editor = editorFrom("{}")
+        editor.toListItem(TextRange(0, 0), TextEditorListItem.None, TextEditorListItem.NumberedList)
+
+        editor.replaceText(offset = 1, removeLength = 1, textToAdd = "be")
+
+        assertTrue(editor.text.contains("be"))
+        assertTrue(editor.toJson().contains("orderedList"))
+        assertNoDecoratorLeak(editor.toJson())
+        assertIdempotent(editor)
+    }
+
+    // ── #58: silent corruption on non-empty items ─────────────────────────────
+
+    @Test
+    fun replace_in_an_ordered_items_decorator_keeps_both_items_in_the_list() {
+        val editor = editorFrom(SampleDocuments.ORDERED_LIST)
+
+        editor.replaceText(offset = 1, removeLength = 0, textToAdd = "zz")
+
+        val json = editor.toJson()
+        assertNoDecoratorLeak(json)
+        // Both items are still list items; the second was falling out of the list as a paragraph.
+        assertEquals(2, json.split("\"type\":\"listItem\"").size - 1, json)
+        assertTrue(editor.text.contains("zzone"), "text lands at the item's content start: [${editor.text}]")
+        assertIdempotent(editor)
+    }
+
+    @Test
+    fun replace_in_a_task_items_decorator_lands_at_the_content_start() {
+        val editor = editorFrom(SampleDocuments.TASK_LIST)
+
+        editor.replaceText(offset = 1, removeLength = 0, textToAdd = "zz")
+
+        // The insert was landing mid-word ("buy m|zz|ilk").
+        assertTrue(editor.text.contains("zzbuy milk"), "text: [${editor.text}]")
+        assertNoDecoratorLeak(editor.toJson())
+        assertIdempotent(editor)
+    }
+
+    @Test
+    fun replace_in_a_bulleted_items_decorator_lands_at_the_content_start() {
+        val editor = editorFrom(BULLETED_LIST)
+
+        editor.replaceText(offset = 1, removeLength = 0, textToAdd = "zz")
+
+        assertTrue(editor.text.contains("zzone"), "text: [${editor.text}]")
+        assertNoDecoratorLeak(editor.toJson())
+        assertIdempotent(editor)
+    }
+
+    @Test
+    fun replace_spanning_decorator_and_content_removes_only_the_content_part() {
+        val editor = editorFrom(SampleDocuments.ORDERED_LIST)
+        val contentStart = editor.offsetOf("one")
+
+        // Window starts inside the decorator and covers "on" of the content.
+        editor.replaceText(offset = 1, removeLength = contentStart - 1 + 2, textToAdd = "X")
+
+        assertTrue(editor.text.contains("Xe"), "only the covered content is replaced: [${editor.text}]")
+        assertNoDecoratorLeak(editor.toJson())
+        assertIdempotent(editor)
+    }
+
+    // ── #58 repro 3: crash after a merge ──────────────────────────────────────
+
+    @Test
+    fun replace_in_a_decorator_after_an_item_merge_does_not_crash() {
+        val editor = editorFrom(SampleDocuments.ORDERED_LIST)
+        editor.deleteText(offset = 5, length = 4)
+
+        editor.replaceText(offset = 1, removeLength = 0, textToAdd = "zz")
+
+        assertNoDecoratorLeak(editor.toJson())
+        assertIdempotent(editor)
+    }
+}


### PR DESCRIPTION
Fixes #57. Fixes #58.

**Problem**

A replace (`TextUpdated` — IME composition, autocorrect, paste over a selection) whose window started inside a list item's decorator region moved its offset past the decorator but subtracted the covered part from the length **without a floor** — a window fully inside the decorator went negative and inverted. Depending on the item's state that:

- crashed with `StringIndexOutOfBoundsException` (#57's empty item, #58 repro 3 after a merge), or
- **silently corrupted the document** — the decorator string leaked into the exported JSON as literal text (`{"type":"text","text":"\t\t2. "}`) with the item falling out of the list, or the inserted text landed mid-word (`buy m|zz|ilk`) (#58 repros 1–2).

The silent cases are the systemic source of the "random" errors: the document is left inconsistent and a later, innocent edit crashes far from the cause.

**Fix**

Clamp the replace window to the item's content in both the single- and multi-paragraph paths of `TextUpdateTransaction`: the start moves past the decorator and the length loses only the part that lay inside it, never below zero — so a window fully inside the decorator becomes a plain insert at the content start. The marks lookup is guarded for the clamped-to-document-end case (empty item).

**Tests**

`ReplaceInListItemTest` (7 cases, written first — 5 red before the fix): the #57 empty-item crash on task and ordered lists, decorator-region replaces on ordered/task/bulleted items (items stay in the list, text lands at the content start, no decorator text in the export), a window spanning decorator + content, and the post-merge crash. Each also asserts the export stays a fixed point.

Verified with the seeded stress harness from #46: the seed that previously crashed at step 14 now runs past the entire replace family. Full `:shared:jvmTest` green; JS + Wasm compile.
