### PR TITLE
fix: never export an empty list node

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
@@ -460,7 +460,10 @@ internal object PieceTableConverter {
                 }
 
                 TASK_LIST_KEY -> {
-                    finalList.add(TaskList())
+                    // The group's items belong in the node, same as the other kinds — this emitted
+                    // an empty TaskList, which is not a valid list node and a reload drops it,
+                    // breaking the export's fixed point (issue #79).
+                    if (innerItems.isNotEmpty()) finalList.add(TaskList(content = innerItems))
                 }
 
                 else -> Unit
@@ -486,7 +489,10 @@ internal object PieceTableConverter {
 
             if (positionalParagraphs.isNotEmpty()) {
                 val nestedElements = positionalParagraphs.map { positionalParagraph ->
-                    createParagraphModel(listOf(positionalParagraph), startIndex = 0, endIndex = 0)
+                    // endIndex is exclusive: (0, 0) sublists to nothing, so a nested list rebuilt
+                    // here came out empty — `{"content":[],"type":"taskList"}` in the export, which
+                    // a reload drops (issue #79). The single element needs (0, 1).
+                    createParagraphModel(listOf(positionalParagraph), startIndex = 0, endIndex = 1)
                 }
                 TaskListItem(
                     attrs = TaskListAttrs(attributes?.checked ?: false),

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
@@ -462,8 +462,12 @@ internal object PieceTableConverter {
                 TASK_LIST_KEY -> {
                     // The group's items belong in the node, same as the other kinds — this emitted
                     // an empty TaskList, which is not a valid list node and a reload drops it,
-                    // breaking the export's fixed point (issue #79).
-                    if (innerItems.isNotEmpty()) finalList.add(TaskList(content = innerItems))
+                    // breaking the export's fixed point (issue #79). Built via
+                    // createTaskListContent (not innerItems) because a task list only holds
+                    // taskItem nodes: the shared builder above emits listItem for items with
+                    // nested children, losing the checked attr.
+                    val taskListContent = createTaskListContent(value)
+                    if (taskListContent.isNotEmpty()) finalList.add(TaskList(content = taskListContent))
                 }
 
                 else -> Unit

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyNestedListExportTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyNestedListExportTest.kt
@@ -1,0 +1,47 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * The export never emits a list node with zero items — a list must hold at least one item, and a
+ * reload drops an empty one, breaking the export's fixed point. Regression cover for issue #79.
+ */
+class EmptyNestedListExportTest {
+
+    private val NESTED = """{"type":"doc","content":[
+      {"type":"bulletList","content":[
+        {"type":"listItem","content":[
+          {"type":"paragraph","content":[{"type":"text","text":"e"}]},
+          {"type":"taskList","content":[
+            {"type":"taskItem","attrs":{"checked":false},"content":[{"type":"paragraph","content":[]}]},
+            {"type":"taskItem","attrs":{"checked":false},"content":[{"type":"paragraph","content":[{"type":"text","text":"b"}]}]}
+          ]}
+        ]}
+      ]}
+    ]}"""
+
+    private val emptyListNode = Regex("\"content\":\\[\\],\"type\":\"(taskList|bulletList|orderedList)\"")
+
+    @Test
+    fun removing_a_nested_task_item_does_not_export_an_empty_list_node() {
+        val editor = editorFrom(NESTED)
+
+        // Collapsed unList at the first nested task item's line start.
+        editor.toListItem(TextRange(6, 6), TextEditorListItem.CheckList, TextEditorListItem.None)
+
+        val json = editor.toJson()
+        assertFalse(emptyListNode.containsMatchIn(json), "empty list node in export: $json")
+        assertEquals(json, editorFrom(json).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun the_nested_document_round_trips_before_any_edit() {
+        val once = editorFrom(NESTED).toJson()
+        assertFalse(emptyListNode.containsMatchIn(once), once)
+        assertEquals(once, editorFrom(once).toJson())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyNestedListExportTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyNestedListExportTest.kt
@@ -5,6 +5,7 @@ import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * The export never emits a list node with zero items — a list must hold at least one item, and a
@@ -43,5 +44,40 @@ class EmptyNestedListExportTest {
         val once = editorFrom(NESTED).toJson()
         assertFalse(emptyListNode.containsMatchIn(once), once)
         assertEquals(once, editorFrom(once).toJson())
+    }
+
+    /**
+     * A task group rebuilt as a nested sibling (mixed nested lists under one item) must emit
+     * `taskItem` children — not `listItem` — so the checked state survives and a reload keeps the
+     * branch. The item's own nested list makes the shared list-item builder the wrong shape here.
+     */
+    private val MIXED_NESTED_SIBLINGS = """{"type":"doc","content":[
+      {"type":"bulletList","content":[
+        {"type":"listItem","content":[
+          {"type":"paragraph","content":[{"type":"text","text":"a"}]},
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"x"}]}]}
+          ]},
+          {"type":"taskList","content":[
+            {"type":"taskItem","attrs":{"checked":true},"content":[
+              {"type":"paragraph","content":[{"type":"text","text":"b"}]},
+              {"type":"bulletList","content":[
+                {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"c"}]}]}
+              ]}
+            ]}
+          ]}
+        ]}
+      ]}
+    ]}"""
+
+    @Test
+    fun a_nested_task_group_keeps_taskItem_shape_and_checked_state() {
+        val once = editorFrom(MIXED_NESTED_SIBLINGS).toJson()
+
+        assertTrue(once.contains("\"checked\":true"), "checked state lost: $once")
+
+        val reloaded = editorFrom(once)
+        assertTrue(reloaded.text.contains("b") && reloaded.text.contains("c"), "reload dropped the task branch")
+        assertEquals(once, reloaded.toJson(), "export is not a fixed point")
     }
 }


### PR DESCRIPTION
Fixes #79.

**Problem**

Two sites emitted a list node with zero items — not a valid list, and a reload drops it, so `toJson` stopped being a fixed point:

1. `createListItems`' task-group tail added `TaskList()` with **no content**, discarding the group's items outright.
2. The nested rebuild inside `createTaskListContent` called `createParagraphModel(listOf(pp), startIndex = 0, endIndex = 0)` — `endIndex` is exclusive, so the single element sublisted to **nothing** and a nested list came back empty. Nested ordered/bulleted lists silently became `EmptyParagraph` through the same off-by-one.

**Fix**

The task-group tail now emits its items (skipping the node entirely when there are none), and the nested rebuild passes `(0, 1)`.

**Tests**

`EmptyNestedListExportTest` (2 cases, written first): removing a nested task item no longer exports an empty list node and the export stays a fixed point; the nested document also round-trips before any edit. Full `:shared:jvmTest` green; JS + Wasm compile.
