### PR TITLE
fix: delete ending at a list decorator no longer orphans it

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
@@ -29,6 +29,15 @@ internal object TextDeletedTransaction {
         actionModel: TextEditorAction.TextRemoved,
         manager: TextKitEditorManager
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
+        val extended = extendPastOrphanedDecorator(lines, actionModel, manager)
+        if (extended != null) {
+            val newLines = manager.transaction.getLineContentWithNeighborParagraphs(
+                extended.offset,
+                extended.offset + extended.length
+            )
+            return deleteText(newLines, extended, manager)
+        }
+
         val selectedParagraphs = lines.paragraphsInSelectedRange.filter { it.piecesInSelectedRange.isNotEmpty() }
         return if (selectedParagraphs.size > 1) {
             val firstParagraphInRange = selectedParagraphs.first()
@@ -37,6 +46,32 @@ internal object TextDeletedTransaction {
         } else {
             manager.transaction.deleteOnSingleParagraph(selectedParagraphs.first(), lines, actionModel)
         }
+    }
+
+    /**
+     * A delete whose range consumes a paragraph's terminating line break and stops exactly at the
+     * next list item's decorator merges the two lines — and would leave that decorator orphaned
+     * mid-line in the text stream while the export drops it (issue #67). When the merged line keeps
+     * a head (the first paragraph's decorator survives by policy, or the delete starts mid-line),
+     * reach one character into the following decorator and re-dispatch, so the existing
+     * partially-selected-decorator handling swallows it whole and renumbers the remaining items.
+     * Returns `null` when no extension applies; the extended range ends inside the decorator, so
+     * the re-dispatch can never extend a second time.
+     */
+    private fun extendPastOrphanedDecorator(
+        lines: MultiPieceParagraph,
+        actionModel: TextEditorAction.TextRemoved,
+        manager: TextKitEditorManager
+    ): TextEditorAction.TextRemoved? {
+        val end = actionModel.offset + actionModel.length
+        if (end >= manager.text.length) return null
+        if (manager.text.getOrNull(end - 1)?.isLineBreak() != true) return null
+        val firstParagraph = lines.paragraphsInSelectedRange.firstOrNull { it.piecesInSelectedRange.isNotEmpty() }
+            ?: return null
+        val keepsLineHead = firstParagraph.isListItem || actionModel.offset > firstParagraph.startOffset
+        if (!keepsLineHead) return null
+        lines.paragraphs.firstOrNull { it.startOffset == end && it.isListItem } ?: return null
+        return actionModel.copy(length = actionModel.length + 1)
     }
 
     /**

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BoundaryDeleteIntoListTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BoundaryDeleteIntoListTest.kt
@@ -1,0 +1,81 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * A delete that swallows the line break between two list items (or a paragraph and a following
+ * item) merges them — and the live text stream must agree with the document model about it. The
+ * exact-boundary case (the range ending at the next item's decorator start) left the decorator
+ * orphaned mid-line in the stream while the export dropped it. Regression cover for issue #67.
+ */
+class BoundaryDeleteIntoListTest {
+
+    private val TWO_BULLETS = """{"type":"doc","content":[{"type":"bulletList","content":[
+        {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"aa"}]}]},
+        {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"bb"}]}]}
+    ]}]}"""
+
+    private val TWO_TASKS = SampleDocuments.TASK_LIST
+
+    /** The live stream and a reload of the export must describe the same text. */
+    private fun assertStreamMatchesModel(editor: com.jjrodcast.textkit.editor.core.TextKitEditorManager) {
+        assertEquals(editorFrom(editor.toJson()).text, editor.text, "live text diverged from the model")
+    }
+
+    @Test
+    fun deleting_up_to_the_next_bullets_decorator_merges_without_an_orphan() {
+        val editor = editorFrom(TWO_BULLETS)
+        val brk = editor.offsetOf("\n")
+
+        // Deletes the last content char + the line break; range ends exactly at item 2's decorator.
+        editor.deleteText(brk - 1, 2)
+
+        assertStreamMatchesModel(editor)
+    }
+
+    @Test
+    fun deleting_only_the_line_break_between_items_merges_without_an_orphan() {
+        val editor = editorFrom(TWO_BULLETS)
+        val brk = editor.offsetOf("\n")
+
+        editor.deleteText(brk, 1)
+
+        assertStreamMatchesModel(editor)
+    }
+
+    @Test
+    fun deleting_up_to_a_task_items_decorator_merges_without_an_orphan() {
+        val editor = editorFrom(TWO_TASKS)
+        val brk = editor.offsetOf("\n")
+
+        editor.deleteText(brk - 1, 2)
+
+        assertStreamMatchesModel(editor)
+    }
+
+    @Test
+    fun deleting_from_a_plain_paragraph_up_to_a_list_decorator_merges_without_an_orphan() {
+        val json = """{"type":"doc","content":[
+            {"type":"paragraph","content":[{"type":"text","text":"intro"}]},
+            {"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"item"}]}]}]}
+        ]}"""
+        val editor = editorFrom(json)
+        val brk = editor.offsetOf("\n")
+
+        editor.deleteText(brk - 1, 2)
+
+        assertStreamMatchesModel(editor)
+    }
+
+    @Test
+    fun deleting_into_the_decorator_still_merges_cleanly() {
+        // The already-working neighbour case, pinned so the fix cannot regress it.
+        val editor = editorFrom(TWO_BULLETS)
+        val brk = editor.offsetOf("\n")
+
+        editor.deleteText(brk - 1, 4)
+
+        assertStreamMatchesModel(editor)
+    }
+}


### PR DESCRIPTION
Fixes #67.

**Problem**

A delete that consumed a paragraph's terminating line break and stopped exactly at the next list item's decorator merged the two lines in the document model — but the text stream kept the following item's decorator as mid-line garbage. Live text and model disagreed, which is the state that later surfaces as impossible offset crashes in unrelated edits. Deletes reaching *into* the decorator were already handled; only the exact-boundary case fell through.

**Fix**

Extend such a delete one character into the following decorator and re-dispatch, so the existing partially-selected-decorator handling swallows it whole and renumbers the remaining items. The extended range ends inside the decorator, so a second extension can never apply. Guarded to the merge case only: a delete removing an entire line (nothing left before the boundary) leaves the following item untouched, as it should.

**Tests**

`BoundaryDeleteIntoListTest` (5 cases, written first — 3 red before the fix): boundary delete into a bulleted and a task item, deleting only the separating line break, plain-paragraph→list boundary, and the already-working into-the-decorator case pinned as a guard. Each asserts the live text matches a reload of the export. Full `:shared:jvmTest` green; JS + Wasm compile.

In the #46 sweep, seed 0 — which previously crashed at step 14, then 19, then 109 as fixes landed — now completes all 250 ops.
