### PR TITLE
fix: stamp paragraph alignment after the decorator is prepended

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/TextEditorConverter.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/TextEditorConverter.kt
@@ -143,11 +143,15 @@ internal object TextEditorConverter {
                         )
                     }
                 }
-                items.applyTextAlign(attrs.textAlign)
                 when (decorator) {
                     is TextDecoratorModel.BlockquoteDecorator -> items.postProcessBlockquotes()
                     else -> items.postProcessParagraph(decorator)
                 }
+                // After post-processing, so the prepended decorator piece is stamped too: an empty
+                // list item has no text piece, and its line-break piece is dropped when the
+                // paragraph converts back — the decorator is then the only piece left to carry the
+                // alignment across a reload.
+                items.applyTextAlign(attrs.textAlign)
             }
 
             is Heading -> {
@@ -163,8 +167,9 @@ internal object TextEditorConverter {
                         )
                     }
                 }
-                items.applyTextAlign(attrs.textAlign)
                 items.postProcessParagraph(decorator)
+                // Same ordering as the Paragraph branch: stamp after the decorator is prepended.
+                items.applyTextAlign(attrs.textAlign)
             }
 
             is OrderedList -> {

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/AlignedEmptyItemTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/AlignedEmptyItemTest.kt
@@ -5,7 +5,6 @@ import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.core.parser.TextAlign
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  * Alignment on an empty list item survives the load/export round trip. An empty item has no text
@@ -41,7 +40,8 @@ class AlignedEmptyItemTest {
         editor.deleteText(xAt, 1)
 
         val once = editor.toJson()
-        assertTrue(once.contains("\"textAlign\":\"right\""), once)
+        // Both items — the emptied one and the "y" item — keep their alignment.
+        assertEquals(2, once.split("\"textAlign\":\"right\"").size - 1, "alignment dropped: $once")
         assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
     }
 

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/AlignedEmptyItemTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/AlignedEmptyItemTest.kt
@@ -1,0 +1,57 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Alignment on an empty list item survives the load/export round trip. An empty item has no text
+ * piece, and its line-break piece is dropped when the paragraph converts back — so the alignment
+ * must ride on the decorator piece, which the loader previously stamped before the decorator was
+ * prepended.
+ */
+class AlignedEmptyItemTest {
+
+    private val LEADING_EMPTY_ALIGNED = """{"type":"doc","content":[
+      {"type":"orderedList","attrs":{"start":1},"content":[
+        {"type":"listItem","content":[{"type":"paragraph","attrs":{"textAlign":"right"},"content":[]}]},
+        {"type":"listItem","content":[{"type":"paragraph","attrs":{"textAlign":"right"},"content":[{"type":"text","text":"x"}]}]}
+      ]}
+    ]}"""
+
+    @Test
+    fun a_loaded_empty_aligned_item_keeps_its_alignment() {
+        val once = editorFrom(LEADING_EMPTY_ALIGNED).toJson()
+
+        assertEquals(2, once.split("\"textAlign\":\"right\"").size - 1, "alignment dropped: $once")
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun emptying_an_aligned_item_keeps_its_alignment_across_reload() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "x\ny")
+        editor.toListItem(TextRange(0, editor.text.length), TextEditorListItem.None, TextEditorListItem.NumberedList)
+        editor.setTextAlign(TextRange(0, editor.text.length), TextAlign.Right)
+        // Empty the first item; its alignment must survive export -> load -> export.
+        val xAt = editor.text.indexOf('x')
+        editor.deleteText(xAt, 1)
+
+        val once = editor.toJson()
+        assertTrue(once.contains("\"textAlign\":\"right\""), once)
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun an_aligned_heading_line_round_trips() {
+        // The Heading branch got the same stamping-order change; pin a heading document.
+        val doc = """{"type":"doc","content":[
+          {"type":"heading","attrs":{"level":2,"textAlign":"center"},"content":[{"type":"text","text":"t"}]}
+        ]}"""
+        val once = editorFrom(doc).toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+}


### PR DESCRIPTION
Closes #87

Moves `applyTextAlign` after `postProcessParagraph` in the loader's `Paragraph` and `Heading` branches, so the prepended decorator piece is stamped with the paragraph's alignment too. An empty list item has no text piece and its line-break piece is dropped on conversion back, so the decorator is the only piece that can carry the alignment across a reload.

Tests: `AlignedEmptyItemTest` — the load and ops cases fail on `main`; a heading guard pins the reordered branch. Full suite passes, JS/Wasm compile clean. In the widened seeded sweep this family accounted for 115 of 118 violations; all gone with the fix.