### PR TITLE
fix: never leave the piece table empty after a delete

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorBasePieceTable.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorBasePieceTable.kt
@@ -180,10 +180,20 @@ internal abstract class RichTextEditorBasePieceTable :
         return MultiPieceParagraph(paragraphs, start, end)
     }
 
+    /**
+     * Reseeds the table with a single zero-length piece when it has none. The rest of the table (and
+     * its readers — the line-content walks all `first()`/`last()` their result) assumes at least one
+     * piece, so an empty document is always represented by one empty piece, never by no pieces. The
+     * piece's [Source] is irrelevant at zero length.
+     */
+    protected fun ensureNotEmpty() {
+        if (rope.isEmpty()) rope.addSingle(createEmptyPiece(Source.ADDED))
+    }
+
     protected fun getPieceIndexAndOffset(offset: Int): Pair<Int, Int> {
         if (offset < 0) throw IndexOutOfBoundsException("Index out of bounds:getPieceIndexAndOffset: $offset")
 
-        if (rope.isEmpty()) rope.addSingle(createEmptyPiece(Source.ADDED))
+        ensureNotEmpty()
 
         // O(log P) walk-down through the rope tree: finds the leftmost piece
         // whose cumulative end length >= offset, without a pre-sorted array.

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorPieceTable.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorPieceTable.kt
@@ -152,6 +152,9 @@ internal class RichTextEditorPieceTable : RichTextEditorBasePieceTable() {
         }
         // O(log P): splice replaces [initialAffectedPieceIndex, finalAffectedPieceIndex] with deletePieces
         rope.splice(initialAffectedPieceIndex, finalAffectedPieceIndex + 1, deletePieces)
+        // A delete spanning every piece can splice them all away; reseed so the table never goes
+        // empty — its readers assume at least one piece (see ensureNotEmpty).
+        ensureNotEmpty()
         patchCache(offset, length, "")
         return true
     }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListToggleAfterClearTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListToggleAfterClearTest.kt
@@ -1,0 +1,77 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Converting an empty document to a list must work regardless of how the document became empty.
+ * Clearing a multi-paragraph document left the piece table in a state where the next list toggle
+ * crashed (`NoSuchElementException: ArrayDeque is empty`) — regression cover for issue #59.
+ */
+class ListToggleAfterClearTest {
+
+    private fun clearAll(editor: com.jjrodcast.textkit.editor.core.TextKitEditorManager) {
+        editor.deleteText(0, editor.text.length)
+        assertEquals("", editor.text)
+    }
+
+    @Test
+    fun list_toggle_works_after_clearing_a_multi_paragraph_document() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "x")
+        editor.typeText(1, "\n")
+        editor.typeText(2, "y")
+
+        clearAll(editor)
+        editor.toListItem(TextRange(0, 0), TextEditorListItem.None, TextEditorListItem.CheckList)
+
+        assertTrue(editor.toJson().contains("taskList"))
+    }
+
+    @Test
+    fun every_list_kind_works_after_clearing_a_multi_paragraph_document() {
+        for (kind in listOf(
+            TextEditorListItem.NumberedList,
+            TextEditorListItem.BulletedList,
+            TextEditorListItem.CheckList,
+        )) {
+            val editor = editorFrom("{}")
+            editor.typeText(0, "a")
+            editor.typeText(1, "\n")
+            editor.typeText(2, "b")
+
+            clearAll(editor)
+            editor.toListItem(TextRange(0, 0), TextEditorListItem.None, kind)
+
+            val json = editor.toJson()
+            assertTrue(
+                json.contains("orderedList") || json.contains("bulletList") || json.contains("taskList"),
+                "kind=$kind json=$json",
+            )
+        }
+    }
+
+    @Test
+    fun list_toggle_works_after_clearing_a_loaded_multi_paragraph_document() {
+        val editor = editorFrom(SampleDocuments.TWO_PARAGRAPHS)
+
+        clearAll(editor)
+        editor.toListItem(TextRange(0, 0), TextEditorListItem.None, TextEditorListItem.NumberedList)
+
+        assertTrue(editor.toJson().contains("orderedList"))
+    }
+
+    @Test
+    fun typing_still_works_after_clearing_a_multi_paragraph_document() {
+        val editor = editorFrom(SampleDocuments.TWO_PARAGRAPHS)
+
+        clearAll(editor)
+        editor.typeText(0, "fresh")
+
+        assertEquals("fresh", editor.text)
+        assertEquals(editor.toJson(), editorFrom(editor.toJson()).toJson())
+    }
+}


### PR DESCRIPTION
Fixes #59.

**Problem**

A delete spanning every piece — clearing a multi-paragraph document — spliced them all away and left the rope with **no pieces**, a state the table's readers don't expect: the next line-content walk crashed with `NoSuchElementException: ArrayDeque is empty`. That broke not just the reported list toggle but **plain typing** after the clear too (both go through `getLineContentWithNeighborListItems`). A single-paragraph clear survived only because that delete path keeps a zero-length piece — which is why the bug looked sequence-dependent.

**Fix**

Reseed the table with a single empty piece when a splice empties it — the same representation `build()` uses for an empty document, and the same guard `getPieceIndexAndOffset` already applied inline, now shared as `ensureNotEmpty()`. Writer-side, so no reader can ever observe the empty-rope state.

**Tests**

`ListToggleAfterClearTest` (4 cases, written first — all red before the fix): list toggle after clearing a typed multi-paragraph document, all three list kinds, the same on a loaded document, and typing after a clear (with an export fixed-point check). Full `:shared:jvmTest` green; JS + Wasm compile.
