### PR TITLE
fix: land a token at the content start when its range crosses a line break

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -211,7 +211,9 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
      * points reach the piece table directly, so they clamp here.
      */
     private fun contentStartFor(offset: Int): Int {
-        val item = transaction.getLineContent(offset, offset).paragraphs.firstOrNull { paragraph ->
+        // The lookup spans one character past [offset]: at an exact paragraph boundary a collapsed
+        // range resolves to the paragraph that ends there, never the item that starts there.
+        val item = transaction.getLineContent(offset, offset + 1).paragraphs.firstOrNull { paragraph ->
             paragraph.isListItem &&
                 offset >= paragraph.startOffset &&
                 offset < paragraph.startOffset + paragraph.startPiece.length
@@ -257,12 +259,25 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
             }
         )
         val start = contentStartFor(replaceRange.min)
-        val length = maxOf(replaceRange.max, start) - start
-        if (length > 0) transaction.update(start, length, model) else transaction.insert(
-            model,
+        val end = maxOf(replaceRange.max, start)
+        // The replaced window is removed through the text path rather than spliced out of the piece
+        // table: a range reaching past the end of its paragraph covers that paragraph's line break,
+        // and dropping it raw merges the next paragraph up. That path resolves decorators for the
+        // window it removes (#74, #82, #104).
+        val insertAt = if (end > start) {
+            val removal = TextEditorAction.TextRemoved(
+                offset = start,
+                length = end - start,
+                selection = TextRange(start),
+            )
+            // Clamped again: the removal can leave the caret on the marker of the item that moved
+            // up into the freed line.
+            contentStartFor(TextTransaction.onTextUpdated(removal, this).second.end)
+        } else {
             start
-        )
-        return TextRange(start + text.length)
+        }
+        transaction.insert(model, insertAt)
+        return TextRange(insertAt + text.length)
     }
 
     /**

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/TokenRangeAcrossBreakTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/TokenRangeAcrossBreakTest.kt
@@ -1,0 +1,63 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A token whose replace range reaches past the end of its paragraph removes that paragraph's line
+ * break, so the item below moves up into the freed line. The token must then still land inside that
+ * item's content: the caret the removal reports sits exactly on the item's marker, and an offset at
+ * a paragraph boundary has to resolve to the paragraph that *starts* there, not the one that ends.
+ */
+class TokenRangeAcrossBreakTest {
+
+    private fun TextKitEditorManager.assertNoMidlineDecorator() {
+        getParagraphs().forEachIndexed { i, p ->
+            assertTrue(
+                p.children.drop(1).none { it.decorator != null },
+                "paragraph $i carries a mid-line decorator: ${text.replace("\n", "\\n").replace("\t", "\\t")}",
+            )
+        }
+    }
+
+    /** "a", an empty line, then a numbered item holding "b". */
+    private fun editorWithEmptyLineAboveAnItem(): TextKitEditorManager {
+        val editor = editorFrom("{}")
+        editor.typeText(0, "ab")
+        editor.typeText(1, "\n")
+        editor.toListItem(TextRange(2, 3), TextEditorListItem.None, TextEditorListItem.NumberedList)
+        editor.typeText(1, "\n")
+        return editor
+    }
+
+    @Test
+    fun a_token_replacing_the_line_above_an_item_lands_inside_that_item() {
+        val editor = editorWithEmptyLineAboveAnItem()
+
+        // The range covers the empty line's break, so the item below moves up into it.
+        editor.insertMention(id = "u1", label = "J", replaceRange = TextRange(2, 3))
+
+        editor.assertNoMidlineDecorator()
+        val item = editor.getParagraphs().last()
+        assertEquals(1, item.children.count { it.decorator != null }, editor.text.replace("\t", "\\t"))
+        assertTrue(editor.text.endsWith("@Jb"), editor.text.replace("\t", "\\t").replace("\n", "\\n"))
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+
+    @Test
+    fun a_hashtag_replacing_the_line_above_an_item_lands_inside_that_item() {
+        val editor = editorWithEmptyLineAboveAnItem()
+
+        editor.insertToken(nodeType = "hashtag", id = "h1", label = "kt", replaceRange = TextRange(2, 3))
+
+        editor.assertNoMidlineDecorator()
+        assertTrue(editor.text.endsWith("@ktb"), editor.text.replace("\t", "\\t").replace("\n", "\\n"))
+        val once = editor.toJson()
+        assertEquals(once, editorFrom(once).toJson(), "export is not a fixed point")
+    }
+}


### PR DESCRIPTION
Closes #106

Removes a token's replaced window through the text-removal path instead of splicing it out of the piece table, then re-clamps the caret that removal reports — it can sit exactly on the marker of the item that moved up into the freed line. The clamp itself also had to widen its lookup by one character: a collapsed range at a paragraph boundary resolves to the paragraph that ends there, so the item starting there was invisible to it and the clamp quietly did nothing.

Tests: `TokenRangeAcrossBreakTest` — mention and hashtag cases, both failing on `main`. The cases added in #103 still pass, so the strictly-inside-a-decorator path is unchanged. Full suite passes on JVM, JS, Wasm and the iOS test compile.
