### PR TITLE
fix: replace on an empty paragraph or at the document end no longer crashes

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextUpdateTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextUpdateTransaction.kt
@@ -19,13 +19,35 @@ internal object TextUpdateTransaction {
         manager: TextKitEditorManager
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         val selectedParagraphs = lines.paragraphsInSelectedRange.filter { it.piecesInSelectedRange.isNotEmpty() }
-        return if (selectedParagraphs.size > 1) {
-            val firstParagraphInRange = selectedParagraphs.first()
-            val lastParagraphInRange = selectedParagraphs.last()
-            manager.transaction.updateOnMultipleParagraphs(firstParagraphInRange, lastParagraphInRange, lines, actionModel)
-        } else {
-            manager.transaction.updateOnSingleParagraph(selectedParagraphs.first(), actionModel)
+        return when {
+            // No piece in range — the window sits on an empty paragraph or at the document end
+            // (an IME composition delivering text there). Degrade to a plain replacement at the
+            // offset instead of crashing on the empty selection (issue #77).
+            selectedParagraphs.isEmpty() -> manager.transaction.updateOutsidePieces(actionModel)
+
+            selectedParagraphs.size > 1 -> {
+                val firstParagraphInRange = selectedParagraphs.first()
+                val lastParagraphInRange = selectedParagraphs.last()
+                manager.transaction.updateOnMultipleParagraphs(firstParagraphInRange, lastParagraphInRange, lines, actionModel)
+            }
+
+            else -> manager.transaction.updateOnSingleParagraph(selectedParagraphs.first(), actionModel)
         }
+    }
+
+    private fun TextEditorTransaction.updateOutsidePieces(
+        actionModel: TextEditorAction.TextUpdated
+    ): Pair<TextRange, List<TextEditorListItemTransaction>> {
+        // At the document end there is no piece at the offset itself; inherit the marks of the
+        // character before it so an IME composition finishing there continues the formatting.
+        val marks = when {
+            actionModel.offset < text.length -> marksAtOrEmpty(actionModel.offset)
+            actionModel.offset > 0 -> marksAtOrEmpty(actionModel.offset - 1)
+            else -> emptySet()
+        }
+        val model = TextEditorModel.create(text = actionModel.text, marks = marks, decorator = null)
+        val transaction = updateTransaction(actionModel.offset, model, actionModel.removeLength)
+        return Pair(TextRange(actionModel.offset + actionModel.text.length), listOf(transaction))
     }
 
     private fun TextEditorTransaction.updateOnMultipleParagraphs(

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ReplaceOutsidePiecesTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ReplaceOutsidePiecesTest.kt
@@ -1,0 +1,85 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A replace whose window sits where no piece is in range — an empty paragraph or the document end —
+ * must degrade to a plain replacement instead of crashing. A replace with `removeLength = 0` is how
+ * IME composition and autocorrect deliver text, and the document end is where composition usually
+ * happens. Regression cover for issue #77.
+ */
+class ReplaceOutsidePiecesTest {
+
+    private val EMPTY_PARA_MID = """{"type":"doc","content":[
+        {"type":"paragraph","content":[{"type":"text","text":"a"}]},
+        {"type":"paragraph"},
+        {"type":"paragraph","content":[{"type":"text","text":"b"}]}
+    ]}"""
+
+    private fun assertConsistent(editor: com.jjrodcast.textkit.editor.core.TextKitEditorManager) {
+        val json = editor.toJson()
+        assertEquals(editorFrom(json).text, editor.text, "live text diverged from the model")
+        assertEquals(json, editorFrom(json).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun replace_on_an_empty_paragraph_inserts_there() {
+        val editor = editorFrom(EMPTY_PARA_MID)
+
+        editor.replaceText(offset = 2, removeLength = 0, textToAdd = "e")
+
+        assertEquals("a\ne\nb", editor.text)
+        assertConsistent(editor)
+    }
+
+    @Test
+    fun replace_at_the_document_end_appends() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+
+        editor.replaceText(offset = editor.text.length, removeLength = 0, textToAdd = "e")
+
+        assertEquals("Hello worlde", editor.text)
+        assertConsistent(editor)
+    }
+
+    @Test
+    fun replace_on_a_trailing_blank_line_inserts_there() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        editor.typeText(editor.text.length, "\n")
+
+        editor.replaceText(offset = editor.text.length, removeLength = 0, textToAdd = "e")
+
+        assertEquals("Hello world\ne", editor.text)
+        assertConsistent(editor)
+    }
+
+    @Test
+    fun replace_at_the_end_of_a_bold_run_continues_the_formatting() {
+        val editor = editorFrom(SampleDocuments.SINGLE_PARAGRAPH)
+        editor.applyStyle(editor.rangeOf("Hello world"), com.jjrodcast.textkit.editor.components.TextEditorStyleItem.Bold)
+
+        editor.replaceText(offset = editor.text.length, removeLength = 0, textToAdd = "e")
+
+        assertEquals("Hello worlde", editor.text)
+        assertTrue(
+            editor.marksAt(editor.rangeOf("worlde")).has<com.jjrodcast.textkit.editor.core.parser.BoldMark>(),
+            "the appended character inherits the bold run: ${editor.toJson()}",
+        )
+        assertConsistent(editor)
+    }
+
+    @Test
+    fun replace_on_a_blank_line_only_document_inserts_there() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "x")
+        editor.typeText(1, "\n")
+        editor.deleteText(0, 1)
+
+        editor.replaceText(offset = 1, removeLength = 0, textToAdd = "e")
+
+        assertEquals("\ne", editor.text)
+        assertConsistent(editor)
+    }
+}


### PR DESCRIPTION
Fixes #77.

**Problem**

`updateText` filtered the selected paragraphs to those with pieces in range and called `.first()` unguarded — on an empty paragraph or at the document end the filter yields nothing and the call threw `NoSuchElementException`. A replace with `removeLength = 0` is how IME composition and autocorrect deliver text, and the document end is where composition usually happens — an everyday hard crash on mobile input.

**Fix**

Degrade the no-pieces case to a plain replacement at the offset, inheriting the marks at that position when there are any.

**Tests**

`ReplaceOutsidePiecesTest` (4 cases, written first — all red before the fix): replace on an empty paragraph between two others, at the document end, on a trailing blank line, and on a blank-line-only document — each asserting the resulting text, stream/model agreement, and a fixed-point export. Full `:shared:jvmTest` green; JS + Wasm compile.
