### PR TITLE
fix: a delete inside a task decorator removes the decorator whole

### DIFF
--- a/shared/src/androidMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.android.kt
+++ b/shared/src/androidMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.android.kt
@@ -17,7 +17,7 @@ actual object TextDecoratorTransaction {
         actionModel: TextEditorAction.TextRemoved
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         return when (paragraph.startPiece.decorator) {
-            is TextDecoratorModel.TaskDecoratorModel -> deleteTaskDecorator(paragraph, actionModel)
+            is TextDecoratorModel.TaskDecoratorModel -> deleteTaskDecorator(paragraph, lines, actionModel)
             else -> TextTransactionsUtils.getCommonDeleteDecoratorTransactions(paragraph, lines)
         }
     }
@@ -40,12 +40,14 @@ actual object TextDecoratorTransaction {
      * This function deletes a decorator.
      *
      * When we delete text within a decorator we need to validate if the remaining text matches a type of decorator.
-     * If it does, we replace it with the new decorator, otherwise we simply delete the decorator and insert the text from the previous decorator as text.
+     * If it does, we replace it with the new decorator; otherwise the decorator is removed whole via the
+     * common delete path (the item becomes a paragraph) — see issue #74.
      *
      * @return A Pair with the new cursor position and a list of transactions [TextEditorListItemTransaction].
      */
     private fun deleteTaskDecorator(
         paragraph: PieceParagraph,
+        lines: MultiPieceParagraph,
         actionModel: TextEditorAction.TextRemoved
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         val decoratorOffset = paragraph.startOffset
@@ -65,13 +67,10 @@ actual object TextDecoratorTransaction {
 
             Pair(TextRange(actionModel.offset), listOf(transaction))
         } else {
-            val model = TextEditorModel.create(text = newText)
-            val transaction = TextTransactionsUtils.updateTransaction(
-                decoratorOffset,
-                model,
-                paragraph.startPiece.length
-            )
-            Pair(TextRange(actionModel.offset), listOf(transaction))
+            // The remnant is no longer a valid decorator: remove the decorator whole (item becomes
+            // a paragraph), matching the common path and the iOS actual — restoring the fragments
+            // as literal text persisted presentation garbage into the export (issue #74).
+            TextTransactionsUtils.getCommonDeleteDecoratorTransactions(paragraph, lines)
         }
     }
 }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MidDecoratorDeleteTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MidDecoratorDeleteTest.kt
