### PR TITLE
fix: clamp token and embed insertion out of a list decorator

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -202,6 +202,22 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
     fun onDecoratorChange(offset: Int) = transaction.onDecoratorChange(offset)
 
     /**
+     * Moves [offset] to the start of its list item's content when it falls inside the item's
+     * decorator. A decorator is presentation-only and atomic, so anything inserted there would split
+     * it — leaving the marker stranded mid-line and the paragraph carrying two decorator pieces. The
+     * typing, replace and paste paths clamp the same way (#58, #69, #89); the token and embed entry
+     * points reach the piece table directly, so they clamp here.
+     */
+    private fun contentStartFor(offset: Int): Int {
+        val item = transaction.getLineContent(offset, offset).paragraphs.firstOrNull { paragraph ->
+            paragraph.isListItem &&
+                offset >= paragraph.startOffset &&
+                offset < paragraph.startOffset + paragraph.startPiece.length
+        } ?: return offset
+        return item.startOffset + item.startPiece.length
+    }
+
+    /**
      * Inserts a trigger token, replacing [replaceRange] (typically the `<char>query` text the user
      * was typing).
      *
@@ -238,8 +254,8 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
                 )
             }
         )
-        val start = replaceRange.min
-        val length = replaceRange.length
+        val start = contentStartFor(replaceRange.min)
+        val length = maxOf(replaceRange.max, start) - start
         if (length > 0) transaction.update(start, length, model) else transaction.insert(
             model,
             start
@@ -290,8 +306,9 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
      * stays isolated (left text · embed · right text). Returns the placeholder's range.
      */
     fun insertEmbed(embedType: String, rawJson: String, label: String, at: TextRange): TextRange {
-        val start = at.min
-        if (at.length > 0) transaction.delete(start, at.length)
+        val start = contentStartFor(at.min)
+        val end = maxOf(at.max, start)
+        if (end > start) transaction.delete(start, end - start)
         val fullText = text
         var pos = start
         // Close the current paragraph on the left when the caret sits mid-line.

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/TokenInsertOnDecoratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/TokenInsertOnDecoratorTest.kt
@@ -1,0 +1,99 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import com.jjrodcast.textkit.editor.utils.TABS
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A decorator is presentation-only and atomic, so a token or an embed inserted while the caret sits
+ * on a list item's marker must land at the item's content start. Splicing into the marker splits it
+ * around the insertion, leaving the paragraph with a stranded decorator piece mid-line — the same
+ * corruption the typing, replace and paste paths already clamp against (#58, #69, #89).
+ */
+class TokenInsertOnDecoratorTest {
+
+    private val TABLE = """{"type":"table","content":[{"type":"tableRow","content":[]}]}"""
+
+    /** "abc" as a single item of [type]; the caret offset 2 sits inside its decorator. */
+    private fun listItemEditor(type: TextEditorListItem): TextKitEditorManager =
+        editorFrom("{}").also {
+            it.typeText(0, "abc")
+            it.toListItem(TextRange(0, 3), TextEditorListItem.None, type)
+        }
+
+    private fun TextKitEditorManager.assertNoMidlineDecorator() {
+        getParagraphs().forEachIndexed { i, p ->
+            assertTrue(
+                p.children.drop(1).none { it.decorator != null },
+                "paragraph $i carries a mid-line decorator: ${text.replace("\n", "\\n").replace("\t", "\\t")}",
+            )
+        }
+    }
+
+    @Test
+    fun a_hashtag_inserted_on_a_decorator_lands_at_the_content_start() {
+        val editor = listItemEditor(TextEditorListItem.BulletedList)
+
+        editor.insertToken(nodeType = "hashtag", id = "1", label = "kt", replaceRange = TextRange(2, 2))
+
+        assertEquals("$TABS• @ktabc", editor.text)
+        editor.assertNoMidlineDecorator()
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun a_mention_inserted_on_a_decorator_lands_at_the_content_start() {
+        val editor = listItemEditor(TextEditorListItem.NumberedList)
+
+        editor.insertMention(id = "1", label = "Jorge", replaceRange = TextRange(2, 2))
+
+        assertEquals("${TABS}1. @Jorgeabc", editor.text)
+        editor.assertNoMidlineDecorator()
+    }
+
+    @Test
+    fun a_token_range_starting_in_the_decorator_only_replaces_the_content_it_covers() {
+        val editor = listItemEditor(TextEditorListItem.BulletedList)
+        val contentStart = editor.text.indexOf('a')
+
+        // Starts inside the decorator and reaches one character into the content.
+        editor.insertToken(
+            nodeType = "hashtag",
+            id = "1",
+            label = "kt",
+            replaceRange = TextRange(2, contentStart + 1),
+        )
+
+        // Only the covered content character is replaced; the marker survives intact.
+        assertEquals("$TABS• @ktbc", editor.text)
+        editor.assertNoMidlineDecorator()
+    }
+
+    @Test
+    fun an_embed_inserted_on_a_decorator_keeps_the_marker_intact() {
+        val editor = listItemEditor(TextEditorListItem.BulletedList)
+
+        editor.insertEmbed("table", TABLE, label = "T", at = TextRange(2))
+
+        editor.assertNoMidlineDecorator()
+        // The marker stays whole and keeps its line; the embed opens its own paragraph below.
+        assertEquals("$TABS• \nT\nabc", editor.text)
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun a_token_in_a_plain_paragraph_is_unaffected() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "abc")
+
+        editor.insertToken(nodeType = "hashtag", id = "1", label = "kt", replaceRange = TextRange(1, 2))
+
+        assertEquals("a@ktc", editor.text)
+    }
+}


### PR DESCRIPTION
Closes #102

Adds a shared clamp in `TextKitEditorManager`: an insertion offset inside a list item's decorator moves to the item's content start, and a range starting there is trimmed to the content it actually covers. `insertToken` (so also `insertMention`) and `insertEmbed` bypass the text-transaction path that already clamps this way for typing, replace and paste, so they clamp at the call site.

Tests: `TokenInsertOnDecoratorTest` — hashtag, mention, spanning range and embed cases all fail on `main`, plus a plain-paragraph guard that must stay unaffected. Full suite passes, JS/Wasm compile clean. In a seeded sweep that adds tokens, embeds and links to the op mix, this takes the token/mention failures from 199 of 200 seeds to none.
