### PR TITLE
test: add a seeded editing stress harness (#46)

### DIFF
--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
@@ -33,13 +33,30 @@ import kotlin.test.assertTrue
  */
 class EditingStressTest {
 
+    /**
+     * A small cross-platform run. The full sweep lives in `EditingStressSweepTest` (JVM only): it
+     * blocks the event loop far too long for the browser test runner, whose watchdog kills a tab
+     * that cannot answer a ping for two seconds.
+     */
     @Test
     fun random_edit_sequences_keep_the_document_consistent() {
-        for (seed in SEEDS) {
-            val startDoc = START_DOCS[seed % START_DOCS.size]
-            val editor = editorFrom(startDoc)
+        EditingStress.run(SMOKE_SEEDS, SMOKE_OPS_PER_SEED)
+    }
+
+    private companion object {
+        val SMOKE_SEEDS = 0 until 12
+        const val SMOKE_OPS_PER_SEED = 50
+    }
+}
+
+/** The stress machinery, shared by the cross-platform smoke run and the JVM-only full sweep. */
+internal object EditingStress {
+
+    fun run(seeds: IntRange, opsPerSeed: Int) {
+        for (seed in seeds) {
+            val editor = editorFrom(START_DOCS[seed % START_DOCS.size])
             val rng = Random(seed)
-            for (step in 0 until OPS_PER_SEED) {
+            for (step in 0 until opsPerSeed) {
                 val (desc, action) = decideOp(editor, rng)
                 val where = "seed=$seed step=$step doc=${seed % START_DOCS.size} op '$desc'"
                 try {
@@ -170,18 +187,15 @@ class EditingStressTest {
         return TextRange(a, b)
     }
 
-    private companion object {
-        val SEEDS = 0 until 400
-        const val OPS_PER_SEED = 250
-        const val ALPHABET = "abc de"
+    private const val ALPHABET = "abc de"
 
-        val LIST_TYPES = listOf(
+    private val LIST_TYPES = listOf(
             TextEditorListItem.NumberedList,
             TextEditorListItem.BulletedList,
             TextEditorListItem.CheckList,
         )
 
-        val STYLES = listOf(
+    private val STYLES = listOf(
             TextEditorStyleItem.Bold,
             TextEditorStyleItem.Italic,
             TextEditorStyleItem.Underline,
@@ -189,12 +203,12 @@ class EditingStressTest {
             TextEditorStyleItem.Highlight,
         )
 
-        val ALIGNS = listOf(TextAlign.Left, TextAlign.Center, TextAlign.Right)
+    private val ALIGNS = listOf(TextAlign.Left, TextAlign.Center, TextAlign.Right)
 
-        val LIST_TYPES_IN_JSON = listOf("taskList", "bulletList", "orderedList")
+    private val LIST_TYPES_IN_JSON = listOf("taskList", "bulletList", "orderedList")
 
-        /** Each seed starts from one of these, so the ops churn empty, flat and nested documents. */
-        val START_DOCS = listOf(
+    /** Each seed starts from one of these, so the ops churn empty, flat and nested documents. */
+    private val START_DOCS = listOf(
             "{}",
             // Flat lists of every kind, alongside a plain paragraph.
             """{"type":"doc","content":[
@@ -227,5 +241,4 @@ class EditingStressTest {
               ]}
             ]}""",
         )
-    }
 }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
@@ -1,0 +1,231 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.components.TextEditorStyleItem
+import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Deterministic stress test: long, seeded sequences of every editing operation — typing, breaks,
+ * deletes, replaces, multiline pastes, list toggles and type switches, styles, alignment and colour
+ * — over regular paragraphs, ordered/unordered/task lists and deeply nested documents. This is the
+ * kind of churn that surfaces an intermittent editing bug.
+ *
+ * After every operation, five invariants hold:
+ *
+ * 1. No operation throws (#82, #89, #95).
+ * 2. A decorator piece only ever sits at the start of its paragraph — a mid-line decorator is the
+ *    corruption behind #67/#74/#82/#85/#97.
+ * 3. No decorator text leaks into an exported text node: a decorator is presentation-only, so its
+ *    tabs must never serialize as ordinary characters (#97, #99).
+ * 4. The export carries no empty text nodes and no empty list nodes (#81).
+ * 5. The export is a fixed point: `toJson()` → load → `toJson()` is unchanged (#57–#61, #79, #81,
+ *    #87, #93, #99).
+ *
+ * A failure names the seed, step and operation, so a "random, can't reproduce" error becomes an
+ * exact repro. The committed size keeps the run inside a couple of seconds on every target; raising
+ * [SEEDS] locally widens the search without any other change.
+ */
+class EditingStressTest {
+
+    @Test
+    fun random_edit_sequences_keep_the_document_consistent() {
+        for (seed in SEEDS) {
+            val startDoc = START_DOCS[seed % START_DOCS.size]
+            val editor = editorFrom(startDoc)
+            val rng = Random(seed)
+            for (step in 0 until OPS_PER_SEED) {
+                val (desc, action) = decideOp(editor, rng)
+                val where = "seed=$seed step=$step doc=${seed % START_DOCS.size} op '$desc'"
+                try {
+                    action()
+                } catch (t: Throwable) {
+                    throw AssertionError("threw at $where: ${t::class.simpleName}: ${t.message}", t)
+                }
+                editor.assertInvariants(where)
+            }
+        }
+    }
+
+    /** Checks every structural invariant on the current document. */
+    private fun TextKitEditorManager.assertInvariants(where: String) {
+        val visible = text.replace("\n", "\\n").replace("\t", "\\t")
+        getParagraphs().forEach { paragraph ->
+            assertTrue(
+                paragraph.children.drop(1).none { it.decorator != null },
+                "mid-line decorator at $where: $visible",
+            )
+        }
+        val once = toJson()
+        assertTrue(!once.contains("\\t"), "decorator text leaked into the export at $where: $once")
+        assertTrue(!once.contains("\"text\":\"\""), "empty text node at $where: $once")
+        LIST_TYPES_IN_JSON.forEach { type ->
+            assertTrue(!once.contains("\"content\":[],\"type\":\"$type\""), "empty $type at $where: $once")
+        }
+        assertEquals(once, editorFrom(once).toJson(), "toJson not idempotent at $where")
+    }
+
+    /** Decides the next operation from [rng] and returns its description plus a thunk that runs it. */
+    private fun decideOp(editor: TextKitEditorManager, rng: Random): Pair<String, () -> Unit> {
+        val len = editor.text.length
+        return when (rng.nextInt(12)) {
+            0 -> {
+                val at = rng.nextInt(len + 1)
+                val text = randomText(rng)
+                "insert '$text' @$at" to { editor.typeText(at, text); Unit }
+            }
+
+            1 -> {
+                val at = rng.nextInt(len + 1)
+                "break @$at" to { editor.typeText(at, "\n"); Unit }
+            }
+
+            2 -> {
+                if (len == 0) return "delete <empty>" to {}
+                val at = rng.nextInt(len)
+                val length = rng.nextInt(1, minOf(12, len - at) + 1)
+                "delete @$at len=$length" to { editor.deleteText(at, length); Unit }
+            }
+
+            3 -> {
+                if (len == 0) return "replace <empty>" to {}
+                val at = rng.nextInt(len)
+                val remove = rng.nextInt(0, minOf(9, len - at) + 1)
+                val text = randomText(rng)
+                "replace @$at remove=$remove '$text'" to { editor.replaceText(at, remove, text); Unit }
+            }
+
+            4 -> {
+                val range = randomRange(rng, len)
+                val to = LIST_TYPES[rng.nextInt(LIST_TYPES.size)]
+                "toList $to $range" to { editor.toListItem(range, TextEditorListItem.None, to); Unit }
+            }
+
+            5 -> {
+                val range = randomRange(rng, len)
+                val from = LIST_TYPES[rng.nextInt(LIST_TYPES.size)]
+                "unList $from $range" to { editor.toListItem(range, from, TextEditorListItem.None); Unit }
+            }
+
+            6 -> {
+                // Direct type switch, with no plain-paragraph step in between.
+                val range = randomRange(rng, len)
+                val from = LIST_TYPES[rng.nextInt(LIST_TYPES.size)]
+                val to = LIST_TYPES[rng.nextInt(LIST_TYPES.size)]
+                "switchList $from->$to $range" to { editor.toListItem(range, from, to); Unit }
+            }
+
+            7 -> {
+                val range = randomRange(rng, len)
+                val style = STYLES[rng.nextInt(STYLES.size)]
+                "style $style $range" to { editor.applyStyle(range, style); Unit }
+            }
+
+            8 -> {
+                val range = randomRange(rng, len)
+                val style = STYLES[rng.nextInt(STYLES.size)]
+                "unstyle $style $range" to { editor.removeStyle(range, editor.marksAt(range), style); Unit }
+            }
+
+            9 -> {
+                // Inner line breaks take the multiline-paste path rather than the typed-break one.
+                val at = rng.nextInt(len + 1)
+                val text = buildString {
+                    append(randomText(rng)).append('\n').append(randomText(rng))
+                    if (rng.nextBoolean()) append('\n').append(randomText(rng))
+                }
+                "paste multiline @$at" to { editor.typeText(at, text); Unit }
+            }
+
+            10 -> {
+                val range = randomRange(rng, len)
+                val align = ALIGNS[rng.nextInt(ALIGNS.size)]
+                "align $align $range" to { editor.setTextAlign(range, align); Unit }
+            }
+
+            else -> {
+                val range = randomRange(rng, len)
+                val color = if (rng.nextBoolean()) "#ff0000" else null
+                "color $color $range" to { editor.setColor(range, color); Unit }
+            }
+        }
+    }
+
+    private fun randomText(rng: Random): String {
+        val n = rng.nextInt(1, 5)
+        return buildString {
+            repeat(n) { append(ALPHABET[rng.nextInt(ALPHABET.length)]) }
+        }
+    }
+
+    private fun randomRange(rng: Random, len: Int): TextRange {
+        if (len == 0) return TextRange(0)
+        val a = rng.nextInt(len)
+        val b = a + rng.nextInt(0, minOf(10, len - a) + 1)
+        return TextRange(a, b)
+    }
+
+    private companion object {
+        val SEEDS = 0 until 400
+        const val OPS_PER_SEED = 250
+        const val ALPHABET = "abc de"
+
+        val LIST_TYPES = listOf(
+            TextEditorListItem.NumberedList,
+            TextEditorListItem.BulletedList,
+            TextEditorListItem.CheckList,
+        )
+
+        val STYLES = listOf(
+            TextEditorStyleItem.Bold,
+            TextEditorStyleItem.Italic,
+            TextEditorStyleItem.Underline,
+            TextEditorStyleItem.Strikethrough,
+            TextEditorStyleItem.Highlight,
+        )
+
+        val ALIGNS = listOf(TextAlign.Left, TextAlign.Center, TextAlign.Right)
+
+        val LIST_TYPES_IN_JSON = listOf("taskList", "bulletList", "orderedList")
+
+        /** Each seed starts from one of these, so the ops churn empty, flat and nested documents. */
+        val START_DOCS = listOf(
+            "{}",
+            // Flat lists of every kind, alongside a plain paragraph.
+            """{"type":"doc","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"plain"}]},
+              {"type":"orderedList","attrs":{"start":1},"content":[
+                {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"one"}]}]},
+                {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"two"}]}]}
+              ]},
+              {"type":"taskList","content":[
+                {"type":"taskItem","attrs":{"checked":true},"content":[{"type":"paragraph","content":[{"type":"text","text":"do"}]}]}
+              ]}
+            ]}""",
+            // Deep nesting through listItem chains, plus a task list.
+            """{"type":"doc","content":[
+              {"type":"bulletList","content":[
+                {"type":"listItem","content":[
+                  {"type":"paragraph","content":[{"type":"text","text":"a"}]},
+                  {"type":"orderedList","attrs":{"start":1},"content":[
+                    {"type":"listItem","content":[
+                      {"type":"paragraph","content":[{"type":"text","text":"b"}]},
+                      {"type":"bulletList","content":[
+                        {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"c"}]}]}
+                      ]}
+                    ]}
+                  ]}
+                ]}
+              ]},
+              {"type":"taskList","content":[
+                {"type":"taskItem","attrs":{"checked":false},"content":[{"type":"paragraph","content":[{"type":"text","text":"t"}]}]}
+              ]}
+            ]}""",
+        )
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/EditingStressSweepTest.kt
+++ b/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/EditingStressSweepTest.kt
@@ -1,0 +1,21 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+
+/**
+ * The full seeded sweep, kept on the JVM target only.
+ *
+ * It runs the same operations and invariants as the cross-platform [EditingStressTest], just far
+ * more of them: 400 seeds × 250 operations. That is a single synchronous run of a hundred thousand
+ * edits, which starves the browser test runner's event loop — Karma kills a tab that cannot answer
+ * a ping within two seconds — so the wide search runs here and the other targets keep the smoke run.
+ *
+ * Reverting any of #87, #95, #97 or #99 makes this fail with the exact seed, step and operation.
+ */
+class EditingStressSweepTest {
+
+    @Test
+    fun the_full_sweep_keeps_the_document_consistent() {
+        EditingStress.run(0 until 400, 250)
+    }
+}


### PR DESCRIPTION
Part of #46

Adds `EditingStressTest` — deterministic, seeded sequences of every editing operation (typing, breaks, deletes, replaces, multiline pastes, list toggles and direct type switches, styles, alignment, colour) over empty, flat and deeply nested starting documents. After each operation it checks five invariants: nothing throws; a decorator only ever sits at the start of its paragraph; no decorator text leaks into an exported text node; the export carries no empty text or list nodes; and `toJson()` → load → `toJson()` is a fixed point.

This is the harness that found #82, #85, #87, #89, #91, #93, #95, #97 and #99. Committing it keeps those fixed: reverting any one of them makes it fail with the exact seed, step and operation, e.g. `decorator text leaked into the export at seed=248 step=54 op 'color null TextRange(48, 49)'`, so a "random, can't reproduce" report becomes a repro.

The cross-platform run is deliberately small: 12 seeds × 50 operations, which every target can complete comfortably. The full 400 × 250 sweep lives in `EditingStressSweepTest` on the JVM target — a hundred thousand synchronous edits starves the browser runner's event loop, and Karma kills a tab that cannot answer a ping within two seconds. Both share one runner, so the operations and invariants cannot drift apart. Raising the sweep's bounds widens the search with no other change.

Not covered here, so #46 stays open: hyperlinks and embeds are outside the op mix.
