### PR TITLE
fix: remove a fully consumed piece instead of leaving a zero-length husk

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorPieceTable.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorPieceTable.kt
@@ -93,6 +93,16 @@ internal class RichTextEditorPieceTable : RichTextEditorBasePieceTable() {
 
         if (initialAffectedPieceIndex == finalAffectedPieceIndex) {
             val piece = rope.get(initialAffectedPieceIndex)
+            if (length == piece.length && initialBufferOffset == piece.offset) {
+                // The piece is fully consumed: remove it rather than leaving a zero-length husk.
+                // A husk surviving at a line start hides a following decorator from paragraph-type
+                // detection, so the next list item exports as plain text (issue #72).
+                rope.splice(initialAffectedPieceIndex, initialAffectedPieceIndex + 1, emptyList())
+                ensureNotEmpty()
+                patchCache(offset, length, "")
+                // Structural change, same as the multi-piece path's full consumption.
+                return true
+            }
             if (initialBufferOffset == piece.offset) {
                 // Deleting from the start — the END of the piece is unchanged.
                 val newLength = piece.length - length

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/WholeLineDeleteBeforeListTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/WholeLineDeleteBeforeListTest.kt
@@ -1,0 +1,61 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Deleting an entire line that precedes a list item must leave the item untouched — it keeps its
+ * decorator and its list identity in the export. The delete was leaving a zero-length remnant piece
+ * at the line start, which hid the following decorator from paragraph-type detection: the item
+ * exported as a plain paragraph with the decorator string as literal text. Regression cover for
+ * issue #72.
+ */
+class WholeLineDeleteBeforeListTest {
+
+    private fun docWithLeadingParagraph(listNode: String) =
+        """{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"intro"}]},$listNode]}"""
+
+    private val BULLET = """{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"item"}]}]}]}"""
+    private val ORDERED = """{"type":"orderedList","attrs":{"start":1},"content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"item"}]}]}]}"""
+    private val TASK = """{"type":"taskList","content":[{"type":"taskItem","attrs":{"checked":true},"content":[{"type":"paragraph","content":[{"type":"text","text":"item"}]}]}]}"""
+
+    private fun assertKeepsIdentity(listNode: String, marker: String) {
+        val editor = editorFrom(docWithLeadingParagraph(listNode))
+        val brk = editor.offsetOf("\n")
+
+        editor.deleteText(0, brk + 1)
+
+        val json = editor.toJson()
+        assertTrue(json.contains(marker), "the item must keep its list identity: $json")
+        assertFalse(json.contains("\\t"), "no decorator leak: $json")
+        assertEquals(editorFrom(json).text, editor.text, "live text diverged from the model")
+    }
+
+    @Test
+    fun whole_line_delete_keeps_a_bulleted_item() = assertKeepsIdentity(BULLET, "bulletList")
+
+    @Test
+    fun whole_line_delete_keeps_an_ordered_item() = assertKeepsIdentity(ORDERED, "orderedList")
+
+    @Test
+    fun whole_line_delete_keeps_a_task_item() = assertKeepsIdentity(TASK, "\"checked\":true")
+
+    @Test
+    fun whole_line_delete_between_list_items_keeps_the_following_item() {
+        val json = """{"type":"doc","content":[
+            {"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"aa"}]}]}]},
+            {"type":"paragraph","content":[{"type":"text","text":"mid"}]},
+            {"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"bb"}]}]}]}
+        ]}"""
+        val editor = editorFrom(json)
+        val start = editor.offsetOf("mid")
+
+        editor.deleteText(start, "mid\n".length)
+
+        val out = editor.toJson()
+        assertFalse(out.contains("\\t"), "no decorator leak: $out")
+        assertEquals(editorFrom(out).text, editor.text)
+    }
+}


### PR DESCRIPTION
Fixes #72.

**Problem**

A delete that consumed a piece exactly replaced it with a **zero-length husk**. A husk surviving at a line start hides the following decorator from paragraph-type detection — so deleting an entire line before a list item exported that item as a plain paragraph with its decorator string as literal text content (`{"type":"text","text":"\t\t• "}`): persistent corruption of the saved document, with live text and model agreeing on the corrupted form.

**Fix**

When a delete fully consumes a single piece, remove it from the rope instead of replacing it with a zero-length copy — matching the multi-piece delete path, which already drops fully covered pieces — and reseed via `ensureNotEmpty()` (from #64) when the table empties.

**Tests**

`WholeLineDeleteBeforeListTest` (4 cases, written first — 3 red before the fix): a whole-line delete before a bulleted, ordered, and task item keeps the item's list identity with no decorator leak and the stream matching the model, plus a whole-line delete *between* two lists. Full `:shared:jvmTest` green; JS + Wasm compile.
