### PR TITLE
fix: pass document coordinates to the format merge helpers

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/processor/PieceTableProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/processor/PieceTableProcessor.kt
@@ -281,10 +281,14 @@ internal object PieceTableProcessor {
                         marks
                     )
                 } else if (leftModel.isLastOnParagraph) {
+                    // Re-mark the whole central piece. getCentralPieceTransaction measures the range
+                    // against the piece's DOCUMENT offset, so the buffer offset must not be passed
+                    // here: their difference becomes the split delta and rebuilds the piece over a
+                    // span of the buffer that is not its own.
                     getCentralPieceTransaction(
                         centralModel,
                         indexOfCentralPiece,
-                        centralPiece.offset,
+                        centralModel.offsetInDocument,
                         centralPiece.length,
                         marks
                     )
@@ -314,10 +318,11 @@ internal object PieceTableProcessor {
                         marks
                     )
                 } else if (centralModel.isLastOnParagraph) {
+                    // Document offset, not the buffer one — see the note above.
                     getCentralPieceTransaction(
                         centralModel,
                         indexOfCentralPiece,
-                        centralPiece.offset,
+                        centralModel.offsetInDocument,
                         centralPiece.length,
                         marks
                     )
@@ -399,26 +404,29 @@ internal object PieceTableProcessor {
             }
 
             leftLengthTest == centralPiece.offset -> {
-                val length = leftPiece.length + centralPiece.length
+                // The merge helpers take the DOCUMENT offset and the length of the central piece's
+                // own portion — they add the neighbor's length themselves. Passing the buffer offset
+                // and the combined length made the rebuilt piece start before the central piece and
+                // run past it, so it read a span of the buffer belonging to other pieces.
                 getLeftPieceTransaction(
                     leftModel,
                     indexOfLeftPiece,
                     centralModel,
                     indexOfCentralPiece,
-                    leftPiece.offset,
-                    length,
+                    centralModel.offsetInDocument,
+                    centralPiece.length,
                     marks
                 )
             }
 
             centralLengthTest == rightPiece.offset -> {
-                val length = centralPiece.length + rightPiece.length
+                // Document offset and the central piece's own length — see the note above.
                 getRightPieceTransaction(
                     rightModel,
                     centralModel,
                     indexOfCentralPiece,
-                    centralPiece.offset,
-                    length,
+                    centralModel.offsetInDocument,
+                    centralPiece.length,
                     marks
                 )
             }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/FormatMergeCoordinatesTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/FormatMergeCoordinatesTest.kt
@@ -1,0 +1,59 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorStyleItem
+import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The merge helpers that coalesce a formatted piece with a neighbor measure their range against the
+ * piece's DOCUMENT offset. Handing them a BUFFER offset (and, for the merge branches, a length that
+ * already includes the neighbor) rebuilds the piece over a span of the buffer that is not its own,
+ * so the rope starts yielding text the document never contained.
+ */
+class FormatMergeCoordinatesTest {
+
+    /** What the piece rope actually holds, independent of the cached plain-text snapshot. */
+    private fun TextKitEditorManager.ropeText(): String =
+        buildString { transaction.getLineContentModels(0, text.length).forEach { append(it.text) } }
+
+    @Test
+    fun merging_a_formatted_piece_with_its_right_neighbor_keeps_the_document_text() {
+        val editor = editorFrom("{}")
+        // Typing out of order interleaves the ADDED buffer, so document-adjacent pieces need not be
+        // buffer-adjacent — and vice versa.
+        editor.typeText(0, "c")
+        editor.typeText(1, "b")
+        editor.typeText(0, "a")
+        editor.removeStyle(TextRange(2, 3), editor.marksAt(TextRange(2, 3)), TextEditorStyleItem.Bold)
+        editor.typeText(3, "b")
+        assertEquals("acbb", editor.text)
+
+        editor.removeStyle(TextRange(2, 3), editor.marksAt(TextRange(2, 3)), TextEditorStyleItem.Italic)
+
+        assertEquals("acbb", editor.ropeText(), "the rope no longer holds the document's text")
+        assertEquals("acbb", editorFrom(editor.toJson()).text, "the export does not round trip")
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun re_marking_a_line_ending_piece_beside_a_loaded_piece_keeps_the_document_text() {
+        val doc = """{"type":"doc","content":[
+          {"type":"paragraph","content":[{"type":"text","text":"one"}]},
+          {"type":"paragraph","content":[{"type":"text","text":"two"}]}
+        ]}"""
+        val editor = editorFrom(doc)
+        // Typed pieces (ADDED) surrounding a loaded piece (ORIGINAL) that ends its paragraph.
+        editor.typeText(2, "a")
+        editor.typeText(2, "c")
+        assertEquals("oncae\ntwo", editor.text)
+
+        editor.removeStyle(TextRange(4, 6), editor.marksAt(TextRange(4, 6)), TextEditorStyleItem.Italic)
+
+        assertEquals("oncae\ntwo", editor.ropeText(), "the rope no longer holds the document's text")
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+}


### PR DESCRIPTION
Closes #99

Passes `centralModel.offsetInDocument` and the central piece's own length at the four call sites that were handing the merge helpers buffer coordinates (and, in `mergeAllPieces`, a length that double-counted the neighbor the helper appends itself). The helpers compute their split delta against the piece's document offset, so a buffer offset made them rebuild the piece over a span of the buffer that is not its own — the rope then yields text the document never contained, and decorator characters leak into exported text nodes.

Tests: `FormatMergeCoordinatesTest` — one case per site (a 6-step typing sequence and a 3-step case over a loaded document), both failing on `main`. Full suite passes, JS/Wasm compile clean. With this the seeded sweep reports no violations at all across 400 seeds (the one remaining on this branch alone is #97, fixed in #98).
