### PR TITLE
fix: serialize marks in the loader's canonical order

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/InlineNodeMapper.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/InlineNodeMapper.kt
@@ -7,6 +7,7 @@ import com.jjrodcast.textkit.editor.core.parser.HashtagType
 import com.jjrodcast.textkit.editor.core.parser.Mention
 import com.jjrodcast.textkit.editor.core.parser.MentionType
 import com.jjrodcast.textkit.editor.core.parser.Text
+import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
 import com.jjrodcast.textkit.editor.core.piecetable.models.RichToken
 import com.jjrodcast.textkit.editor.utils.removeLineBreakSuffix
 
@@ -20,8 +21,18 @@ import com.jjrodcast.textkit.editor.utils.removeLineBreakSuffix
  */
 internal fun TextEditorModel.toInlineNode(): BaseText {
     val token = piece.token
-    return token?.toInlineNode(piece.marks.toSet())
-        ?: Text(text = text.removeLineBreakSuffix(), marks = piece.marks.toSet())
+    return token?.toInlineNode(piece.marks.inCanonicalOrder())
+        ?: Text(text = text.removeLineBreakSuffix(), marks = piece.marks.inCanonicalOrder())
+}
+
+/**
+ * Serializes marks in the order a load produces them: `recreateMarks` rebuilds every set as
+ * "other marks, then textStyle", while live formatting appends whichever mark was toggled most
+ * recently — so a set that carries textStyle mid-way would change order across a reload.
+ */
+private fun Set<com.jjrodcast.textkit.editor.core.parser.Mark>.inCanonicalOrder(): Set<com.jjrodcast.textkit.editor.core.parser.Mark> {
+    val (styleMarks, otherMarks) = partition { it is TextStyleMark }
+    return (otherMarks + styleMarks).toSet()
 }
 
 /** Rebuilds the concrete inline node for [RichToken.type]; unknown types fall back to a [Mention]. */

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MarkOrderRoundTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MarkOrderRoundTripTest.kt
@@ -1,0 +1,48 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorStyleItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Marks serialize in the order a load produces them: other marks first, textStyle last. Live
+ * formatting can leave a textStyle mid-set (clearing the color over a selection whose formatting
+ * is mixed re-adds the default textStyle before the pieces' own marks), and the loader always
+ * rebuilds the set textStyle-last — so an export that follows the live set order changes across a
+ * reload and the fixed point breaks even though the marks themselves are identical.
+ */
+class MarkOrderRoundTripTest {
+
+    @Test
+    fun clearing_color_over_a_partially_underlined_range_round_trips() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "ab")
+        editor.applyStyle(TextRange(1, 2), TextEditorStyleItem.Underline)
+        editor.setColor(TextRange(0, 2), "#ff0000")
+        editor.setColor(TextRange(0, 2), null)
+
+        val once = editor.toJson()
+        assertTrue(
+            once.contains("""[{"type":"underline"},{"attrs":{"color":"#000000","fontSize":14},"type":"textStyle"}]"""),
+            "textStyle is not serialized last: $once"
+        )
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun a_document_with_textstyle_listed_first_loads_to_the_canonical_order() {
+        val doc = """{"type":"doc","content":[
+          {"type":"paragraph","content":[{"type":"text","text":"x","marks":[
+            {"type":"textStyle","attrs":{"color":"#ff0000","fontSize":14}},{"type":"bold"}
+          ]}]}
+        ]}"""
+        val once = editorFrom(doc).toJson()
+        assertTrue(
+            once.contains("""[{"type":"bold"},{"attrs":{"color":"#ff0000","fontSize":14},"type":"textStyle"}]"""),
+            "textStyle is not serialized last: $once"
+        )
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+}


### PR DESCRIPTION
Closes #93

Orders marks at the serialization boundary (`toInlineNode`) the way a load rebuilds them: other marks first, textStyle last. Live formatting can leave a textStyle mid-set; instead of chasing every format path, the exporter now emits the canonical order, so export → load → export is stable regardless of toggle history.

Tests: `MarkOrderRoundTripTest` — the color-clear repro fails on `main`; a load-order case guards the canonical form. Full suite passes, JS/Wasm compile clean. In the seeded sweep this family accounted for 23 of 29 remaining violations; all gone with the fix.
