### PR TITLE
Bug: Removing text that includes list items when selection from bottom to top

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -171,7 +171,7 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
         color: String?
     ): Pair<Boolean, TextRange> {
         val prevFormatMarks =
-            transaction.getMarksWithType(selection.start, selection.end, configuration)
+            transaction.getMarksWithType(selection.min, selection.max, configuration)
 
         // Keep the current font size and only change the color. Removing the color (color == null)
         // falls back to the configured default color instead of dropping the text-style mark.

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/MultiPieceParagraph.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/MultiPieceParagraph.kt
@@ -258,7 +258,7 @@ internal data class MultiPieceParagraph(
             // so we take the marks of the first piece on the left side.
             data.size == 1 || (data.size == 2 && range.collapsed) -> {
                 val element = data.first()
-                if (element.isDecorator) MarkSearchType()
+                if (element.isDecorator) return MarkSearchType()
                 if (element.piece.marks.any { it is LinkMark }) {
                     val piece = element.piece
                     val newRange = if (range.collapsed) {

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorBasePieceTable.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/RichTextEditorBasePieceTable.kt
@@ -121,7 +121,9 @@ internal abstract class RichTextEditorBasePieceTable :
      * identify them just by checking the [PieceParagraph.outOfRange] property.
      */
     override fun getLineContent(start: Int, end: Int): MultiPieceParagraph {
-        return MultiPieceParagraph(findFastPiecesMultiLine(start, end), start, end)
+        val rangeStart = minOf(start, end)
+        val rangeEnd = maxOf(start, end)
+        return MultiPieceParagraph(findFastPiecesMultiLine(rangeStart, rangeEnd), rangeStart, rangeEnd)
     }
 
     /**
@@ -148,15 +150,17 @@ internal abstract class RichTextEditorBasePieceTable :
      * [PieceParagraph.outOfRange] == `true`.
      */
     override fun getLineContentWithNeighborListItems(start: Int, end: Int): MultiPieceParagraph {
-        val newStart = start.coerceAtLeast(0)
-        val newEnd = end.coerceAtMost(rope.totalLength)
+        val rangeStart = minOf(start, end)
+        val rangeEnd = maxOf(start, end)
+        val newStart = rangeStart.coerceAtLeast(0)
+        val newEnd = rangeEnd.coerceAtMost(rope.totalLength)
         // Two fused O(log P) walks (findParagraphStartAt / findParagraphEndAt) replace the
         // previous 4 separate walks (2× findByDocumentOffset + 2× paragraph-boundary search).
         val newStartPieceIndex = rope.findParagraphStartAt(newStart)
         val newEndPieceIndex = rope.findParagraphEndAt(newEnd)
 
         val paragraphs =
-            ArrayDeque(findFastPiecesMultiLine(start, end, newStartPieceIndex, newEndPieceIndex))
+            ArrayDeque(findFastPiecesMultiLine(rangeStart, rangeEnd, newStartPieceIndex, newEndPieceIndex))
 
         // Doc offsets read from the already-built models — O(1), no extra rope walk.
         val previousOffset = paragraphs.first().startOffset
@@ -177,7 +181,7 @@ internal abstract class RichTextEditorBasePieceTable :
             }
         }
 
-        return MultiPieceParagraph(paragraphs, start, end)
+        return MultiPieceParagraph(paragraphs, rangeStart, rangeEnd)
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
@@ -42,7 +42,13 @@ internal object TextDeletedTransaction {
         return if (selectedParagraphs.size > 1) {
             val firstParagraphInRange = selectedParagraphs.first()
             val lastParagraphInRange = selectedParagraphs.last()
-            deleteOnMultipleParagraphs(firstParagraphInRange, lastParagraphInRange, lines, actionModel)
+            deleteOnMultipleParagraphs(
+                firstParagraphInRange,
+                lastParagraphInRange,
+                lines,
+                actionModel,
+                documentLength = manager.text.length,
+            )
         } else {
             manager.transaction.deleteOnSingleParagraph(selectedParagraphs.first(), lines, actionModel)
         }
@@ -91,7 +97,8 @@ internal object TextDeletedTransaction {
         firstParagraph: PieceParagraph,
         lastParagraph: PieceParagraph,
         lines: MultiPieceParagraph,
-        actionModel: TextEditorAction.TextRemoved
+        actionModel: TextEditorAction.TextRemoved,
+        documentLength: Int,
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         val firstParagraphIncludesDecorator = firstParagraph.piecesInSelectedRange.first().piece.isDecorator
         // Document coordinates: the window's end lies strictly inside the last item's decorator
@@ -108,9 +115,13 @@ internal object TextDeletedTransaction {
         var length = actionModel.length
 
         if (firstParagraphIncludesDecorator) {
-            val remainingDecoratorOffset = getOffsetAfterDecorator(firstParagraph, actionModel.offset)
-            offset += remainingDecoratorOffset
-            length -= remainingDecoratorOffset
+            val decorSkip = maxOf(getOffsetAfterDecorator(firstParagraph, actionModel.offset), 0)
+            val wouldOrphanOpeningDecorator = decorSkip > 0 &&
+                actionModel.length >= documentLength - actionModel.offset
+            if (!wouldOrphanOpeningDecorator) {
+                offset += decorSkip
+                length = maxOf(length - decorSkip, 0)
+            }
         }
 
         if (isLastDecoratorPartiallySelected) {
@@ -155,18 +166,23 @@ internal object TextDeletedTransaction {
         return TextDecoratorTransaction.getDeleteTransaction(paragraph, lines, actionModel)
     }
 
-    private fun deleteTextAndDecorator(
+    private fun TextEditorTransaction.deleteTextAndDecorator(
         paragraph: PieceParagraph,
         actionModel: TextEditorAction.TextRemoved
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         return if (paragraph.piecesInSelectedRange.first().piece.isDecorator) {
-            val remainingDecoratorOffset = getOffsetAfterDecorator(paragraph, actionModel.offset)
-            val newOffset = actionModel.offset + remainingDecoratorOffset
-            val newLength = actionModel.length - remainingDecoratorOffset
-            val deleteTransaction = TextTransactionsUtils.deleteTransaction(newOffset, newLength)
-            val range = TextRange(newOffset)
-
-            Pair(range, listOf(deleteTransaction))
+            val decorSkip = maxOf(getOffsetAfterDecorator(paragraph, actionModel.offset), 0)
+            val wouldOrphanOpeningDecorator = decorSkip > 0 &&
+                actionModel.length >= text.length - actionModel.offset
+            if (wouldOrphanOpeningDecorator) {
+                val deleteTransaction = TextTransactionsUtils.deleteTransaction(actionModel.offset, actionModel.length)
+                Pair(TextRange(actionModel.offset), listOf(deleteTransaction))
+            } else {
+                val newOffset = actionModel.offset + decorSkip
+                val newLength = maxOf(actionModel.length - decorSkip, 0)
+                val deleteTransaction = TextTransactionsUtils.deleteTransaction(newOffset, newLength)
+                Pair(TextRange(newOffset), listOf(deleteTransaction))
+            }
         } else {
             val deleteTransaction = TextTransactionsUtils.deleteTransaction(actionModel.offset, actionModel.length)
             val range = TextRange(actionModel.offset)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
@@ -227,7 +227,8 @@ internal object TextInsertedTransaction {
 
         val length = currentDecorator.createDecoratorString().length
         val nextLevelTabsLength = if (currentParagraph.startPiece.decorator.toLevel() > 1) TABS.length else length
-        val rangeOffset = actionModel.offset - nextLevelTabsLength
+        val rangeOffset = (actionModel.offset - nextLevelTabsLength)
+            .coerceAtLeast(currentParagraph.startOffset)
 
         return Pair(TextRange(rangeOffset), transactions)
     }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -324,16 +324,33 @@ class TextKitState(
      * the caret to the list item the user clicked or arrowed onto.
      */
     private fun normalizeSelectionForListLayout(selection: TextRange): TextRange {
-        if (!selection.collapsed || !editorSegmentsNeedOffsetMapping(editorSegments)) return selection
-        val fieldOffset = selection.start.coerceIn(0, textFieldValue.text.length)
-        val displayOffset = editorOffsetMapping.originalToTransformed(fieldOffset)
-        val resolved = resolveParagraphCaretFieldOffset(
-            rawOffset = fieldOffset,
-            segments = editorSegments,
-            textLength = textFieldValue.text.length,
-            displayOffset = displayOffset,
+        if (!editorSegmentsNeedOffsetMapping(editorSegments)) return selection
+        val textLength = textFieldValue.text.length
+
+        fun roundTripFieldOffset(fieldOffset: Int): Int {
+            val field = fieldOffset.coerceIn(0, textLength)
+            val display = editorOffsetMapping.originalToTransformed(field)
+            return editorOffsetMapping.transformedToOriginal(display).coerceIn(0, textLength)
+        }
+
+        if (selection.collapsed) {
+            val fieldOffset = roundTripFieldOffset(selection.start)
+            val displayOffset = editorOffsetMapping.originalToTransformed(fieldOffset)
+            val resolved = resolveParagraphCaretFieldOffset(
+                rawOffset = fieldOffset,
+                segments = editorSegments,
+                textLength = textLength,
+                displayOffset = displayOffset,
+            )
+            return TextRange(resolved)
+        }
+
+        // Range selections must snap through display space so Compose never applies field offsets
+        // (which include list gutters) to the shorter transformed layout text.
+        return TextRange(
+            roundTripFieldOffset(selection.start),
+            roundTripFieldOffset(selection.end),
         )
-        return TextRange(resolved)
     }
 
     /**
@@ -1118,7 +1135,7 @@ class TextKitState(
                     textFieldValue = textFieldValue.copy(selection = snapped)
                 }
                 readSelectionContext()
-                checkDecorator(textFieldValue.selection.start, textFieldValue.selection.end)
+                checkDecorator(textFieldValue.selection.min, textFieldValue.selection.max)
                 tokenState.refreshQuery(textFieldValue.text, selection)
             } else {
                 // Replacing the same length of characters using the clipboard
@@ -1197,7 +1214,8 @@ class TextKitState(
      * Bounding box (in the text field's local coordinates) of the active trigger char, used to
      * anchor the popup. Null when no token is being composed or the layout is not ready.
      */
-    fun tokenAnchorBounds(): Rect? = tokenState.anchorBounds(textLayoutResult)
+    fun tokenAnchorBounds(): Rect? =
+        tokenState.anchorBounds(textLayoutResult) { editorOffsetMapping.originalToTransformed(it) }
 
     /** Backward-compatible alias of [dismissToken]. */
     fun dismissMention() = dismissToken()
@@ -1444,13 +1462,15 @@ class TextKitState(
             }
 
             isUsingClipboard -> {
+                val (offset, replacement) = replacementOverPriorSelection(
+                    priorText = textFieldValue.text,
+                    priorSelection = textFieldValue.selection,
+                    updatedText = prevTextFieldValue.text,
+                )
                 TextEditorAction.TextUpdated(
                     removeLength = textFieldValue.selection.length,
-                    text = prevTextFieldValue.text.substring(
-                        textFieldValue.selection.start,
-                        prevTextFieldValue.selection.end
-                    ),
-                    offset = textFieldValue.selection.start,
+                    text = replacement,
+                    offset = offset,
                     selection = prevTextFieldValue.selection
                 )
             }
@@ -1479,13 +1499,15 @@ class TextKitState(
             }
 
             isUsingClipboard -> {
+                val (offset, replacement) = replacementOverPriorSelection(
+                    priorText = textFieldValue.text,
+                    priorSelection = textFieldValue.selection,
+                    updatedText = prevTextFieldValue.text,
+                )
                 TextEditorAction.TextUpdated(
                     removeLength = textFieldValue.selection.length,
-                    text = prevTextFieldValue.text.substring(
-                        textFieldValue.selection.start,
-                        prevTextFieldValue.selection.end
-                    ),
-                    offset = textFieldValue.selection.start,
+                    text = replacement,
+                    offset = offset,
                     selection = prevTextFieldValue.selection
                 )
             }
@@ -1496,6 +1518,24 @@ class TextKitState(
                 selection = textFieldValue.selection
             )
         }
+    }
+
+    /**
+     * Text inserted when [updatedText] replaces the prior [priorSelection] in [priorText].
+     * Uses [priorSelection.min]/[priorSelection.max] so backward selections (start > end) are safe.
+     */
+    private fun replacementOverPriorSelection(
+        priorText: String,
+        priorSelection: TextRange,
+        updatedText: String,
+    ): Pair<Int, String> {
+        val removeStart = priorSelection.min.coerceIn(0, priorText.length)
+        val removeEnd = priorSelection.max.coerceIn(removeStart, priorText.length)
+        val removeLength = removeEnd - removeStart
+        val insertedLength = updatedText.length - priorText.length + removeLength
+        if (insertedLength <= 0) return removeStart to ""
+        val insertEnd = (removeStart + insertedLength).coerceIn(removeStart, updatedText.length)
+        return removeStart to updatedText.substring(removeStart, insertEnd)
     }
 
     companion object {

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -345,12 +345,10 @@ class TextKitState(
             return TextRange(resolved)
         }
 
-        // Range selections must snap through display space so Compose never applies field offsets
-        // (which include list gutters) to the shorter transformed layout text.
-        return TextRange(
-            roundTripFieldOffset(selection.start),
-            roundTripFieldOffset(selection.end),
-        )
+        // Range endpoints stay in field coordinates (TextFieldValue is always field text). Round-
+        // tripping through display space would snap offset 0 out of a list gutter into content
+        // (e.g. 0 → after "1. ") and break select-all and delete-over-selection.
+        return selection
     }
 
     /**
@@ -1467,12 +1465,21 @@ class TextKitState(
                     priorSelection = textFieldValue.selection,
                     updatedText = prevTextFieldValue.text,
                 )
-                TextEditorAction.TextUpdated(
-                    removeLength = textFieldValue.selection.length,
-                    text = replacement,
-                    offset = offset,
-                    selection = prevTextFieldValue.selection
-                )
+                val removeLength = textFieldValue.selection.max - textFieldValue.selection.min
+                if (replacement.isEmpty()) {
+                    TextEditorAction.TextRemoved(
+                        offset = offset,
+                        length = removeLength,
+                        selection = prevTextFieldValue.selection,
+                    )
+                } else {
+                    TextEditorAction.TextUpdated(
+                        removeLength = removeLength,
+                        text = replacement,
+                        offset = offset,
+                        selection = prevTextFieldValue.selection
+                    )
+                }
             }
 
             else -> {
@@ -1504,12 +1511,21 @@ class TextKitState(
                     priorSelection = textFieldValue.selection,
                     updatedText = prevTextFieldValue.text,
                 )
-                TextEditorAction.TextUpdated(
-                    removeLength = textFieldValue.selection.length,
-                    text = replacement,
-                    offset = offset,
-                    selection = prevTextFieldValue.selection
-                )
+                val removeLength = textFieldValue.selection.max - textFieldValue.selection.min
+                if (replacement.isEmpty()) {
+                    TextEditorAction.TextRemoved(
+                        offset = offset,
+                        length = removeLength,
+                        selection = prevTextFieldValue.selection,
+                    )
+                } else {
+                    TextEditorAction.TextUpdated(
+                        removeLength = removeLength,
+                        text = replacement,
+                        offset = offset,
+                        selection = prevTextFieldValue.selection
+                    )
+                }
             }
 
             else -> TextEditorAction.TextRemoved(

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitTokenState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitTokenState.kt
@@ -150,14 +150,19 @@ internal class TextKitTokenState(
      * Bounding box (text-field local coordinates) of the active trigger char, used to anchor the
      * popup. Null when no token is being composed or the [layout] is not ready.
      */
-    fun anchorBounds(layout: TextLayoutResult?): Rect? {
+    fun anchorBounds(
+        layout: TextLayoutResult?,
+        originalToTransformed: (Int) -> Int,
+    ): Rect? {
         if (anchor < 0 || layout == null) return null
+        // [anchor] is a field (piece-table) offset; layout text is the transformed display string.
+        val displayAnchor = originalToTransformed(anchor)
         // getBoundingBox needs a valid character index in [0, length). When the trigger char was just
         // typed at the very end of the document the layout is momentarily one frame behind (its text
         // is still the pre-insert, shorter string), so anchor can equal its length — skip this frame
         // instead of crashing; recomposition re-runs anchorBounds once the updated layout arrives.
-        if (anchor >= layout.layoutInput.text.length) return null
-        return layout.getBoundingBox(anchor)
+        if (displayAnchor >= layout.layoutInput.text.length) return null
+        return layout.getBoundingBox(displayAnchor)
     }
 
     /**

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
@@ -428,4 +428,49 @@ class ListItemUiTest {
             "Z must appear before the original second item text"
         )
     }
+
+    @Test
+    fun complexJsonV1_offsetMappingIsMonotonicAcrossFieldText() {
+        val state = stateWith(DocumentUtils.complexJsonV1)
+        val fieldText = state.textFieldValue.text
+        val transformed = state.visualTransformation.filter(AnnotatedString(fieldText))
+        val mapping = transformed.offsetMapping
+        assertTrue(transformed.text.length < fieldText.length)
+
+        var prevDisplay = -1
+        for (fieldOffset in 0..fieldText.length) {
+            val display = mapping.originalToTransformed(fieldOffset)
+            assertTrue(display in 0..transformed.text.length)
+            assertTrue(display >= prevDisplay, "field $fieldOffset mapped to non-monotonic display")
+            prevDisplay = display
+        }
+    }
+
+    @Test
+    fun complexJsonV1_rangeSelectionThroughListItemsDoesNotThrow() {
+        val state = stateWith(DocumentUtils.complexJsonV1)
+        val len = state.textFieldValue.text.length
+        val mid = len / 2
+
+        state.onTextFieldChange(state.textFieldValue.copy(selection = TextRange(0, len)))
+        state.onTextFieldChange(state.textFieldValue.copy(selection = TextRange(len, mid)))
+        state.onTextFieldChange(state.textFieldValue.copy(selection = TextRange(mid, len)))
+
+        assertTrue(state.textFieldValue.selection.length > 0)
+    }
+
+    @Test
+    fun complexJsonV1_deleteBackwardSelectionOverListsDoesNotThrow() {
+        val state = stateWith(DocumentUtils.complexJsonV1)
+        val before = state.textFieldValue.text
+        val len = before.length
+        val mid = len / 2
+        val afterDelete = before.removeRange(mid, len)
+
+        state.onTextFieldChange(state.textFieldValue.copy(selection = TextRange(len, mid)))
+        state.onTextFieldChange(TextFieldValue(text = afterDelete, selection = TextRange(mid)))
+
+        assertEquals(afterDelete, state.textFieldValue.text)
+        assertEquals(TextRange(mid), state.textFieldValue.selection)
+    }
 }


### PR DESCRIPTION
## Summary of changes
Fixes test failures introduced by the split list-layout work (selection mapping, delete-over-selection, and list decorators). :shared:allTests passes again.

## TextKitState.kt
Range selections: Stopped round-tripping range endpoints through display offset mapping. Round-tripping moved document start (e.g. 0) past list gutters (e.g. after "1. "), which broke select-all and list removal.
Delete over selection: When the clipboard/replace path has an empty replacement, route through TextRemoved with selection.min / selection.max instead of TextUpdated, so backward selections and pure deletes behave correctly.
TextDeletedTransaction.kt
Suffix deletes starting on a list decorator: If a delete covers the full suffix from the selection start to the end of the document, the opening list decorator is removed with the rest. Previously the engine skipped the decorator and left orphan text (e.g. "2. ").
Applied in both multi-paragraph and single-paragraph delete paths, with maxOf/coerce for safe length math.
TextInsertedTransaction.kt
Line break on empty list items: Clamped caret offset after subtracting gutter/decorator length with coerceAtLeast(paragraph.startOffset) so Enter inside a gutter cannot produce a negative TextRange (regression caught by EditingStressSweepTest).

## Tests fixed
ListToggleTest.removing_a_list_over_full_selection_keeps_whole_document_selected
ListItemUiTest.complexJsonV1_deleteBackwardSelectionOverListsDoesNotThrow
Full JVM suite including EditingStressSweepTest