### PR TITLE
fix: preserve empty paragraphs across export and drop empty text nodes

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
@@ -74,7 +74,7 @@ internal object PieceTableConverter {
      * @return A flat list of [TextEditorParagraphModel] representing each line of the document.
      */
     private fun convertPieceTableToParagraphs(pieceTable: RichTextEditor<TextEditorDocumentModel, TextEditorModel>): List<TextEditorParagraphModel> {
-        return createInternalParagraphs(pieceTable.annotatedText)
+        return createInternalParagraphs(pieceTable.annotatedText, preserveTrailingEmptyParagraph = true)
     }
 
     /**
@@ -83,7 +83,10 @@ internal object PieceTableConverter {
      * @param models The flat list of [TextEditorModel] elements representing all text pieces.
      * @return A list of [TextEditorParagraphModel] grouped by line break boundaries.
      */
-    private fun createInternalParagraphs(models: List<TextEditorModel>): List<TextEditorParagraphModel> {
+    private fun createInternalParagraphs(
+        models: List<TextEditorModel>,
+        preserveTrailingEmptyParagraph: Boolean = false,
+    ): List<TextEditorParagraphModel> {
         val paragraphs = arrayListOf<TextEditorParagraphModel>()
         val texts = arrayListOf<TextEditorModel>()
         models.fastForEach { model ->
@@ -94,13 +97,16 @@ internal object PieceTableConverter {
             }
         }
 
-        when (texts.count { it.text.isNotEmpty() }) {
-            0 -> texts.clear()
-            else -> {
+        when {
+            texts.any { it.text.isNotEmpty() } -> paragraphs.add(TextEditorParagraphModel(texts.toList()))
+            // A document-final line break opens one last, empty paragraph — preserved at the document
+            // level so a trailing blank line survives export (see issue #61). A document with no
+            // paragraphs at all stays empty (its canonical export is `{}`), and list-item content
+            // (the other caller) keeps dropping its terminal-break group.
+            preserveTrailingEmptyParagraph && paragraphs.isNotEmpty() ->
                 paragraphs.add(TextEditorParagraphModel(texts.toList()))
-                texts.clear()
-            }
         }
+        texts.clear()
         return paragraphs
     }
 
@@ -535,23 +541,14 @@ internal object PieceTableConverter {
         // 2. Return the list of paragraphs
         return internalParagraphs.fastMap { paragraph ->
             val textAlign = paragraph.styledText.resolveTextAlign()
+            // A zero-length piece (an edit remnant) must not become an empty text node — invalid
+            // ProseMirror, silently dropped on reload (issue #61).
             val texts = paragraph.styledText
-                .mapNotNull { if (it.isDecorator) null else it }
+                .mapNotNull { if (it.isDecorator || it.text.isEmpty()) null else it }
                 .fastMap { it.toInlineNode() }
 
-            when (texts.size) {
-                0 -> Paragraph(attrs = ParagraphAttrs(textAlign = textAlign))
-                1 -> {
-                    val first = texts.first()
-                    if (first is Text && first.text.isEmpty()) {
-                        Paragraph(attrs = ParagraphAttrs(textAlign = textAlign))
-                    } else {
-                        Paragraph(attrs = ParagraphAttrs(textAlign = textAlign), content = texts)
-                    }
-                }
-
-                else -> Paragraph(attrs = ParagraphAttrs(textAlign = textAlign), content = texts)
-            }
+            if (texts.isEmpty()) Paragraph(attrs = ParagraphAttrs(textAlign = textAlign))
+            else Paragraph(attrs = ParagraphAttrs(textAlign = textAlign), content = texts)
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/models/PositionalParagraph.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/models/PositionalParagraph.kt
@@ -30,7 +30,9 @@ internal data class PositionalParagraph(
     internal fun getParagraphContent(): List<BaseText> {
         return if (textStyled.any { it.text.isNotEmpty() }) {
             textStyled.mapNotNull {
-                if (it.text.isLineBreak()) null
+                // A zero-length piece (an edit remnant) must not become an empty text node — that
+                // is not a valid ProseMirror node and a reload would silently drop it (issue #61).
+                if (it.text.isLineBreak() || it.text.isEmpty()) null
                 else it.toInlineNode()
             }
         } else {

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyParagraphPreservationTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyParagraphPreservationTest.kt
@@ -1,0 +1,110 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Empty paragraphs are preserved across save → reload, and the export never emits an empty text
+ * node — the policy settled on issue #61: `toJson()` and load agree, so blank lines a user
+ * deliberately left survive a round trip exactly. The one canonical normalization kept: a document
+ * with no content at all exports as `{}`.
+ */
+class EmptyParagraphPreservationTest {
+
+    private fun reloaded(editor: com.jjrodcast.textkit.editor.core.TextKitEditorManager) =
+        editorFrom(editor.toJson())
+
+    // ── Trailing empty paragraph ───────────────────────────────────────────────
+
+    @Test
+    fun a_loaded_trailing_empty_paragraph_survives_the_export() {
+        val json = """{"type":"doc","content":[
+            {"type":"paragraph","content":[{"type":"text","text":"abc"}]},
+            {"type":"paragraph"}
+        ]}"""
+        val editor = editorFrom(json)
+        assertEquals("abc\n", editor.text)
+
+        assertEquals("abc\n", reloaded(editor).text, "the trailing blank line was lost on export")
+    }
+
+    @Test
+    fun a_typed_trailing_blank_line_survives_save_and_reload() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        editor.typeText(editor.text.length, "\n")
+        assertEquals("Hello world\n", editor.text)
+
+        assertEquals("Hello world\n", reloaded(editor).text)
+    }
+
+    @Test
+    fun a_blank_line_only_document_survives_save_and_reload() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "x")
+        editor.typeText(1, "\n")
+        editor.deleteText(0, 1)
+        assertEquals("\n", editor.text)
+
+        assertEquals("\n", reloaded(editor).text)
+    }
+
+    // ── Empty text nodes ───────────────────────────────────────────────────────
+
+    @Test
+    fun removing_a_list_decorator_leaves_no_empty_text_node_in_the_export() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "x")
+        editor.toListItem(TextRange(0, 1), TextEditorListItem.None, TextEditorListItem.CheckList)
+        editor.toListItem(TextRange(1, 2), TextEditorListItem.CheckList, TextEditorListItem.None)
+
+        assertFalse(editor.toJson().contains("\"text\":\"\""), editor.toJson())
+    }
+
+    @Test
+    fun deleting_a_paragraph_start_leaves_no_empty_text_node_in_the_export() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "ab")
+        editor.typeText(2, "\n")
+        editor.typeText(3, "cd")
+        editor.deleteText(0, 2)
+
+        assertFalse(editor.toJson().contains("\"text\":\"\""), editor.toJson())
+    }
+
+    // ── Stability & canonical empty form ───────────────────────────────────────
+
+    @Test
+    fun exports_stay_a_fixed_point_for_documents_with_empty_paragraphs() {
+        val docs = listOf(
+            """{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"a"}]},{"type":"paragraph"},{"type":"paragraph","content":[{"type":"text","text":"b"}]}]}""",
+            """{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"abc"}]},{"type":"paragraph"}]}""",
+        )
+        for (doc in docs) {
+            val once = editorFrom(doc).toJson()
+            assertEquals(once, editorFrom(once).toJson(), "not a fixed point for $doc")
+        }
+    }
+
+    @Test
+    fun a_truly_empty_document_still_exports_as_empty_json() {
+        assertEquals("{}", editorFrom("{}").toJson())
+
+        val cleared = editorFrom(SampleDocuments.TWO_PARAGRAPHS)
+        cleared.deleteText(0, cleared.text.length)
+        assertEquals("", cleared.text)
+        assertEquals("{}", cleared.toJson())
+    }
+
+    @Test
+    fun a_list_item_does_not_gain_a_phantom_empty_paragraph() {
+        // The trailing-paragraph preservation applies to the document, not inside list items.
+        val editor = editorFrom(SampleDocuments.ORDERED_LIST)
+        val json = editor.toJson()
+
+        assertEquals(json, editorFrom(json).toJson())
+        assertFalse(json.contains("\"content\":[]"), "no empty paragraph inside list items: $json")
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/LargeDocumentTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/LargeDocumentTest.kt
@@ -26,15 +26,9 @@ class LargeDocumentTest {
         "V6" to DocumentUtils.complexJsonV6,
     )
 
-    // Subset whose serialization is stable. V3 and V6 are excluded — see
-    // [PotentialBugsTest.sample_v3_reserialization_is_not_idempotent] and
-    // [PotentialBugsTest.sample_v6_reserialization_is_not_idempotent].
-    private val idempotentSamples: List<Pair<String, String>> = listOf(
-        "V1" to DocumentUtils.complexJsonV1,
-        "V2" to DocumentUtils.complexJsonV2,
-        "V4" to DocumentUtils.complexJsonV4,
-        "V5" to DocumentUtils.complexJsonV5,
-    )
+    // Every sample's serialization is stable. V3 and V6 joined once the trailing-empty-paragraph
+    // preservation landed (issue #61) — their round-trip no longer loses a paragraph per pass.
+    private val idempotentSamples: List<Pair<String, String>> = samples
 
     @Test
     fun every_sample_loads_into_non_empty_text_and_paragraphs() {

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/PotentialBugsTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/PotentialBugsTest.kt
@@ -15,36 +15,9 @@ import kotlin.test.assertTrue
  */
 class PotentialBugsTest {
 
-    /**
-     * BUG: Re-serializing [DocumentUtils.complexJsonV3] is not idempotent.
-     *
-     * The first `load -> toJson` emits a trailing empty paragraph (`{"content":[],"type":"paragraph"}`)
-     * that the next `load -> toJson` drops, so `once != twice`. A round-trip should reach a fixed
-     * point after the first pass.
-     */
-    @Test
-    fun sample_v3_reserialization_is_not_idempotent() {
-        val once = editorFrom(DocumentUtils.complexJsonV3).toJson()
-        val twice = editorFrom(once).toJson()
-        assertTrue(
-            once != twice,
-            "if this fails, V3 serialization is now stable — move it into LargeDocumentTest.idempotentSamples"
-        )
-    }
-
-    /**
-     * BUG: Re-serializing [DocumentUtils.complexJsonV6] is not idempotent either (same trailing
-     * empty-paragraph symptom as V3).
-     */
-    @Test
-    fun sample_v6_reserialization_is_not_idempotent() {
-        val once = editorFrom(DocumentUtils.complexJsonV6).toJson()
-        val twice = editorFrom(once).toJson()
-        assertTrue(
-            once != twice,
-            "if this fails, V6 serialization is now stable — move it into LargeDocumentTest.idempotentSamples"
-        )
-    }
+    // The V3/V6 reserialization-idempotency characterizations moved to
+    // [LargeDocumentTest.toJson_is_idempotent_across_a_second_round_trip]: preserving trailing empty
+    // paragraphs (issue #61) made every sample's serialization stable.
 
     /**
      * BUG: Removing an existing link duplicates text / merges the linked piece with its neighbor.


### PR DESCRIPTION
Fixes #61 — implementing the "preserve on both sides" decision from the issue.

**Problem**

`toJson()` and load disagreed about empty paragraphs, so save → reload was not a round trip:

1. The empty paragraph opened by a document-final line break was dropped by the export — a user's trailing blank line silently disappeared.
2. A blank-line-only document collapsed to nothing after a reload.
3. Edit remnants (zero-length pieces) leaked into the export as `{"type":"text","text":""}` — invalid ProseMirror that a reload silently dropped, so re-serialization never reached a fixed point.

**Fix**

- The top-level converter now emits the final empty paragraph a document-ending line break opens. Scoped precisely: list-item content is unaffected (no phantom paragraphs inside items), and a document with no content at all keeps its canonical `{}` export.
- Both paragraph-content builders skip zero-length pieces, so an empty text node can never be emitted.

**Bonus: V3/V6 idempotency fixed**

The long-documented `PotentialBugsTest` characterizations (V3/V6 sample documents losing a paragraph per round-trip) started failing after this fix — because their serialization is now stable. Per the protocol documented in that file, they moved into `LargeDocumentTest.idempotentSamples` as positive assertions: **every** sample document now re-serializes to a fixed point.

**Tests**

`EmptyParagraphPreservationTest` (8 cases, written first — 4 red before the fix): loaded and typed trailing blank lines survive reload, a blank-line-only document survives, no empty text nodes after decorator removal or paragraph-start deletes, fixed-point checks, the canonical `{}` for a truly empty document, and no phantom paragraphs inside list items.

Verified with the #46 stress harness: the seed that previously failed idempotency at step 19 now completes all 250 ops. Full `:shared:jvmTest` green; JS + Wasm compile.
