### PR TITLE
fix: report the content-start caret when an insert is blocked on a decorator

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
@@ -265,7 +265,10 @@ internal object TextInsertedTransaction {
     }
 
     private fun preventTextInsertionOnDecorator(paragraph: PieceParagraph): Pair<TextRange, List<TextEditorListItemTransaction>> {
-        val offset = paragraph.startOffset + paragraph.startPiece.length + 1
+        // The caret lands at the item's content start — not one past it. On an empty item that
+        // overshoots the document, and a multiline insert replays its next segment at the returned
+        // caret, so an out-of-range caret becomes an out-of-range insert.
+        val offset = paragraph.startOffset + paragraph.startPiece.length
         return Pair(TextRange(offset), emptyList())
     }
 

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MultilinePasteOnDecoratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MultilinePasteOnDecoratorTest.kt
@@ -1,0 +1,66 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * A multiline paste whose offset falls in a list item's decorator region must replay cleanly.
+ * Blocking a segment on a numbered decorator used to report the caret one past the item's content
+ * start; the replay then inserted the next segment at that caret, which overruns the document when
+ * the item is empty and crashes the piece table.
+ */
+class MultilinePasteOnDecoratorTest {
+
+    @Test
+    fun pasting_multiline_at_the_start_of_an_empty_numbered_item_does_not_crash() {
+        val editor = editorFrom("{}")
+        editor.toListItem(TextRange(0, 0), TextEditorListItem.None, TextEditorListItem.NumberedList)
+
+        editor.typeText(0, "x\ny")
+
+        // The "x" is blocked on the numbered decorator, the break dissolves the empty item, and the
+        // "y" lands as plain text — the same result the sequence produces when typed.
+        assertEquals("y", editor.text)
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun pasting_multiline_into_the_decorator_of_a_nonempty_numbered_item_splits_at_the_content_start() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "abc")
+        editor.toListItem(TextRange(0, 3), TextEditorListItem.None, TextEditorListItem.NumberedList)
+
+        editor.typeText(1, "x\ny")
+
+        assertEquals("\t\t1. \n\t\t2. yabc", editor.text)
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun pasting_multiline_at_the_start_of_an_empty_bullet_item_lands_at_the_content_start() {
+        val editor = editorFrom("{}")
+        editor.toListItem(TextRange(0, 0), TextEditorListItem.None, TextEditorListItem.BulletedList)
+
+        editor.typeText(0, "x\ny")
+
+        assertEquals("\t\t• x\n\t\t• y", editor.text)
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun typing_on_a_numbered_decorator_leaves_the_caret_at_the_content_start() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "abc")
+        editor.toListItem(TextRange(0, 3), TextEditorListItem.None, TextEditorListItem.NumberedList)
+
+        val caret = editor.typeText(2, "z")
+
+        assertEquals("\t\t1. abc", editor.text)
+        assertEquals(TextRange(5), caret)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MultilinePasteOnDecoratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MultilinePasteOnDecoratorTest.kt
@@ -2,6 +2,7 @@ package com.jjrodcast.textkit
 
 import androidx.compose.ui.text.TextRange
 import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.utils.TABS
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -35,7 +36,7 @@ class MultilinePasteOnDecoratorTest {
 
         editor.typeText(1, "x\ny")
 
-        assertEquals("\t\t1. \n\t\t2. yabc", editor.text)
+        assertEquals("${TABS}1. \n${TABS}2. yabc", editor.text)
         val once = editor.toJson()
         assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
     }
@@ -47,7 +48,7 @@ class MultilinePasteOnDecoratorTest {
 
         editor.typeText(0, "x\ny")
 
-        assertEquals("\t\t• x\n\t\t• y", editor.text)
+        assertEquals("${TABS}• x\n${TABS}• y", editor.text)
         val once = editor.toJson()
         assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
     }
@@ -60,7 +61,8 @@ class MultilinePasteOnDecoratorTest {
 
         val caret = editor.typeText(2, "z")
 
-        assertEquals("\t\t1. abc", editor.text)
-        assertEquals(TextRange(5), caret)
+        assertEquals("${TABS}1. abc", editor.text)
+        // The content start: right after the decorator, whose tab prefix is platform-specific.
+        assertEquals(TextRange(editor.text.indexOf("abc")), caret)
     }
 }


### PR DESCRIPTION
Closes #89

Drops the `+1` in `preventTextInsertionOnDecorator`: the caret after blocking text on a numbered decorator is the item's content start, not one past it. The overshoot dates back to the initial integration and was masked interactively by text-field caret clamping, but `insertMultiline` replays paste segments at the returned caret, so on an empty item the next segment inserted past the end of the document and crashed `createRemainingPiece` with a negative remaining length.

Tests: `MultilinePasteOnDecoratorTest` — the empty-item crash repro, a non-empty-item split-position case, and a caret-position case fail on `main`; a bullet-item guard pins the neighbouring clamp path. Full suite passes, JS/Wasm compile clean. The seeded sweep that caught this shows no paste crashes in 400 seeds with the fix.
