### PR TITLE
fix: swallow a following decorator when a removal window reaches into it

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
@@ -94,8 +94,14 @@ internal object TextDeletedTransaction {
         actionModel: TextEditorAction.TextRemoved
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         val firstParagraphIncludesDecorator = firstParagraph.piecesInSelectedRange.first().piece.isDecorator
-        val isLastDecoratorPartiallySelected =
-            getOffsetAfterDecorator(lastParagraph, lastParagraph.piecesInSelectedRange.last().piece.offset) > 0
+        // Document coordinates: the window's end lies strictly inside the last item's decorator
+        // span. The previous form passed the piece's *buffer* offset into document-offset math, so
+        // once a decorator lived deep in the ADDED buffer the predicate went false and the partial
+        // decorator survived the delete as a mid-line fragment.
+        val windowEnd = actionModel.offset + actionModel.length
+        val isLastDecoratorPartiallySelected = lastParagraph.isListItem &&
+            windowEnd > lastParagraph.startOffset &&
+            getOffsetAfterDecorator(lastParagraph, windowEnd) > 0
         val transactions = mutableListOf<TextEditorListItemTransaction>()
 
         var offset = actionModel.offset

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextUpdateTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextUpdateTransaction.kt
@@ -11,6 +11,8 @@ import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorAction
 import com.jjrodcast.textkit.editor.core.transactions.text.TextTransactionsUtils.getOffsetAfterDecorator
 import com.jjrodcast.textkit.editor.core.transactions.text.TextTransactionsUtils.reorderListItemsOnUpdate
 import com.jjrodcast.textkit.editor.core.transactions.text.TextTransactionsUtils.updateTransaction
+import com.jjrodcast.textkit.editor.utils.endsWithLineBreak
+import com.jjrodcast.textkit.editor.utils.isLineBreak
 
 internal object TextUpdateTransaction {
     internal fun updateText(
@@ -18,6 +20,15 @@ internal object TextUpdateTransaction {
         actionModel: TextEditorAction.TextUpdated,
         manager: TextKitEditorManager
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
+        val extended = extendPastOrphanedDecorator(lines, actionModel, manager)
+        if (extended != null) {
+            val newLines = manager.transaction.getLineContentWithNeighborParagraphs(
+                extended.offset,
+                extended.offset + extended.removeLength
+            )
+            return updateText(newLines, extended, manager)
+        }
+
         val selectedParagraphs = lines.paragraphsInSelectedRange.filter { it.piecesInSelectedRange.isNotEmpty() }
         return when {
             // No piece in range — the window sits on an empty paragraph or at the document end
@@ -33,6 +44,35 @@ internal object TextUpdateTransaction {
 
             else -> manager.transaction.updateOnSingleParagraph(selectedParagraphs.first(), actionModel)
         }
+    }
+
+    /**
+     * A replace whose removal window consumes a paragraph's terminating line break and stops
+     * exactly at the next list item's start merges the two lines — and, unless the replacement
+     * text restores the break, leaves that item's decorator orphaned mid-line in the text stream
+     * (the delete path got the same rule for issue #67). Reach one character into the following
+     * decorator and re-dispatch, so the existing partially-selected-decorator handling swallows it
+     * whole and renumbers the remaining items. Returns `null` when no extension applies; the
+     * extended range ends inside the decorator, so the re-dispatch can never extend a second time.
+     */
+    private fun extendPastOrphanedDecorator(
+        lines: MultiPieceParagraph,
+        actionModel: TextEditorAction.TextUpdated,
+        manager: TextKitEditorManager
+    ): TextEditorAction.TextUpdated? {
+        val end = actionModel.offset + actionModel.removeLength
+        if (end >= manager.text.length) return null
+        if (manager.text.getOrNull(end - 1)?.isLineBreak() != true) return null
+        if (actionModel.text.endsWithLineBreak()) return null
+        val firstParagraph = lines.paragraphsInSelectedRange.firstOrNull { it.piecesInSelectedRange.isNotEmpty() }
+            ?: return null
+        // Unlike a plain delete, any non-empty replacement itself becomes a head for the merged
+        // line, so the following decorator is orphaned even when the whole first line is removed.
+        val keepsLineHead = actionModel.text.isNotEmpty() ||
+            firstParagraph.isListItem || actionModel.offset > firstParagraph.startOffset
+        if (!keepsLineHead) return null
+        lines.paragraphs.firstOrNull { it.startOffset == end && it.isListItem } ?: return null
+        return actionModel.copy(removeLength = actionModel.removeLength + 1)
     }
 
     private fun TextEditorTransaction.updateOutsidePieces(
@@ -57,8 +97,13 @@ internal object TextUpdateTransaction {
         actionModel: TextEditorAction.TextUpdated
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         val firstParagraphIncludesDecorator = firstParagraph.piecesInSelectedRange.first().piece.isDecorator
-        val isLastDecoratorPartiallySelected =
-            getOffsetAfterDecorator(lastParagraph, lastParagraph.piecesInSelectedRange.last().piece.offset) > 0
+        // Document coordinates: the window's end lies strictly inside the last item's decorator
+        // span (see the same predicate in TextDeletedTransaction — the previous buffer-offset form
+        // went false for decorators deep in the ADDED buffer, leaving mid-line fragments).
+        val windowEnd = actionModel.offset + actionModel.removeLength
+        val isLastDecoratorPartiallySelected = lastParagraph.isListItem &&
+            windowEnd > lastParagraph.startOffset &&
+            getOffsetAfterDecorator(lastParagraph, windowEnd) > 0
         val transactions = mutableListOf<TextEditorListItemTransaction>()
 
         var offset = actionModel.offset

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/RemovalWindowIntoDecoratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/RemovalWindowIntoDecoratorTest.kt
@@ -1,0 +1,140 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A delete or replace whose removal window reaches into a following list item's decorator — either
+ * ending strictly inside it, or stopping at the item's start after consuming the preceding line
+ * break — must swallow the decorator whole and merge the lines. Leaving a fragment puts decorator
+ * text mid-line, which the export silently drops and later inserts crash on.
+ *
+ * The items are built by typing + toggling (not loading), so their decorators live in the ADDED
+ * buffer: the broken predicate compared a buffer offset against document offsets and only
+ * misfired once decorators sat deep in that buffer.
+ */
+class RemovalWindowIntoDecoratorTest {
+
+    /** No decorator piece may sit anywhere but the start of its paragraph. */
+    private fun TextKitEditorManager.assertNoMidlineDecorator() {
+        getParagraphs().forEachIndexed { i, p ->
+            assertTrue(
+                p.children.drop(1).none { it.decorator != null },
+                "paragraph $i carries a mid-line decorator: ${text.replace("\n", "\\n").replace("\t", "\\t")}"
+            )
+        }
+    }
+
+    private fun TextKitEditorManager.assertExportStable() {
+        val once = toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    /**
+     * `\t\t• one` / `\t\t• two`, built after typing and deleting a long padding paragraph. The
+     * padding grows the ADDED buffer while the document shrinks back, so the items' decorators sit
+     * at buffer offsets far past any document offset — the states where the buffer/document mixup
+     * flipped the predicate (in a fresh document the two coordinate spaces track too closely to
+     * misfire).
+     */
+    private fun twoBulletItems(): TextKitEditorManager {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "padding padding padding padding padding")
+        editor.deleteText(0, editor.text.length)
+        editor.typeText(0, "one\ntwo")
+        editor.toListItem(TextRange(0, editor.text.length), TextEditorListItem.None, TextEditorListItem.BulletedList)
+        return editor
+    }
+
+    @Test
+    fun a_delete_ending_inside_the_next_items_decorator_swallows_it_whole() {
+        val editor = twoBulletItems()
+        val breakAt = editor.text.lastIndexOf('\n')
+
+        // From inside "one", across the break, ending two characters into item two's decorator.
+        editor.deleteText(breakAt - 1, 3)
+
+        assertTrue(editor.text.contains("on"), editor.text)
+        assertTrue(editor.text.contains("two"), editor.text)
+        editor.assertNoMidlineDecorator()
+        editor.assertExportStable()
+        assertEquals(1, editor.toJson().split("\"type\":\"listItem\"").size - 1, "items must merge into one")
+    }
+
+    @Test
+    fun a_replace_ending_inside_the_next_items_decorator_swallows_it_whole() {
+        val editor = twoBulletItems()
+        val breakAt = editor.text.lastIndexOf('\n')
+
+        editor.replaceText(breakAt - 1, 3, "X")
+
+        assertTrue(editor.text.contains("onX"), editor.text)
+        editor.assertNoMidlineDecorator()
+        editor.assertExportStable()
+        assertEquals(1, editor.toJson().split("\"type\":\"listItem\"").size - 1, "items must merge into one")
+    }
+
+    @Test
+    fun replacing_the_break_between_two_items_merges_them_without_orphaning_the_decorator() {
+        val editor = twoBulletItems()
+        val breakAt = editor.text.lastIndexOf('\n')
+
+        // The removal window is exactly the terminating break; the replacement text becomes the
+        // head of the merged line, so the second item's decorator must go with the merge.
+        editor.replaceText(breakAt, 1, "X")
+
+        assertTrue(editor.text.contains("oneXtwo"), editor.text)
+        editor.assertNoMidlineDecorator()
+        editor.assertExportStable()
+    }
+
+    @Test
+    fun replacing_the_break_between_two_task_items_merges_them() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "a\nb")
+        editor.toListItem(TextRange(0, editor.text.length), TextEditorListItem.None, TextEditorListItem.CheckList)
+        val breakAt = editor.text.indexOf('\n')
+
+        editor.replaceText(breakAt, 1, "X")
+
+        assertTrue(editor.text.contains("aXb"), editor.text)
+        editor.assertNoMidlineDecorator()
+        editor.assertExportStable()
+        assertEquals(1, editor.toJson().split("\"checked\"").size - 1, "task items must merge into one")
+    }
+
+    @Test
+    fun typing_after_the_merge_does_not_crash() {
+        // The downstream symptom of the fragment: a later insert near the leaked decorator text
+        // routed into the task-decorator handler with an offset far outside the decorator.
+        val editor = editorFrom("{}")
+        editor.typeText(0, "a\nb")
+        editor.toListItem(TextRange(0, editor.text.length), TextEditorListItem.None, TextEditorListItem.CheckList)
+        editor.replaceText(editor.text.indexOf('\n'), 1, "cc")
+
+        editor.typeText(editor.text.length, "d")
+
+        assertTrue(editor.text.contains("ccbd") || editor.text.contains("ccb") && editor.text.endsWith("d"), editor.text)
+        editor.assertNoMidlineDecorator()
+        editor.assertExportStable()
+    }
+
+    @Test
+    fun a_delete_into_a_numbered_decorator_renumbers_the_remaining_items() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "one\ntwo\nthree")
+        editor.toListItem(TextRange(0, editor.text.length), TextEditorListItem.None, TextEditorListItem.NumberedList)
+        val breakAt = editor.text.indexOf('\n')
+
+        // Swallow item two's decorator: items one and two merge, item three becomes number two.
+        editor.deleteText(breakAt - 1, 3)
+
+        editor.assertNoMidlineDecorator()
+        editor.assertExportStable()
+        assertTrue(editor.text.contains("2. three") || editor.text.contains("2."), editor.text)
+    }
+}


### PR DESCRIPTION
Closes #82

Two changes, both in the multi-paragraph removal paths:

- `isLastDecoratorPartiallySelected` is now computed in document coordinates (window end strictly inside the last item's decorator span, and only for list items). The previous form compared the decorator piece's buffer offset against document offsets, so the partial-decorator swallow stopped firing once decorators sat deep in the ADDED buffer.
- `TextUpdateTransaction` gets the replace-side mirror of `extendPastOrphanedDecorator` (#67/`TextDeletedTransaction`): a removal window that consumes the terminating line break and stops at the next item's start extends one char into the decorator and re-dispatches, so the existing handling swallows it whole and renumbers. One difference from the delete rule: a non-empty replacement is itself a head for the merged line, so the extension also applies when the whole first line is replaced (and not when the replacement itself ends with a line break).

Tests: `RemovalWindowIntoDecoratorTest` — 6 cases covering delete/replace windows ending inside a decorator, replacing the break between bulleted/task items, renumbering after the merge, and the downstream insert-crash. All 6 fail on `main`. Full suite passes, JS/Wasm compile clean. In the seeded sweep (100 seeds × 250 ops) these two holes accounted for every remaining crash; none remain with the fix.