### PR TITLE
fix: export the loader's canonical form for nested lists

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
@@ -492,7 +492,12 @@ internal object PieceTableConverter {
             val attributes = item.textStyled.firstOrNull()?.piece?.decorator as? TaskDecoratorModel
 
             if (positionalParagraphs.isNotEmpty()) {
-                val nestedElements = positionalParagraphs.map { positionalParagraph ->
+                // A task item's nested lists sit exactly one level below the item — that is the
+                // only shape a load can represent (nested lists inside a taskItem re-enter at the
+                // item's own level, unlike listItem chains which preserve relative depth). Deeper
+                // levels reached through live edits are flattened to document-ordered siblings so
+                // the export stays a fixed point.
+                val nestedElements = positionalParagraphs.flatMap { it.flattenSubtree() }.map { positionalParagraph ->
                     // endIndex is exclusive: (0, 0) sublists to nothing, so a nested list rebuilt
                     // here came out empty — `{"content":[],"type":"taskList"}` in the export, which
                     // a reload drops (issue #79). The single element needs (0, 1).
@@ -544,6 +549,10 @@ internal object PieceTableConverter {
         return result
     }
 
+    /** The node followed by all its descendants in document order, each with its children detached. */
+    private fun PositionalParagraph.flattenSubtree(): List<PositionalParagraph> =
+        listOf(copy(positionalParagraphs = arrayListOf())) + positionalParagraphs.flatMap { it.flattenSubtree() }
+
     private fun getParagraphContent(textStyled: List<TextEditorModel>): List<BaseParagraph> {
         // 1. Create internal Paragraph
         val internalParagraphs = createInternalParagraphs(textStyled)
@@ -552,9 +561,12 @@ internal object PieceTableConverter {
         return internalParagraphs.fastMap { paragraph ->
             val textAlign = paragraph.styledText.resolveTextAlign()
             // A zero-length piece (an edit remnant) must not become an empty text node — invalid
-            // ProseMirror, silently dropped on reload (issue #61).
+            // ProseMirror, silently dropped on reload (issue #61). A lone line-break piece is the
+            // same case one step removed: toInlineNode strips the break and leaves "" (a loaded
+            // empty item carries its break as a separate piece; a live-edited one keeps it on the
+            // decorator piece, which is why only reloads leaked the node).
             val texts = paragraph.styledText
-                .mapNotNull { if (it.isDecorator || it.text.isEmpty()) null else it }
+                .mapNotNull { if (it.isDecorator || it.text.isEmpty() || it.text.isLineBreak()) null else it }
                 .fastMap { it.toInlineNode() }
 
             if (texts.isEmpty()) Paragraph(attrs = ParagraphAttrs(textAlign = textAlign))

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/NestedListCanonicalFormTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/NestedListCanonicalFormTest.kt
@@ -1,0 +1,92 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The export emits the loader's canonical nested-list form, so `toJson()` is a fixed point in
+ * every nested state (issue #81):
+ *
+ * - `listItem` chains preserve relative depth on load, so their nesting is kept as-is.
+ * - Anything nested below a `taskItem` re-enters at exactly one level under the item on load —
+ *   deeper levels reached through live edits are exported as document-ordered sibling lists,
+ *   because that is the only shape a reload can represent.
+ * - A loaded empty nested item carries its line break as a standalone piece; that piece must not
+ *   surface as an empty text node (`{"text":""}`) on re-export.
+ */
+class NestedListCanonicalFormTest {
+
+    /** `listItem` chain, three levels: bullet > ordered > bullet. Depth survives load. */
+    private val LIST_ITEM_CHAIN = """{"type":"doc","content":[
+      {"type":"bulletList","content":[
+        {"type":"listItem","content":[
+          {"type":"paragraph","content":[{"type":"text","text":"a"}]},
+          {"type":"orderedList","attrs":{"start":1},"content":[
+            {"type":"listItem","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"b"}]},
+              {"type":"bulletList","content":[
+                {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"c"}]}]}
+              ]}
+            ]}
+          ]}
+        ]}
+      ]}
+    ]}"""
+
+    private val EMPTY_NESTED_ITEM = """{"type":"doc","content":[
+      {"type":"taskList","content":[
+        {"type":"taskItem","attrs":{"checked":false},"content":[
+          {"type":"paragraph","content":[]},
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[{"type":"paragraph","content":[]}]}
+          ]},
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"x"}]}]}
+          ]}
+        ]}
+      ]}
+    ]}"""
+
+    @Test
+    fun a_loaded_empty_nested_item_does_not_export_an_empty_text_node() {
+        val once = editorFrom(EMPTY_NESTED_ITEM).toJson()
+
+        assertFalse(once.contains("\"text\":\"\""), "empty text node leaked: $once")
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun deep_nesting_under_a_task_item_exports_the_loadable_flattened_shape() {
+        // Load the listItem chain (depth preserved: levels 1..3), then convert the top item to a
+        // task item. The level-2 and level-3 lists now hang under a task item — a shape only live
+        // edits can produce, which the loader flattens to sibling lists one level below the item.
+        val editor = editorFrom(LIST_ITEM_CHAIN)
+        val aAt = editor.text.indexOf('a')
+        editor.toListItem(TextRange(aAt, aAt + 1), TextEditorListItem.BulletedList, TextEditorListItem.CheckList)
+
+        val once = editor.toJson()
+        val reloaded = editorFrom(once)
+
+        assertEquals(once, reloaded.toJson(), "export is not a fixed point")
+        assertTrue(once.contains("\"checked\""), once)
+        // No content is lost across the round trip.
+        for (t in listOf("a", "b", "c")) {
+            assertTrue(reloaded.text.contains(t), "reload lost '$t': ${reloaded.text}")
+        }
+    }
+
+    @Test
+    fun a_list_item_chain_keeps_its_nesting_and_its_indentation() {
+        val editor = editorFrom(LIST_ITEM_CHAIN)
+        val once = editor.toJson()
+        val reloaded = editorFrom(once)
+
+        assertEquals(once, reloaded.toJson(), "export is not a fixed point")
+        // Depth is preserved through listItem chains: the reloaded text renders identically.
+        assertEquals(editor.text, reloaded.text)
+    }
+}


### PR DESCRIPTION
Closes #81

Defines the canonical nested-list form as what a load can represent, and makes the export emit it, so `toJson()` → load → `toJson()` is a fixed point in every nested state:

- **`listItem` chains keep their nesting** — the loader preserves relative depth through `listItem` content, so nothing changes for bullet/ordered chains (a guard test pins this, including indentation across reload).
- **A task item's nested lists are exported as document-ordered sibling lists one level below the item** — on load, anything nested inside a `taskItem` re-enters at exactly that level, so deeper chains built by live edits restructured on reload. The export now flattens the subtree to the loadable shape.
- **A lone line-break piece no longer becomes an empty text node** — a loaded empty nested item carries its break as a standalone piece; `toInlineNode` strips the break and emitted `{"text":""}`, which the next reload dropped. Filtered next to the existing decorator/empty-piece filters.

Tests: `NestedListCanonicalFormTest` — 2 cases fail on `main`, plus the `listItem`-chain guard. Full suite passes, JS/Wasm compile clean.

With this and #83, the #46 seeded sweep runs 300 seeds × 250 ops with zero crashes and zero export divergences.