### PR TITLE
Inserting multiples Enter on list item move the caret

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/listlayout/ListItemEditorTransform.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/listlayout/ListItemEditorTransform.kt
@@ -97,15 +97,20 @@ private class ListItemOffsetMapping(
     }
 
     override fun transformedToOriginal(offset: Int): Int {
-        for (segment in segments) {
-            if (offset < segment.displayStart) break
-            if (offset <= segment.displayEnd) {
-                val local = offset - segment.displayStart
-                return if (segment.gutterLength == 0) {
-                    segment.fieldStart + local
-                } else {
-                    segment.fieldStart + segment.gutterLength + local
-                }
+        segments.forEachIndexed { index, segment ->
+            if (offset < segment.displayStart) return@forEachIndexed
+            val isLast = index == segments.lastIndex
+            // Display ranges are consecutive: [displayStart, displayEnd) for interior segments.
+            // Offset displayEnd is shared with the next segment's displayStart (caret after the
+            // paragraph-separator space); it must map to the following paragraph, not the previous
+            // one — otherwise consecutive empty list items collapse to the same field offset.
+            val inSegment = offset < segment.displayEnd || (isLast && offset <= segment.displayEnd)
+            if (!inSegment) return@forEachIndexed
+            val local = offset - segment.displayStart
+            return if (segment.gutterLength == 0) {
+                segment.fieldStart + local
+            } else {
+                segment.fieldStart + segment.gutterLength + local
             }
         }
         return segments.lastOrNull()?.fieldEnd ?: offset

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -79,6 +79,8 @@ import com.jjrodcast.textkit.ui.listlayout.ViewerBlock
 import com.jjrodcast.textkit.ui.listlayout.buildEditorSegments
 import com.jjrodcast.textkit.ui.listlayout.buildViewerBlocks
 import com.jjrodcast.textkit.ui.listlayout.buildViewerParagraphContent
+import com.jjrodcast.textkit.ui.listlayout.editorSegmentsNeedOffsetMapping
+import com.jjrodcast.textkit.ui.listlayout.resolveParagraphCaretFieldOffset
 import com.jjrodcast.textkit.ui.listlayout.resolveParagraphOperationOffset
 import com.jjrodcast.textkit.ui.utils.createStyle
 import com.jjrodcast.textkit.ui.utils.restore
@@ -314,6 +316,24 @@ class TextKitState(
         val coerced = displayOffset.coerceIn(0, displayLength)
         return editorOffsetMapping.transformedToOriginal(coerced)
             .coerceIn(0, textFieldValue.text.length)
+    }
+
+    /**
+     * When list gutters are omitted from the display text, a field offset on a shared `\n` between
+     * items can sit on the wrong paragraph; use display space (via [editorOffsetMapping]) to snap
+     * the caret to the list item the user clicked or arrowed onto.
+     */
+    private fun normalizeSelectionForListLayout(selection: TextRange): TextRange {
+        if (!selection.collapsed || !editorSegmentsNeedOffsetMapping(editorSegments)) return selection
+        val fieldOffset = selection.start.coerceIn(0, textFieldValue.text.length)
+        val displayOffset = editorOffsetMapping.originalToTransformed(fieldOffset)
+        val resolved = resolveParagraphCaretFieldOffset(
+            rawOffset = fieldOffset,
+            segments = editorSegments,
+            textLength = textFieldValue.text.length,
+            displayOffset = displayOffset,
+        )
+        return TextRange(resolved)
     }
 
     /**
@@ -1088,7 +1108,8 @@ class TextKitState(
                 prevTextFieldValue.selection != textFieldValue.selection
             ) {
                 // Update selection
-                textFieldValue = prevTextFieldValue
+                val normalized = normalizeSelectionForListLayout(prevTextFieldValue.selection)
+                textFieldValue = prevTextFieldValue.copy(selection = normalized)
                 selection = textFieldValue.selection
                 // Atomicity: a collapsed caret may not rest inside an atomic token — snap it out.
                 val snapped = tokenState.snapCaretOutOfToken(selection)

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemEdgeCasesTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemEdgeCasesTest.kt
@@ -63,6 +63,36 @@ class ListItemEdgeCasesTest {
         assertTrue(editor.toJson().contains("orderedList"))
     }
 
+    @Test
+    fun typing_in_second_empty_list_item_after_two_enters_at_first_item_end() {
+        val editor = editorFrom(SampleDocuments.ORDERED_LIST)
+        val endOfOne = editor.offsetOf("one") + "one".length
+        repeat(2) { editor.typeText(endOfOne, "\n") }
+        assertEquals(4, editor.listItemCount())
+        val item2ContentStart = editor.getParagraphs()[1].children
+            .first { it.decorator == null }
+            .start
+        editor.typeText(item2ContentStart, "Q")
+        val text = editor.text
+        val qIndex = text.indexOf('Q')
+        val marker2 = text.indexOf("2.")
+        val marker3 = text.indexOf("3.")
+        assertTrue(qIndex > marker2 && qIndex < marker3, "Q must sit in the second list item")
+    }
+
+    @Test
+    fun typing_on_empty_list_item_after_single_enter() {
+        val editor = editorFrom(SampleDocuments.ORDERED_LIST)
+        val endOfOne = editor.offsetOf("one") + "one".length
+        val caret = editor.typeText(endOfOne, "\n")
+        editor.typeText(caret.min, "Q")
+        val text = editor.text
+        val qIndex = text.indexOf('Q')
+        val marker2 = text.indexOf("2.")
+        val marker3 = text.indexOf("3.") // "two" was renumbered to 3
+        assertTrue(qIndex > marker2 && qIndex < marker3, "Q must sit in the new empty second item")
+    }
+
     // ── Converting selections ──────────────────────────────────────────────────
 
     @Test

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
@@ -1,6 +1,8 @@
 package com.jjrodcast.textkit
 
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.TextFieldValue
+import com.jjrodcast.textkit.editor.utils.DocumentUtils
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.style.TextAlign as ComposeTextAlign
 import com.jjrodcast.textkit.editor.core.parser.TextAlign
@@ -24,6 +26,19 @@ class ListItemUiTest {
 
     private fun stateWith(json: String): TextKitState =
         TextKitState(json, createTextKitConfiguration()).apply { setup() }
+
+    /** Simulates the user typing [text] at [fieldOffset] (field coordinates), as BasicTextField would. */
+    private fun TextKitState.simulateTypingAt(fieldOffset: Int, text: String) {
+        val before = textFieldValue
+        val inserted = before.text.substring(0, fieldOffset) + text +
+            before.text.substring(fieldOffset)
+        onTextFieldChange(
+            TextFieldValue(
+                text = inserted,
+                selection = TextRange(fieldOffset + text.length),
+            )
+        )
+    }
 
     private fun centeredBulletListDoc() = """
         {"type":"doc","content":[
@@ -355,5 +370,62 @@ class ListItemUiTest {
         val fieldText = state.textFieldValue.text
         val transformed = state.visualTransformation.filter(AnnotatedString(fieldText))
         assertEquals(fieldText.length, transformed.text.length)
+    }
+
+    @Test
+    fun displayOffsetAfterEmptyListItemMapsToNextItemNotPrevious() {
+        val state = stateWith(SampleDocuments.ORDERED_LIST)
+        val endOfOne = state.textFieldValue.text.indexOf("one") + "one".length
+        repeat(3) {
+            state.simulateTypingAt(
+                state.textFieldValue.text.indexOf("one") + "one".length,
+                "\n",
+            )
+        }
+        val segs = state.editorSegments().filter { it.gutter != null }
+        assertTrue(segs.size >= 4, "expected original item plus three new empty items")
+        val thirdEmpty = segs[2]
+        val mapping = state.visualTransformation.filter(AnnotatedString(state.textFieldValue.text)).offsetMapping
+        val fieldAtThirdStart = mapping.transformedToOriginal(thirdEmpty.displayStart)
+        assertEquals(
+            thirdEmpty.fieldStart + thirdEmpty.gutterLength,
+            fieldAtThirdStart,
+            "caret at the start of the third list item's display line must target that item"
+        )
+    }
+
+    @Test
+    fun typingInEmptyListItemAfterFirstInsertsInThatItem() {
+        val state = stateWith(SampleDocuments.ORDERED_LIST)
+        val endOfOne = state.textFieldValue.text.indexOf("one") + "one".length
+        repeat(2) { state.simulateTypingAt(endOfOne, "\n") }
+        val segs = state.editorSegments().filter { it.gutter != null }
+        val secondItemContentStart = segs[1].fieldStart + segs[1].gutterLength
+        state.simulateTypingAt(secondItemContentStart, "X")
+        assertTrue(state.textFieldValue.text.contains("X"))
+        val text = state.textFieldValue.text
+        val marker2 = text.indexOf("2.")
+        val marker3 = text.indexOf("3.")
+        val xIndex = text.indexOf('X')
+        assertTrue(xIndex > marker2 && xIndex < marker3, "X must land in the second list item")
+    }
+
+    @Test
+    fun complexJsonV1_firstListItemEnterThenTypeInNewEmptyItem() {
+        val state = stateWith(DocumentUtils.complexJsonV1)
+        val text = state.textFieldValue.text
+        val firstItemEnd = text.indexOf("First item") + "First item".length
+        state.simulateTypingAt(firstItemEnd, "\n")
+        val segs = state.editorSegments().filter { it.gutter != null }
+        val newItem = segs[1]
+        val contentStart = newItem.fieldStart + newItem.gutterLength
+        state.simulateTypingAt(contentStart, "Z")
+        assertTrue(state.toJson().contains("Z"))
+        val updated = state.textFieldValue.text
+        val secondItemRegion = updated.indexOf("Second")
+        assertTrue(
+            updated.indexOf('Z') < secondItemRegion,
+            "Z must appear before the original second item text"
+        )
     }
 }


### PR DESCRIPTION
- ListItemEditorTransform.kt: Treat display ranges as [displayStart, displayEnd) for interior segments; the last segment still allows the document-end offset.
- TextKitState.kt: normalizeSelectionForListLayout() when the caret moves and list split layout is active.
- Tests in ListItemUiTest and ListItemEdgeCasesTest: multiple Enters, mapping on the 3rd empty item, typing in an empty item, and complexJsonV1.
- Manual check: Load complexJsonV1, press Enter several times after First item, place the caret on a middle empty item, and type; text should appear on that numbered line.