### PR TITLE
fix: do not merge format pieces across an untouched piece

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/marks/MultiPieceFormatTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/marks/MultiPieceFormatTransaction.kt
@@ -159,9 +159,15 @@ internal object MultiPieceFormatTransaction {
         }
 
         val startIndex = if (left == null) 0 else 1
+        // A merge coalesces with the last INSERTED piece, which is only the document-previous piece
+        // while every element so far produced one. An element that needs no transaction (its marks
+        // already match) is left in place, so merging across it would splice two pieces that are
+        // buffer-adjacent but have that untouched piece between them in the document — the merged
+        // piece then carries its text to the wrong position and reorders the document.
+        var previousProducedPieces = left != null
         for (i in startIndex until centralElements.size) {
             val currentModel = centralElements[i]
-            val lastPiece = transactionManager.getLastInsertedPiece()
+            val lastPiece = if (previousProducedPieces) transactionManager.getLastInsertedPiece() else null
             val finalMarks = TextEditorMarkProcessor.process(
                 currentModel.piece.marks,
                 prevFormatMarks,
@@ -189,7 +195,12 @@ internal object MultiPieceFormatTransaction {
                 Mark.areTheSame(
                     finalMarks,
                     currentModel.piece.marks
-                ) && adjustedRange.length == currentModel.pieceLength -> RichPieceTransaction.Empty
+                ) && adjustedRange.length == currentModel.pieceLength -> {
+                    // Untouched: it stays between the pieces around it, so nothing may merge across
+                    // it from here on.
+                    previousProducedPieces = false
+                    RichPieceTransaction.Empty
+                }
 
                 else -> {
                     transaction.getTransactionMarks(
@@ -205,11 +216,13 @@ internal object MultiPieceFormatTransaction {
 
             if (transactionMarks.insertAtIndex >= 0) {
                 transactionManager.add(transactionMarks)
+                previousProducedPieces = true
             }
         }
 
         if (right != null) {
-            val lastPiece = transactionManager.getLastInsertedPiece()
+            // Same rule for the trailing neighbor: only merge into it when the chain is unbroken.
+            val lastPiece = if (previousProducedPieces) transactionManager.getLastInsertedPiece() else null
 
             val transactionMarks = when {
                 lastPiece != null && canMergeWithPrevious(

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/FormatAcrossUntouchedPieceTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/FormatAcrossUntouchedPieceTest.kt
@@ -1,0 +1,71 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.components.TextEditorStyleItem
+import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A format change spanning several pieces must not coalesce across a piece it leaves untouched.
+ * Text typed before an existing line break lands after it in the ADDED buffer, so the piece ending
+ * a line and the break itself can be buffer-adjacent while another piece sits between them in the
+ * document — merging those two carries the break to the wrong position and reorders the document.
+ */
+class FormatAcrossUntouchedPieceTest {
+
+    /** No decorator piece may sit anywhere but the start of its paragraph. */
+    private fun TextKitEditorManager.assertNoMidlineDecorator() {
+        getParagraphs().forEachIndexed { i, p ->
+            assertTrue(
+                p.children.drop(1).none { it.decorator != null },
+                "paragraph $i carries a mid-line decorator: ${text.replace("\n", "\\n").replace("\t", "\\t")}"
+            )
+        }
+    }
+
+    /** "abZ\n": Z is typed between "ab" and the break, so "b" and the break are buffer-adjacent. */
+    private fun buildReorderShape(): TextKitEditorManager {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "ab")
+        editor.typeText(2, "\n")
+        editor.typeText(2, "Z")
+        return editor
+    }
+
+    @Test
+    fun formatting_across_an_untouched_piece_keeps_the_document_order() {
+        val editor = buildReorderShape()
+        assertEquals("abZ\n", editor.text)
+
+        // Spans "b", the untouched "Z", and the line break.
+        editor.removeStyle(TextRange(1, 4), editor.marksAt(TextRange(1, 4)), TextEditorStyleItem.Italic)
+
+        // "Z" must still end the first paragraph, not open the second one.
+        val paragraphs = editor.getParagraphs()
+        assertEquals("abZ\n", paragraphs.first().children.joinToString("") { it.text })
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun formatting_across_an_untouched_piece_does_not_pull_a_decorator_into_the_line() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "ab")
+        editor.typeText(2, "\n")
+        editor.typeText(3, "c")
+        val line2 = editor.text.indexOf('\n') + 1
+        editor.toListItem(TextRange(line2, line2 + 1), TextEditorListItem.None, TextEditorListItem.NumberedList)
+        editor.typeText(2, "Z")
+
+        editor.removeStyle(TextRange(1, 4), editor.marksAt(TextRange(1, 4)), TextEditorStyleItem.Italic)
+
+        editor.assertNoMidlineDecorator()
+        val once = editor.toJson()
+        // A decorator dragged into the line would serialize its tabs as ordinary text.
+        assertTrue(!once.contains("\\t"), "decorator text leaked into the export: $once")
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+}


### PR DESCRIPTION
Closes #97

Tracks whether the previous element actually produced pieces, and only allows the buffer-adjacency merge while that chain is unbroken (the same guard applies to the trailing-neighbor merge). An element that needs no transaction stays between its neighbors in the document, so coalescing across it moved the merged piece's text — most visibly a line break — to the wrong position.

Tests: `FormatAcrossUntouchedPieceTest` — a reordering case and a decorator-drag case, both failing on `main`. Full suite passes, JS/Wasm compile clean. In the seeded sweep this removes the last mid-line-decorator violation across 400 seeds.
