### PR TITLE
fix: reconcile a stale "not in a list" state in a collapsed list toggle

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
@@ -2,6 +2,7 @@ package com.jjrodcast.textkit.editor.core.transactions.lists
 
 import androidx.compose.ui.text.TextRange
 import com.jjrodcast.textkit.editor.components.TextEditorDecoratorItem
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.components.TextEditorListItem.BulletedList
 import com.jjrodcast.textkit.editor.components.TextEditorListItem.CheckList
 import com.jjrodcast.textkit.editor.components.TextEditorListItem.None
@@ -80,9 +81,19 @@ internal object ListItemTransaction {
         val currentItem = items.first()
         val transformedParagraphs = lines.paragraphs.map(::transformToTextEditorDecoratorLine)
         val currentIndex = transformedParagraphs.indexOf(currentItem)
-        val currentListItem = listItem.toFinalListItemType(prevListItem, currentItem.piece.decorator.toLevel(0))
+        // The caller's prevListItem reflects the observed caret state, which can be stale at list
+        // boundaries; the paragraph itself is the source of truth. Re-derive when the caller claims
+        // "not in a list" over an actual list item, so the toggle converts it instead of stacking a
+        // second decorator — the same re-derivation applyRangeChanges does for mixed selections.
+        // Restricted to real list kinds: a non-list decorator (blockquote) must not be promoted into
+        // the list-conversion paths.
+        val actualListItem = currentItem.piece.decorator.toTextEditorListItem()
+        val effectivePrevListItem =
+            if (prevListItem == None && actualListItem is TextEditorListItem && actualListItem != None) actualListItem
+            else prevListItem
+        val currentListItem = listItem.toFinalListItemType(effectivePrevListItem, currentItem.piece.decorator.toLevel(0))
 
-        return if (prevListItem == None) {
+        return if (effectivePrevListItem == None) {
             // Changing paragraph to list item
             updateParagraphToListItem(lines, currentIndex, currentListItem, range)
         } else if (currentListItem == None) {
@@ -90,7 +101,7 @@ internal object ListItemTransaction {
             updateListItemToParagraph(lines, currentIndex, range)
         } else {
             // change list item type or levels
-            updateNestedListItems(currentIndex, lines, prevListItem, currentListItem, range)
+            updateNestedListItems(currentIndex, lines, effectivePrevListItem, currentListItem, range)
         }
     }
 

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListToggleStaleStateTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListToggleStaleStateTest.kt
@@ -1,0 +1,59 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * A list toggle whose `from` state claims "not in a list" while the range actually sits inside a
+ * list item must behave exactly as if the state had been read correctly — the paragraph itself is
+ * the source of truth. It was instead stacking a second decorator onto the item, leaving the live
+ * text and the document model disagreeing. Regression cover for issue #60.
+ *
+ * The stale claim is reachable in practice: the caret list-state at list boundaries has been wrong
+ * before (#31), and the UI drives `from` off that observed state.
+ */
+class ListToggleStaleStateTest {
+
+    private fun toggled(
+        startJson: String,
+        from: TextEditorListItem,
+        to: TextEditorListItem,
+    ): Pair<String, String> {
+        val editor = editorFrom(startJson)
+        editor.toListItem(TextRange(1, 2), from, to)
+        return editor.text to editor.toJson()
+    }
+
+    @Test
+    fun stale_none_over_a_task_item_behaves_like_the_correct_from_state() {
+        val stale = toggled(SampleDocuments.TASK_LIST, TextEditorListItem.None, TextEditorListItem.NumberedList)
+        val correct = toggled(SampleDocuments.TASK_LIST, TextEditorListItem.CheckList, TextEditorListItem.NumberedList)
+
+        assertEquals(correct, stale)
+    }
+
+    @Test
+    fun stale_none_over_an_ordered_item_behaves_like_the_correct_from_state() {
+        val stale = toggled(SampleDocuments.ORDERED_LIST, TextEditorListItem.None, TextEditorListItem.BulletedList)
+        val correct = toggled(SampleDocuments.ORDERED_LIST, TextEditorListItem.NumberedList, TextEditorListItem.BulletedList)
+
+        assertEquals(correct, stale)
+    }
+
+    @Test
+    fun stale_none_never_stacks_a_second_decorator() {
+        val editor = editorFrom(SampleDocuments.TASK_LIST)
+
+        editor.toListItem(TextRange(1, 2), TextEditorListItem.None, TextEditorListItem.NumberedList)
+
+        val lines = editor.text.split("\n")
+        for (line in lines) {
+            val markers = Regex("""-\[[ x]?\]|\d+\. """).findAll(line).count()
+            assertFalse(markers > 1, "line carries more than one decorator: [$line]")
+        }
+        assertEquals(editor.toJson(), editorFrom(editor.toJson()).toJson(), "export is not a fixed point")
+    }
+}


### PR DESCRIPTION
Fixes #60.

**Problem**

A collapsed list toggle branched on the caller's `prevListItem` claim. With a stale `None` over a range actually inside a list item, it took the paragraph-to-list path and **stacked a second decorator** onto the item:

```
\t\t-[] \t\t-[] buy milk
```

The live text stream and the document model then disagree — offsets computed against the rendered text no longer match the model, which is the state that later surfaces as "impossible" IndexOutOfBounds crashes in unrelated edits. The stale claim is reachable in practice: the UI drives `from` off the observed caret list-state, and that state at list boundaries has been wrong before (#31).

**Fix**

Re-derive the previous state from the paragraph's **actual decorator** when the caller claims `None` — the same re-derivation `applyRangeChanges` already does for mixed selections — so the toggle converts the item exactly as an accurate call would. The paragraph is the source of truth; the claim is only trusted when it doesn't contradict it.

**Tests**

`ListToggleStaleStateTest` (3 cases, written first — all red before the fix): the stale-`None` call produces byte-identical text and JSON to the correct-`from` call on task and ordered lists, and no line ever carries more than one decorator marker (with an export fixed-point check). Full `:shared:jvmTest` green; JS + Wasm compile.