@@ -1,0 +1,70 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * A delete whose range falls inside a list item's decorator removes the decorator **whole** — the
+ * item becomes a plain paragraph, per the existing backspace-on-decorator convention — instead of
+ * truncating the marker into literal text fragments that persist in the export. Regression cover
+ * for issue #74.
+ */
+class MidDecoratorDeleteTest {
+
+    private val ONE_BULLET = """{"type":"doc","content":[{"type":"bulletList","content":[
+        {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"bb"}]}]}
+    ]}]}"""
+
+    private fun assertNoCorruption(editor: com.jjrodcast.textkit.editor.core.TextKitEditorManager) {
+        val json = editor.toJson()
+        assertFalse(json.contains("\\t"), "no decorator leak: $json")
+        assertEquals(editorFrom(json).text, editor.text, "live text diverged from the model")
+        assertEquals(json, editorFrom(json).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun mid_decorator_delete_on_an_empty_task_item_removes_the_decorator_whole() {
+        val editor = editorFrom("{}")
+        editor.toListItem(TextRange(0, 0), TextEditorListItem.None, TextEditorListItem.CheckList)
+
+        editor.deleteText(2, 3)
+
+        assertNoCorruption(editor)
+    }
+
+    @Test
+    fun mid_decorator_delete_on_a_bulleted_item_keeps_the_content() {
+        val editor = editorFrom(ONE_BULLET)
+
+        editor.deleteText(1, 2)
+
+        assertTrue(editor.text.contains("bb"), "content survives: [${editor.text}]")
+        assertNoCorruption(editor)
+    }
+
+    @Test
+    fun mid_decorator_delete_on_an_ordered_item_keeps_the_content() {
+        val editor = editorFrom(SampleDocuments.ORDERED_LIST)
+
+        editor.deleteText(1, 2)
+
+        assertTrue(editor.text.contains("one"), "content survives: [${editor.text}]")
+        assertNoCorruption(editor)
+    }
+
+    @Test
+    fun a_delete_starting_in_the_decorator_and_ending_in_content_keeps_the_rest() {
+        val editor = editorFrom(ONE_BULLET)
+        val contentStart = editor.offsetOf("bb")
+
+        // From inside the decorator through the first content char.
+        editor.deleteText(2, contentStart - 2 + 1)
+
+        assertTrue(editor.text.contains("b"), "remaining content survives: [${editor.text}]")
+        assertNoCorruption(editor)
+    }
+}

--- a/shared/src/jvmMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.jvm.kt
@@ -17,7 +17,7 @@ actual object TextDecoratorTransaction {
         actionModel: TextEditorAction.TextRemoved
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         return when (paragraph.startPiece.decorator) {
-            is TextDecoratorModel.TaskDecoratorModel -> deleteTaskDecorator(paragraph, actionModel)
+            is TextDecoratorModel.TaskDecoratorModel -> deleteTaskDecorator(paragraph, lines, actionModel)
             else -> TextTransactionsUtils.getCommonDeleteDecoratorTransactions(paragraph, lines)
         }
     }
@@ -40,12 +40,14 @@ actual object TextDecoratorTransaction {
      * This function deletes a decorator.
      *
      * When we delete text within a decorator we need to validate if the remaining text matches a type of decorator.
-     * If it does, we replace it with the new decorator, otherwise we simply delete the decorator and insert the text from the previous decorator as text.
+     * If it does, we replace it with the new decorator; otherwise the decorator is removed whole via the
+     * common delete path (the item becomes a paragraph) — see issue #74.
      *
      * @return A Pair with the new cursor position and a list of transactions [TextEditorListItemTransaction].
      */
     private fun deleteTaskDecorator(
         paragraph: PieceParagraph,
+        lines: MultiPieceParagraph,
         actionModel: TextEditorAction.TextRemoved
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         val decoratorOffset = paragraph.startOffset
@@ -65,13 +67,10 @@ actual object TextDecoratorTransaction {
 
             Pair(TextRange(actionModel.offset), listOf(transaction))
         } else {
-            val model = TextEditorModel.create(text = newText)
-            val transaction = TextTransactionsUtils.updateTransaction(
-                decoratorOffset,
-                model,
-                paragraph.startPiece.length
-            )
-            Pair(TextRange(actionModel.offset), listOf(transaction))
+            // The remnant is no longer a valid decorator: remove the decorator whole (item becomes
+            // a paragraph), matching the common path and the iOS actual — restoring the fragments
+            // as literal text persisted presentation garbage into the export (issue #74).
+            TextTransactionsUtils.getCommonDeleteDecoratorTransactions(paragraph, lines)
         }
     }
 }

--- a/shared/src/webMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.web.kt
+++ b/shared/src/webMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.web.kt
@@ -17,7 +17,7 @@ actual object TextDecoratorTransaction {
         actionModel: TextEditorAction.TextRemoved
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         return when (paragraph.startPiece.decorator) {
-            is TextDecoratorModel.TaskDecoratorModel -> deleteTaskDecorator(paragraph, actionModel)
+            is TextDecoratorModel.TaskDecoratorModel -> deleteTaskDecorator(paragraph, lines, actionModel)
             else -> TextTransactionsUtils.getCommonDeleteDecoratorTransactions(paragraph, lines)
         }
     }
@@ -40,12 +40,14 @@ actual object TextDecoratorTransaction {
      * This function deletes a decorator.
      *
      * When we delete text within a decorator we need to validate if the remaining text matches a type of decorator.
-     * If it does, we replace it with the new decorator, otherwise we simply delete the decorator and insert the text from the previous decorator as text.
+     * If it does, we replace it with the new decorator; otherwise the decorator is removed whole via the
+     * common delete path (the item becomes a paragraph) — see issue #74.
      *
      * @return A Pair with the new cursor position and a list of transactions [TextEditorListItemTransaction].
      */
     private fun deleteTaskDecorator(
         paragraph: PieceParagraph,
+        lines: MultiPieceParagraph,
         actionModel: TextEditorAction.TextRemoved
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         val decoratorOffset = paragraph.startOffset
@@ -65,13 +67,10 @@ actual object TextDecoratorTransaction {
 
             Pair(TextRange(actionModel.offset), listOf(transaction))
         } else {
-            val model = TextEditorModel.create(text = newText)
-            val transaction = TextTransactionsUtils.updateTransaction(
-                decoratorOffset,
-                model,
-                paragraph.startPiece.length
-            )
-            Pair(TextRange(actionModel.offset), listOf(transaction))
+            // The remnant is no longer a valid decorator: remove the decorator whole (item becomes
+            // a paragraph), matching the common path and the iOS actual — restoring the fragments
+            // as literal text persisted presentation garbage into the export (issue #74).
+            TextTransactionsUtils.getCommonDeleteDecoratorTransactions(paragraph, lines)
         }
     }
 }


### PR DESCRIPTION
Fixes #74.

**Problem**

When a delete range fell inside a task item's decorator and the remnant no longer matched a decorator pattern, the jvm/android/web `TextDecoratorTransaction` replaced the decorator with the **leftover fragments as literal text** — tabs and marker characters persisted into the exported document as content (`{"type":"text","text":"\t\t "}`), destroying the item's identity. Live text and model agreed on the corrupted form, so nothing downstream caught it.

Notably, the **iOS actual never had this path** — it routes every decorator delete through the common whole-decorator removal.

**Fix**

Align the three actuals with iOS for the invalid-remnant case: remove the decorator whole via `getCommonDeleteDecoratorTransactions` (the item becomes a paragraph, per the existing backspace-on-decorator convention). The still-valid-remnant morph branch is kept unchanged.

**Tests**

`MidDecoratorDeleteTest` (4 cases, written first): mid-decorator deletes on an empty task item (the red repro), bulleted and ordered items, and a delete spanning decorator into content — each asserting no decorator leak, stream/model agreement, and a fixed-point export. Full `:shared:jvmTest` green; JS + Wasm compile (the web actual is among the changed files).
