### PR TITLE
fix: recover newly decorated paragraphs by index in a multi-level toggle

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
@@ -370,9 +370,6 @@ internal object ListItemTransaction {
             }
         }
 
-        // Paragraph positions within nextElements that will receive a new decorator (for transaction tracking).
-        val selectedParagraphIndices = nextElements.mapIndexedNotNull { idx, item -> if (item.richPiece.decorator == null) idx else null }
-
         // Mutate newRichPiece in-place for prevElements that need a type change.
         prevElements.forEach { item ->
             if (item.richPiece.decorator.toTextEditorListItem() != listItem) {
@@ -403,7 +400,12 @@ internal object ListItemTransaction {
         val newPositionalListItems = ListsConverter.fromPositionalListItems(startItems + prevElements + itemsWithChangedLevels)
         val flattenItems = PositionalListItemUtils.reorderItems(items = newPositionalListItems)
 
-        val selectedParagraphs = selectedParagraphIndices.map { flattenItems[startItems.size + prevElements.size + it] }
+        // Recover the newly decorated paragraphs by their document index — the flat list's layout
+        // is not positionally stable after reorderItems restructures the tree (a selection ending
+        // inside a following item's decorator shifted the layout, handing that item an Insert and
+        // stacking a second decorator onto it).
+        val insertIndices = nextElements.mapNotNull { if (it.richPiece.decorator == null) it.index else null }.toSet()
+        val selectedParagraphs = flattenItems.filter { it.index in insertIndices }
         val transactions = flattenItems.createTransactions(selectedParagraphs)
         val newRange = ListItemTextEditorRangeUtils.getTextEditorRangeForMultiRange(flattenItems, selectedIndices, range)
         return Pair(transactions, newRange)

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/RangeToggleOverNestedItemTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/RangeToggleOverNestedItemTest.kt
@@ -51,8 +51,9 @@ class RangeToggleOverNestedItemTest {
 
         editor.assertNoMidlineDecorator()
         assertTrue(editor.text.contains("c"), editor.text)
-        // The break between the converted empty line and the following item survives.
-        assertEquals(4, editor.text.count { it == '\n' }, editor.text.replace("\n", "\\n").replace("\t", "\\t"))
+        // The break between the converted empty line and the following item survives: three lines
+        // were separated by three breaks before the toggle and still are after it.
+        assertEquals(3, editor.text.count { it == '\n' }, editor.text.replace("\n", "\\n").replace("\t", "\\t"))
         val once = editor.toJson()
         assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
     }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/RangeToggleOverNestedItemTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/RangeToggleOverNestedItemTest.kt
@@ -1,0 +1,74 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A range toggle whose selection spans a plain paragraph and reaches into a following nested list
+ * item must convert cleanly: the nested item's existing decorator is replaced, never stacked
+ * behind a second one, and the line break between the paragraphs survives.
+ */
+class RangeToggleOverNestedItemTest {
+
+    /** No decorator piece may sit anywhere but the start of its paragraph. */
+    private fun TextKitEditorManager.assertNoMidlineDecorator() {
+        getParagraphs().forEachIndexed { i, p ->
+            assertTrue(
+                p.children.drop(1).none { it.decorator != null },
+                "paragraph $i carries a mid-line decorator: ${text.replace("\n", "\\n").replace("\t", "\\t")}"
+            )
+        }
+    }
+
+    /** Parent bullet item with two nested (level-2) items. */
+    private val NESTED_TWO = """{"type":"doc","content":[
+      {"type":"bulletList","content":[
+        {"type":"listItem","content":[
+          {"type":"paragraph","content":[{"type":"text","text":"a"}]},
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"b"}]}]},
+            {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"c"}]}]}
+          ]}
+        ]}
+      ]}
+    ]}"""
+
+    @Test
+    fun a_toggle_spanning_a_plain_line_and_a_nested_items_decorator_does_not_stack_decorators() {
+        val editor = editorFrom(NESTED_TWO)
+        // Open an empty plain line between the two nested items, then toggle from inside the first
+        // nested item's text, across the empty line, ending inside the second item's decorator.
+        val cLine = editor.text.lastIndexOf('\n') + 1
+        editor.typeText(cLine, "\n")
+        val bAt = editor.text.indexOf('b')
+        val cLineStart = editor.text.lastIndexOf('\n') + 1
+
+        editor.toListItem(TextRange(bAt, cLineStart + 2), TextEditorListItem.None, TextEditorListItem.BulletedList)
+
+        editor.assertNoMidlineDecorator()
+        assertTrue(editor.text.contains("c"), editor.text)
+        // The break between the converted empty line and the following item survives.
+        assertEquals(4, editor.text.count { it == '\n' }, editor.text.replace("\n", "\\n").replace("\t", "\\t"))
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun typing_after_the_toggle_does_not_crash() {
+        val editor = editorFrom(NESTED_TWO)
+        val cLine = editor.text.lastIndexOf('\n') + 1
+        editor.typeText(cLine, "\n")
+        val bAt = editor.text.indexOf('b')
+        val cLineStart = editor.text.lastIndexOf('\n') + 1
+        editor.toListItem(TextRange(bAt, cLineStart + 2), TextEditorListItem.None, TextEditorListItem.BulletedList)
+
+        editor.typeText(editor.text.length, "d")
+
+        assertTrue(editor.text.endsWith("d"), editor.text)
+        editor.assertNoMidlineDecorator()
+    }
+}


### PR DESCRIPTION
Closes #85

`applyMultipleParagraphsLevels` now recovers the newly decorated paragraphs by their document index instead of by position in the flat list, which is not stable after `reorderItems` restructures the tree. With the positional lookup, a selection ending inside a following nested item's decorator handed that item an `Insert` instead of an `Update` — stacking a second decorator onto its line without removing the first and dropping the line break before it.

Tests: `RangeToggleOverNestedItemTest` — both fail on `main`. Full suite passes, JS/Wasm compile clean. With this fix the #46 sweep holds all three invariants (no throw, no mid-line decorator, export fixed point) across 300 seeds × 250 ops.