### PR TITLE
fix: remove an embed through the text-removal path

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -18,6 +18,8 @@ import com.jjrodcast.textkit.editor.core.parser.embedType
 import com.jjrodcast.textkit.editor.utils.fastForEach
 import com.jjrodcast.textkit.editor.core.piecetable.models.RichToken
 import com.jjrodcast.textkit.editor.core.transactions.TextEditorTransaction
+import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorAction
+import com.jjrodcast.textkit.editor.core.transactions.text.TextTransaction
 import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorSelectedMark
 import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorTransactionType
 import com.jjrodcast.textkit.editor.models.MarkSearchType
@@ -336,7 +338,16 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
     /** Removes the placeholder at [range] (and its line break) → the block disappears from the JSON. */
     fun removeEmbedAt(range: TextRange): Boolean {
         if (range.length <= 0) return false
-        return transaction.delete(range.min, range.length)
+        // Routed through the text-removal path rather than deleting the pieces outright: the
+        // placeholder carries the line break that ends its own paragraph, and dropping that break
+        // raw merges the following paragraph into this one — stranding a following list item's
+        // decorator mid-line. That path already resolves decorators for the same window (#74, #82).
+        val action = TextEditorAction.TextRemoved(
+            offset = range.min,
+            length = range.length,
+            selection = TextRange(range.min),
+        )
+        return TextTransaction.onTextUpdated(action, this).first
     }
 
     /** The embed placeholder at document [offset], or null when [offset] is not on one. */

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/RemoveEmbedAboveListItemTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/RemoveEmbedAboveListItemTest.kt
@@ -1,0 +1,66 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import com.jjrodcast.textkit.editor.utils.TABS
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * An embed placeholder carries the line break that ends its own paragraph. Removing it must go
+ * through the text-removal path, which resolves decorators for the window it deletes: dropping the
+ * break outright merges the following paragraph into this one, so a list item below the embed loses
+ * its own line and its marker ends up stranded mid-line.
+ */
+class RemoveEmbedAboveListItemTest {
+
+    private val TABLE = """{"type":"table","content":[{"type":"tableRow","content":[]}]}"""
+
+    private fun TextKitEditorManager.assertNoMidlineDecorator() {
+        getParagraphs().forEachIndexed { i, p ->
+            assertTrue(
+                p.children.drop(1).none { it.decorator != null },
+                "paragraph $i carries a mid-line decorator: ${text.replace("\n", "\\n").replace("\t", "\\t")}",
+            )
+        }
+    }
+
+    @Test
+    fun removing_an_embed_above_a_list_item_keeps_the_item_on_its_own_line() {
+        val editor = editorFrom("{}")
+        editor.insertEmbed("table", TABLE, label = "T", at = TextRange(0))
+        editor.insertEmbed("table", TABLE, label = "T", at = TextRange(0))
+        // Both placeholder lines become task items, so the first one's trailing break is the only
+        // thing separating the two markers.
+        editor.toListItem(TextRange(1, 3), TextEditorListItem.None, TextEditorListItem.CheckList)
+        assertEquals("$TABS-[] T\n$TABS-[] T", editor.text)
+
+        val embed = editor.embedAt(editor.text.indexOf('T', startIndex = 1) + 1)
+            ?: editor.embedAt(editor.text.indexOf('T'))
+        editor.removeEmbedAt(embed!!.range)
+
+        editor.assertNoMidlineDecorator()
+        assertEquals("$TABS-[] T", editor.text)
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun removing_a_standalone_embed_still_leaves_the_neighbours_alone() {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "x\nabc")
+        val second = editor.text.indexOf('\n') + 1
+        editor.toListItem(TextRange(second, second + 3), TextEditorListItem.None, TextEditorListItem.BulletedList)
+        editor.insertEmbed("table", TABLE, label = "T", at = TextRange(1))
+
+        val embed = (0 until editor.text.length).firstNotNullOfOrNull { editor.embedAt(it) }
+        editor.removeEmbedAt(embed!!.range)
+
+        editor.assertNoMidlineDecorator()
+        assertTrue(editor.text.contains("$TABS• abc"), editor.text.replace("\t", "\\t"))
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/RemoveEmbedAboveListItemTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/RemoveEmbedAboveListItemTest.kt
@@ -32,17 +32,22 @@ class RemoveEmbedAboveListItemTest {
         val editor = editorFrom("{}")
         editor.insertEmbed("table", TABLE, label = "T", at = TextRange(0))
         editor.insertEmbed("table", TABLE, label = "T", at = TextRange(0))
-        // Both placeholder lines become task items, so the first one's trailing break is the only
-        // thing separating the two markers.
-        editor.toListItem(TextRange(1, 3), TextEditorListItem.None, TextEditorListItem.CheckList)
-        assertEquals("$TABS-[] T\n$TABS-[] T", editor.text)
+        // Both placeholder lines become list items, so the first one's trailing break is the only
+        // thing separating the two markers. Marker text is platform-specific, so this asserts on
+        // the paragraph structure rather than on the rendered decorator.
+        editor.toListItem(TextRange(1, 3), TextEditorListItem.None, TextEditorListItem.BulletedList)
+        assertEquals(2, editor.getParagraphs().size, editor.text.replace("\n", "\\n").replace("\t", "\\t"))
+        assertTrue(editor.getParagraphs().all { it.children.first().decorator != null }, editor.text)
 
-        val embed = editor.embedAt(editor.text.indexOf('T', startIndex = 1) + 1)
-            ?: editor.embedAt(editor.text.indexOf('T'))
+        val embed = (0 until editor.text.length).firstNotNullOfOrNull { editor.embedAt(it) }
         editor.removeEmbedAt(embed!!.range)
 
         editor.assertNoMidlineDecorator()
-        assertEquals("$TABS-[] T", editor.text)
+        // One item is left, still carrying exactly one marker of its own.
+        val paragraphs = editor.getParagraphs()
+        assertEquals(1, paragraphs.size, editor.text.replace("\n", "\\n").replace("\t", "\\t"))
+        assertEquals(1, paragraphs.single().children.count { it.decorator != null }, editor.text)
+        assertTrue(editor.text.endsWith("T"), editor.text.replace("\t", "\\t"))
         val once = editor.toJson()
         assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
     }


### PR DESCRIPTION
Closes #104

`removeEmbedAt` now dispatches a `TextRemoved` action instead of deleting the pieces outright, so the placeholder's trailing line break is resolved the same way any other removal window is. Deleting it raw merged the paragraph below into the embed's line, which stranded a following list item's marker mid-line.

Tests: `RemoveEmbedAboveListItemTest` — the two-item repro fails on `main`, plus a standalone-embed guard for the neighbouring case. Existing embed tests are unaffected. Full suite passes, JS/Wasm compile clean. With this and #103, a seeded sweep covering typing, lists, styles, links, embeds, mentions and hashtags reports no violations across 200 seeds.
