### PR TITLE
fix: guard the previous-line-break removal when the item is the first paragraph

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransactionsUtils.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransactionsUtils.kt
@@ -131,7 +131,11 @@ internal object TextTransactionsUtils {
         val previousItemLevel = lines.paragraphs.getOrNull(selectedIndex - 1)?.startPiece?.decorator?.level ?: 1
         val currentDecoratorLevel = paragraph.startPiece.decorator?.level ?: 1
 
-        val needToDeletePreviousLineBreak = previousItemType == paragraph.paragraphType || currentDecoratorLevel > previousItemLevel
+        // A nested item can be the document's first paragraph (its level beats the defaulted
+        // previous level of 1) — there is no previous line break to delete then, and subtracting
+        // one would produce a negative offset.
+        val needToDeletePreviousLineBreak = paragraph.startOffset >= previousLineBreakLength &&
+            (previousItemType == paragraph.paragraphType || currentDecoratorLevel > previousItemLevel)
         val offset =
             if (needToDeletePreviousLineBreak) paragraph.startOffset - previousLineBreakLength else paragraph.startOffset
         val deleteLength = if (needToDeletePreviousLineBreak) decoratorPiece.length + previousLineBreakLength else decoratorPiece.length

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/DeleteFirstNestedDecoratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/DeleteFirstNestedDecoratorTest.kt
@@ -1,0 +1,61 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Deleting inside the decorator of a nested item that is the document's FIRST paragraph must not
+ * crash: the delete path decides to remove the previous line break when the item's level beats the
+ * previous item's, but a first paragraph has no previous line break — its level merely beats the
+ * defaulted level of a paragraph that does not exist, and the offset went negative.
+ */
+class DeleteFirstNestedDecoratorTest {
+
+    private val NESTED_FIRST = """{"type":"doc","content":[
+      {"type":"bulletList","content":[
+        {"type":"listItem","content":[
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"x"}]}]}
+          ]}
+        ]}
+      ]}
+    ]}"""
+
+    @Test
+    fun deleting_inside_the_first_nested_items_decorator_removes_it_whole() {
+        val editor = editorFrom(NESTED_FIRST)
+        editor.deleteText(1, 2)
+
+        // The decorator is presentation-only and atomic: a removal window inside it dissolves the
+        // item into a plain paragraph, same as for a top-level item.
+        assertEquals("x", editor.text)
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    private val NESTED_TWO = """{"type":"doc","content":[
+      {"type":"bulletList","content":[
+        {"type":"listItem","content":[
+          {"type":"bulletList","content":[
+            {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"a"}]}]},
+            {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"b"}]}]}
+          ]}
+        ]}
+      ]}
+    ]}"""
+
+    @Test
+    fun deleting_inside_a_nested_items_decorator_below_another_item_still_merges_up() {
+        val editor = editorFrom(NESTED_TWO)
+        // Inside the SECOND item's decorator: the previous item is the same type, so the item
+        // dissolves and its text merges into the previous line, decorator and break removed.
+        val second = editor.text.indexOf('\n') + 2
+        editor.deleteText(second, 2)
+
+        assertTrue(editor.text.endsWith("ab"), editor.text.replace("\t", "\\t"))
+        assertEquals(0, editor.text.count { it == '\n' }, editor.text.replace("\n", "\\n").replace("\t", "\\t"))
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+}


### PR DESCRIPTION
Closes #95

Only removes the previous line break when the dissolving item actually has text before it. The level comparison that triggers the removal compares against a defaulted level when there is no previous paragraph at all, which sent the delete offset (and the returned caret range) negative for a nested item at the very start of the document.

Tests: `DeleteFirstNestedDecoratorTest` — the load-and-delete crash repro fails on `main`; a two-item case guards the merge-up path the guard must not disturb. Full suite passes, JS/Wasm compile clean. With this fix the seeded sweep that caught it shows no crashes across 400 seeds.
