### PR TITLE
Bug: when reordering list items

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
@@ -71,7 +71,7 @@ internal object TextInsertedTransaction {
         return if (updatedSelectedParagraph != null && isAddingTextToListItem) {
             insertTextInListParagraph(updatedSelectedParagraph, lines, actionModel)
         } else {
-            insertTextInParagraph(updatedSelectedParagraph, actionModel)
+            insertTextInParagraph(updatedSelectedParagraph, lines, actionModel)
         }
     }
 
@@ -133,29 +133,75 @@ internal object TextInsertedTransaction {
 
     private fun insertTextInParagraph(
         paragraph: PieceParagraph?,
+        lines: MultiPieceParagraph,
         actionModel: TextEditorAction.TextAdded
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         return when {
-            paragraph == null || paragraph.text.isLineBreak() -> insertTextInParagraph(
+            paragraph == null -> insertTextInParagraph(
                 actionModel,
                 getMarksForInsertion(actionModel.marks, filterLinkMarks = true)
             )
 
-            paragraph.text.isNotEmpty() -> insertTextInNonEmptyParagraph(paragraph, actionModel)
-            else -> insertTextInParagraph(actionModel, getMarksForInsertion(actionModel.marks))
+            paragraph.text.isLineBreak() && actionModel.text.isLineBreak() -> insertTextInParagraph(
+                actionModel,
+                getMarksForInsertion(actionModel.marks, filterLinkMarks = true)
+            )
+
+            else -> insertTextInNonEmptyParagraph(paragraph, lines, actionModel)
         }
     }
 
     private fun insertTextInNonEmptyParagraph(
         paragraph: PieceParagraph,
+        lines: MultiPieceParagraph,
         actionModel: TextEditorAction.TextAdded
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         // We need to validate if the text added matches with the regex
         val input = matchesListItemPattern(paragraph, actionModel)
         // It matches the regex, so we need to insert the decorator, otherwise just add the text
         return if (input != null) {
-            val updateTransaction = TextDecoratorTransaction.getUpdateDecoratorTransaction(input, paragraph, actionModel)
-            // TODO: Reorder elements on numbered lists.
+            val insertedDecorator = input.model.piece?.decorator
+            val leveledNumberedDecorator = if (insertedDecorator is TextDecoratorModel.NumberDecoratorModel) {
+                val listLevel = numberedListLevelAdjacentTo(lines, paragraph)
+                insertedDecorator.copyValue(level = listLevel)
+            } else {
+                null
+            }
+            val reorderedItems = if (leveledNumberedDecorator != null) {
+                TextTransactionsUtils.numberedListReorderAfterPatternInsert(lines, paragraph, leveledNumberedDecorator)
+            } else {
+                emptyList()
+            }
+            val reorderedCurrent = reorderedItems.find { it.offsetInDocument == paragraph.startOffset }
+            val updateInput = when {
+                reorderedCurrent != null && reorderedCurrent.modified -> {
+                    val decorator = reorderedCurrent.newRichPiece.decorator
+                    TextInputResult(
+                        TextEditorModel.create(
+                            text = decorator.createDecoratorString(),
+                            decorator = decorator,
+                        )
+                    )
+                }
+
+                leveledNumberedDecorator != null -> {
+                    TextInputResult(
+                        TextEditorModel.create(
+                            text = leveledNumberedDecorator.createDecoratorString(),
+                            decorator = leveledNumberedDecorator,
+                        )
+                    )
+                }
+
+                else -> input
+            }
+            val updateTransaction = TextDecoratorTransaction.getUpdateDecoratorTransaction(updateInput, paragraph, actionModel)
+            val transactions = mutableListOf(updateTransaction)
+            if (reorderedItems.isNotEmpty()) {
+                transactions.addAll(
+                    reorderedItems.createTransactions().filter { it.offsetInDocument != paragraph.startOffset }
+                )
+            }
             val modelLength = when (val type = updateTransaction.type) {
                 is TextEditorDecoratorTransactionType.Delete -> 0
                 is TextEditorDecoratorTransactionType.Insert -> type.model.text.length
@@ -163,12 +209,24 @@ internal object TextInsertedTransaction {
             }
             Pair(
                 TextRange(paragraph.startOffset + modelLength),
-                listOf(updateTransaction)
+                transactions
             )
         } else {
             val finalMarks = getMarksForInsertion(actionModel.marks)
             insertTextInParagraph(actionModel, finalMarks)
         }
+    }
+
+    private fun numberedListLevelAdjacentTo(
+        lines: MultiPieceParagraph,
+        paragraph: PieceParagraph,
+    ): Int {
+        val paragraphs = lines.paragraphs
+        val currentIndex = paragraphs.indexOfFirst { it.startOffset == paragraph.startOffset }
+        if (currentIndex < 0) return 1
+        return paragraphs.getOrNull(currentIndex - 1)?.startPiece?.decorator?.toLevel()
+            ?: paragraphs.getOrNull(currentIndex + 1)?.startPiece?.decorator?.toLevel()
+            ?: 1
     }
 
     private fun insertTextInParagraph(

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
@@ -224,10 +224,27 @@ internal object TextInsertedTransaction {
         val paragraphs = lines.paragraphs
         val currentIndex = paragraphs.indexOfFirst { it.startOffset == paragraph.startOffset }
         if (currentIndex < 0) return 1
-        return paragraphs.getOrNull(currentIndex - 1)?.startPiece?.decorator?.toLevel()
-            ?: paragraphs.getOrNull(currentIndex + 1)?.startPiece?.decorator?.toLevel()
-            ?: 1
+
+        fun numberedLevelSteppingFrom(step: Int): Int? {
+            var index = currentIndex + step
+            while (index in paragraphs.indices) {
+                val neighbor = paragraphs[index]
+                when {
+                    isNumberedListParagraph(neighbor) ->
+                        return neighbor.startPiece.decorator.toLevel()
+
+                    neighbor.isListItem -> return null
+                    else -> index += step
+                }
+            }
+            return null
+        }
+
+        return numberedLevelSteppingFrom(-1) ?: numberedLevelSteppingFrom(1) ?: 1
     }
+
+    private fun isNumberedListParagraph(paragraph: PieceParagraph): Boolean =
+        paragraph.isListItem && paragraph.paragraphType == TextEditorListItem.NumberedList
 
     private fun insertTextInParagraph(
         actionModel: TextEditorAction.TextAdded,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransactionsUtils.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransactionsUtils.kt
@@ -1,13 +1,17 @@
 package com.jjrodcast.textkit.editor.core.transactions.text
 
 import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.core.converters.ListsConverter
+import com.jjrodcast.textkit.editor.core.converters.models.PositionalListItem
 import com.jjrodcast.textkit.editor.core.converters.utils.PositionalListItemUtils
 import com.jjrodcast.textkit.editor.core.converters.utils.createTransactions
 import com.jjrodcast.textkit.editor.core.converters.utils.flatten
 import com.jjrodcast.textkit.editor.core.models.MultiPieceParagraph
 import com.jjrodcast.textkit.editor.core.models.PieceParagraph
 import com.jjrodcast.textkit.editor.core.models.TextEditorModel
+import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel
+import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel.Companion.createDecoratorString
 import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel.Companion.toLevel
 import com.jjrodcast.textkit.editor.core.transactions.lists.models.TextEditorDecoratorTransactionType
 import com.jjrodcast.textkit.editor.core.transactions.lists.models.TextEditorListItemTransaction
@@ -43,6 +47,63 @@ internal object TextTransactionsUtils {
         val decoratorLength = paragraph.startPiece.length
         val decoratorEndOffset = decoratorOffset + decoratorLength
         return decoratorEndOffset - offset
+    }
+
+    /**
+     * After the user types a numbered-list marker on a plain paragraph that sits in a numbered
+     * sequence (e.g. exiting an empty item with Enter, then typing `3. `), renumber the connected
+     * block so following siblings stay in order.
+     */
+    internal fun numberedListReorderAfterPatternInsert(
+        lines: MultiPieceParagraph,
+        paragraph: PieceParagraph,
+        insertedDecorator: TextDecoratorModel.NumberDecoratorModel,
+    ): List<PositionalListItem> {
+        val paragraphs = lines.paragraphs
+        val currentIndex = paragraphs.indexOfFirst { it.startOffset == paragraph.startOffset }
+        if (currentIndex < 0) return emptyList()
+
+        val numberedIndices = paragraphs.indices.filter {
+            paragraphs[it].isListItem && paragraphs[it].paragraphType == TextEditorListItem.NumberedList
+        }
+        if (numberedIndices.isEmpty()) return emptyList()
+
+        val hasNumberedBefore = numberedIndices.any { it < currentIndex }
+        val hasNumberedAfter = numberedIndices.any { it > currentIndex }
+        if (!hasNumberedBefore && !hasNumberedAfter) return emptyList()
+
+        val rangeStart = numberedIndices.filter { it < currentIndex }.maxOrNull() ?: currentIndex
+        val rangeEnd = numberedIndices.filter { it > currentIndex }.maxOrNull()
+            ?: numberedIndices.filter { it <= currentIndex }.maxOrNull()
+            ?: currentIndex
+
+        val decoratorText = insertedDecorator.createDecoratorString()
+        val localItems = paragraphs.withIndex()
+            .filter { (index, pieceParagraph) ->
+                index in rangeStart..rangeEnd &&
+                    (
+                        (pieceParagraph.isListItem && pieceParagraph.paragraphType == TextEditorListItem.NumberedList) ||
+                            index == currentIndex
+                        )
+            }
+            .mapIndexed { index, (originalIndex, pieceParagraph) ->
+                val richPiece = if (originalIndex == currentIndex) {
+                    pieceParagraph.startPiece.copy(
+                        decorator = insertedDecorator,
+                        length = decoratorText.length,
+                    )
+                } else {
+                    pieceParagraph.startPiece
+                }
+                PositionalListItem(
+                    index = index,
+                    richPiece = richPiece,
+                    offsetInDocument = pieceParagraph.startOffset,
+                )
+            }
+
+        if (localItems.size <= 1) return emptyList()
+        return PositionalListItemUtils.reorderItems(localItems)
     }
 
     internal fun reorderListItemsOnUpdate(lines: MultiPieceParagraph): List<TextEditorListItemTransaction> {

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransactionsUtils.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransactionsUtils.kt
@@ -63,27 +63,17 @@ internal object TextTransactionsUtils {
         val currentIndex = paragraphs.indexOfFirst { it.startOffset == paragraph.startOffset }
         if (currentIndex < 0) return emptyList()
 
-        val numberedIndices = paragraphs.indices.filter {
-            paragraphs[it].isListItem && paragraphs[it].paragraphType == TextEditorListItem.NumberedList
-        }
-        if (numberedIndices.isEmpty()) return emptyList()
-
-        val hasNumberedBefore = numberedIndices.any { it < currentIndex }
-        val hasNumberedAfter = numberedIndices.any { it > currentIndex }
-        if (!hasNumberedBefore && !hasNumberedAfter) return emptyList()
-
-        val rangeStart = numberedIndices.filter { it < currentIndex }.maxOrNull() ?: currentIndex
-        val rangeEnd = numberedIndices.filter { it > currentIndex }.maxOrNull()
-            ?: numberedIndices.filter { it <= currentIndex }.maxOrNull()
-            ?: currentIndex
+        val targetLevel = insertedDecorator.level
+        val connectedRange = connectedNumberedSiblingRange(paragraphs, currentIndex, targetLevel)
+            ?: return emptyList()
 
         val decoratorText = insertedDecorator.createDecoratorString()
         val localItems = paragraphs.withIndex()
             .filter { (index, pieceParagraph) ->
-                index in rangeStart..rangeEnd &&
+                index in connectedRange &&
                     (
-                        (pieceParagraph.isListItem && pieceParagraph.paragraphType == TextEditorListItem.NumberedList) ||
-                            index == currentIndex
+                        index == currentIndex ||
+                            isNumberedSiblingAtLevel(pieceParagraph, targetLevel)
                         )
             }
             .mapIndexed { index, (originalIndex, pieceParagraph) ->
@@ -103,8 +93,98 @@ internal object TextTransactionsUtils {
             }
 
         if (localItems.size <= 1) return emptyList()
-        return PositionalListItemUtils.reorderItems(localItems)
+
+        val startCount = localItems.firstNotNullOfOrNull { item ->
+            item.richPiece.decorator?.toCount()
+        } ?: 1
+        return PositionalListItemUtils.reorderItems(localItems, start = startCount)
     }
+
+    /**
+     * Document-order span covering the plain paragraph being converted plus numbered siblings at
+     * [targetLevel] reachable without crossing another list kind. Plain paragraphs are crossed
+     * only as gaps; bullets/tasks/block items act as barriers so distant numbered items in the
+     * neighbor window are not pulled into the same renumber pass.
+     */
+    private fun connectedNumberedSiblingRange(
+        paragraphs: List<PieceParagraph>,
+        currentIndex: Int,
+        targetLevel: Int,
+    ): IntRange? {
+        fun isNumberedSibling(pieceParagraph: PieceParagraph) =
+            isNumberedSiblingAtLevel(pieceParagraph, targetLevel)
+
+        fun isBarrier(pieceParagraph: PieceParagraph) =
+            pieceParagraph.isListItem && !isNumberedSibling(pieceParagraph)
+
+        var hasNumberedBefore = false
+        var probe = currentIndex - 1
+        while (probe >= 0) {
+            when {
+                isBarrier(paragraphs[probe]) -> break
+                isNumberedSibling(paragraphs[probe]) -> {
+                    hasNumberedBefore = true
+                    break
+                }
+
+                else -> probe--
+            }
+        }
+
+        var hasNumberedAfter = false
+        probe = currentIndex + 1
+        while (probe < paragraphs.size) {
+            when {
+                isBarrier(paragraphs[probe]) -> break
+                isNumberedSibling(paragraphs[probe]) -> {
+                    hasNumberedAfter = true
+                    break
+                }
+
+                else -> probe++
+            }
+        }
+
+        if (!hasNumberedBefore && !hasNumberedAfter) return null
+
+        var start = currentIndex
+        probe = currentIndex - 1
+        while (probe >= 0) {
+            when {
+                isBarrier(paragraphs[probe]) -> break
+                isNumberedSibling(paragraphs[probe]) -> {
+                    start = probe
+                    probe--
+                }
+
+                else -> probe--
+            }
+        }
+
+        var end = currentIndex
+        probe = currentIndex + 1
+        while (probe < paragraphs.size) {
+            when {
+                isBarrier(paragraphs[probe]) -> break
+                isNumberedSibling(paragraphs[probe]) -> {
+                    end = probe
+                    probe++
+                }
+
+                else -> probe++
+            }
+        }
+
+        return start..end
+    }
+
+    private fun isNumberedSiblingAtLevel(
+        pieceParagraph: PieceParagraph,
+        targetLevel: Int,
+    ): Boolean =
+        pieceParagraph.isListItem &&
+            pieceParagraph.paragraphType == TextEditorListItem.NumberedList &&
+            pieceParagraph.startPiece.decorator.toLevel() == targetLevel
 
     internal fun reorderListItemsOnUpdate(lines: MultiPieceParagraph): List<TextEditorListItemTransaction> {
         val currentParagraphIndex = lines.selectedParagraphIndices.first()

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
@@ -411,6 +411,31 @@ class ListItemUiTest {
     }
 
     @Test
+    fun complexJsonV1_enterEmptyItemThenTypeNumberedMarkerRenumbersFollowingItems() {
+        val state = stateWith(DocumentUtils.complexJsonV1)
+        val text = state.textFieldValue.text
+        val endOfFirst = text.lastIndexOf("item", text.indexOf("Second")) + "item".length
+        state.simulateTypingAt(endOfFirst, "\n")
+        val afterFirstEnter = state.textFieldValue
+        val mapping = state.visualTransformation.filter(AnnotatedString(afterFirstEnter.text)).offsetMapping
+        val caretAfterExit = mapping.transformedToOriginal(afterFirstEnter.selection.max)
+        state.simulateTypingAt(caretAfterExit, "\n")
+        val afterSecondEnter = state.textFieldValue
+        val mapping2 = state.visualTransformation.filter(AnnotatedString(afterSecondEnter.text)).offsetMapping
+        val caretForMarker = mapping2.transformedToOriginal(afterSecondEnter.selection.max)
+        state.simulateTypingAt(caretForMarker, "3. ")
+        state.simulateTypingAt(state.textFieldValue.selection.max, "gap")
+        val updated = state.textFieldValue.text
+        val secondIndex = updated.indexOf("Second")
+        val prefixBeforeSecond = updated.substring((secondIndex - 4).coerceAtLeast(0), secondIndex)
+        assertTrue(
+            prefixBeforeSecond.contains("3."),
+            "Second item must be renumbered after re-entering the list, got: $updated"
+        )
+        assertTrue(updated.contains("gap"))
+    }
+
+    @Test
     fun complexJsonV1_firstListItemEnterThenTypeInNewEmptyItem() {
         val state = stateWith(DocumentUtils.complexJsonV1)
         val text = state.textFieldValue.text


### PR DESCRIPTION
## Problem
After the correct Enter sequence on a numbered list (new empty item → Enter removes it → user types e.g. 3. ), following numbered items were not renumbered. A TODO in the insert path had left that case unimplemented.

##cRoot causes
No reorder after pattern insert — Converting typed text like 3. into a list decorator did not run the same renumbering logic used elsewhere. Empty / line-break-only paragraphs — List marker detection ran only on non-empty paragraphs, so inserts after exiting an empty item often skipped decorator conversion and reordering. Level mismatch — ListItemValidator used level 1 for new markers, while documents like complexJsonV1 use indented list levels; renumbering could treat siblings incorrectly.

## Implementation
TextTransactionsUtils.numberedListReorderAfterPatternInsert — Finds the connected block of numbered items (before, current paragraph, after), applies the new decorator virtually, runs PositionalListItemUtils.reorderItems, and builds update transactions for siblings. TextInsertedTransaction — On numbered pattern match: inherit list level from adjacent numbered items; use reordered count for the current item’s decorator; append reorder transactions for following items; route empty and line-break-only paragraphs through pattern handling (except pure \n on \n).

## Tests
Added ListItemUiTest.complexJsonV1_enterEmptyItemThenTypeNumberedMarkerRenumbersFollowingItems, covering the full UI flow with DocumentUtils.complexJsonV1.