### PR TITLE
fix: clamp inserts whose offset falls inside a list decorator

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
@@ -31,6 +31,33 @@ internal object TextInsertedTransaction {
         lines: MultiPieceParagraph,
         actionModel: TextEditorAction.TextAdded
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
+        // The decorator is presentation-only and atomic, so an insert whose offset falls in a
+        // decorator region must not splice into it (issue #69; the replace path got the same rule
+        // in #58): text lands at the item's content start, a break splits at the item boundary, and
+        // a break exactly before the item opens a plain line above it, leaving the item untouched.
+        val decoratedParagraph = lines.listItemWithDecoratorAt(actionModel.offset)
+        if (decoratedParagraph != null) {
+            if (actionModel.text.isLineBreak() && actionModel.offset == decoratedParagraph.startOffset) {
+                return insertTextInParagraph(actionModel, getMarksForInsertion(actionModel.marks, filterLinkMarks = true))
+            }
+            val contentStart = decoratedParagraph.startOffset + decoratedParagraph.startPiece.length
+            if (actionModel.offset < contentStart) {
+                // A numbered item's established behaviour is to block text typed on its decorator
+                // (see preventTextInsertionOnDecorator); keep that, clamp everything else.
+                if (!actionModel.text.isLineBreak() &&
+                    decoratedParagraph.startPiece.decorator is TextDecoratorModel.NumberDecoratorModel
+                ) {
+                    return preventTextInsertionOnDecorator(decoratedParagraph)
+                }
+                // Re-dispatch with the selection rebuilt at the clamped offset too, so downstream
+                // piecesInSelectedRange routing sees the content position, not the decorator.
+                return addText(
+                    lines.atOffset(contentStart),
+                    actionModel.copy(offset = contentStart, selection = TextRange(contentStart + actionModel.text.length))
+                )
+            }
+        }
+
         val currentParagraph = lines.paragraphsInSelectedRange.firstOrNull()
         val isAtEndOfParagraph = currentParagraph?.isAtEndOfParagraph(actionModel.offset, actionModel.offset) ?: false
         val updatedSelectedParagraph = if (isAtEndOfParagraph) {
@@ -47,6 +74,23 @@ internal object TextInsertedTransaction {
             insertTextInParagraph(updatedSelectedParagraph, actionModel)
         }
     }
+
+    /** The list item whose decorator region contains [offset], or `null` when there is none. */
+    private fun MultiPieceParagraph.listItemWithDecoratorAt(offset: Int): PieceParagraph? =
+        paragraphs.firstOrNull { paragraph ->
+            paragraph.isListItem &&
+                offset >= paragraph.startOffset &&
+                offset < paragraph.startOffset + paragraph.startPiece.length
+        }
+
+    /** The same paragraphs with the collapsed selection moved to [offset], mirroring how the caller
+     *  builds line content for a collapsed insert. */
+    private fun MultiPieceParagraph.atOffset(offset: Int): MultiPieceParagraph =
+        MultiPieceParagraph(
+            paragraphs = paragraphs.map { it.copy(start = offset, end = offset) },
+            start = offset,
+            end = offset,
+        )
 
     private fun getMarks(preselectedMarks: Set<Mark>, previousItemMarks: Set<Mark>, isNewParagraph: Boolean): Set<Mark> {
         return if (isNewParagraph) {

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/InsertInDecoratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/InsertInDecoratorTest.kt
@@ -1,0 +1,89 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * An insert (plain text or a line break) whose offset falls inside a list item's decorator region
+ * must behave as if the offset were at the item's content start — the decorator is presentation-only
+ * and atomic. It was instead splicing the typed text (or the break) into the decorator itself,
+ * leaving the live text stream and the document model disagreeing. Regression cover for issue #69,
+ * completing for the insert path what #58 fixed for replace.
+ */
+class InsertInDecoratorTest {
+
+    private val ONE_BULLET = """{"type":"doc","content":[{"type":"bulletList","content":[
+        {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"bb"}]}]}
+    ]}]}"""
+
+    private fun assertStreamMatchesModel(editor: com.jjrodcast.textkit.editor.core.TextKitEditorManager) {
+        assertEquals(editorFrom(editor.toJson()).text, editor.text, "live text diverged from the model")
+    }
+
+    // ── Plain inserts at decorator-interior offsets ────────────────────────────
+
+    @Test
+    fun typing_at_a_decorator_interior_offset_lands_at_the_content_start() {
+        for (at in 1..3) {
+            val editor = editorFrom(ONE_BULLET)
+
+            editor.typeText(at, "x")
+
+            assertTrue(editor.text.contains("xbb"), "@$at: text lands at content start: [${editor.text}]")
+            assertStreamMatchesModel(editor)
+            assertFalse(editor.toJson().contains("\\t"), "@$at: no decorator leak: ${editor.toJson()}")
+        }
+    }
+
+    @Test
+    fun typing_in_a_task_items_decorator_lands_at_the_content_start() {
+        val editor = editorFrom(SampleDocuments.TASK_LIST)
+
+        editor.typeText(2, "x")
+
+        assertTrue(editor.text.contains("xbuy milk"), "text: [${editor.text}]")
+        assertStreamMatchesModel(editor)
+        assertTrue(editor.toJson().contains("taskList"), "the item stays a task item: ${editor.toJson()}")
+        assertFalse(editor.toJson().contains("\\t"), "no decorator leak: ${editor.toJson()}")
+    }
+
+    // ── Line breaks at decorator-interior offsets ──────────────────────────────
+
+    @Test
+    fun a_break_at_a_decorator_interior_offset_splits_at_the_item_boundary() {
+        for (at in 1..3) {
+            val editor = editorFrom(ONE_BULLET)
+
+            editor.typeText(at, "\n")
+
+            assertStreamMatchesModel(editor)
+            assertFalse(editor.toJson().contains("\\t"), "@$at: no decorator leak: ${editor.toJson()}")
+            assertTrue(editor.text.contains("bb"), "@$at: content survives: [${editor.text}]")
+        }
+    }
+
+    @Test
+    fun a_break_at_the_item_start_inserts_a_line_above_without_touching_the_item() {
+        val editor = editorFrom(ONE_BULLET)
+
+        editor.typeText(0, "\n")
+
+        assertStreamMatchesModel(editor)
+        assertTrue(editor.toJson().contains("bulletList"), "the item stays a list item: ${editor.toJson()}")
+        assertFalse(editor.toJson().contains("\\t"), "no decorator leak: ${editor.toJson()}")
+    }
+
+    // ── Guard: the working boundary stays working ──────────────────────────────
+
+    @Test
+    fun a_break_at_the_content_start_still_splits_cleanly() {
+        val editor = editorFrom(ONE_BULLET)
+        val contentStart = editor.offsetOf("bb")
+
+        editor.typeText(contentStart, "\n")
+
+        assertStreamMatchesModel(editor)
+    }
+}


### PR DESCRIPTION
Fixes #69 — completing for the insert path what #58 did for replace.

**Problem**

An insert at a decorator-interior offset spliced into the decorator itself. Fresh document, single op:

```kotlin
// one bulleted item "bb" — decorator at [0,5)
editorFrom(ONE_BULLET).typeText(2, "x")    // live: "\t\tx• bb"      model: "\t\t• xbb"
editorFrom(ONE_BULLET).typeText(2, "\n")   // live: decorator split  model: clean item boundary
```

Typed text landed **inside the marker** in the stream while the model put it at the content start; a line break **split the decorator piece** across two lines. Live text and model disagreed — the state that later surfaces as impossible offset crashes in unrelated edits (in the #46 sweep, ending in `IllegalArgumentException: start and end cannot be negative`).

**Fix**

Route such inserts by intent, at the top of `TextInsertedTransaction.addText`:

- **Text** at any offset in the decorator region lands at the item's **content start**
- A **break inside** the region splits at the item boundary — the same path a break at the content start already takes
- A **break exactly before** the item opens a plain line above it, leaving the item untouched (matching what the model already concluded)

**Tests**

`InsertInDecoratorTest` (5 cases, written first — 4 red before the fix): typing at every interior offset on bulleted and task items, breaks at every interior offset, a break at the item start, and the already-working content-start break pinned as a guard. Each asserts the live text matches a reload of the export and no decorator text leaks into the JSON. Full `:shared:jvmTest` green; JS + Wasm compile.
