### PR TITLE
fix: keep list markers in step with the layout they are placed on

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
@@ -115,6 +115,7 @@ fun TextKitEditor(
                 ListItemEditorGutterOverlay(
                     layoutResult = state.textLayoutResult,
                     segments = state.editorSegments(),
+                    displayLength = state.editorDisplayLength,
                     textStyle = TextStyle(color = TextKitTheme.colors.onSurface),
                     textColor = TextKitTheme.colors.onSurface,
                     modifier = Modifier.fillMaxSize(),
@@ -223,6 +224,7 @@ fun TextKitEditorOutlined(
                 ListItemEditorGutterOverlay(
                     layoutResult = state.textLayoutResult,
                     segments = state.editorSegments(),
+                    displayLength = state.editorDisplayLength,
                     textStyle = TextStyle(color = TextKitTheme.colors.onSurface),
                     textColor = TextKitTheme.colors.onSurface,
                     modifier = Modifier.fillMaxSize(),

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/listlayout/ListItemEditorTransform.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/listlayout/ListItemEditorTransform.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
@@ -128,34 +129,55 @@ private class ListItemOffsetMapping(
 internal fun ListItemEditorGutterOverlay(
     layoutResult: TextLayoutResult?,
     segments: List<EditorParagraphSegment>,
+    displayLength: Int,
     textStyle: TextStyle,
     textColor: Color,
     modifier: Modifier = Modifier,
 ) {
-    val overlaySegments = editorOverlaySegments(segments)
-    if (layoutResult == null || overlaySegments.isEmpty()) return
+    if (layoutResult == null) return
 
-    val displayLength = layoutResult.layoutInput.text.length
-    if (displayLength == 0) return
+    val laidOutLength = layoutResult.layoutInput.text.length
+    if (laidOutLength == 0) return
+
+    // The layout lags the segments by a frame: right after a list item is removed the segments
+    // already describe the shorter document while [layoutResult] still measures the longer one, so
+    // every marker would be placed on whatever line the *old* text had at that offset — the whole
+    // gutter jumps for one frame. Rather than mixing the two generations, keep painting the last
+    // pair that agreed until the matching layout arrives (#112).
+    val lastAgreed = remember { arrayOfNulls<List<GutterMarker>>(1) }
+    val markers = if (laidOutLength == displayLength) {
+        buildGutterMarkers(editorOverlaySegments(segments), layoutResult, laidOutLength)
+            .also { lastAgreed[0] = it }
+    } else {
+        lastAgreed[0] ?: return
+    }
+    if (markers.isEmpty()) return
 
     Box(modifier = modifier) {
         val markerStyle = textStyle.copy(color = textColor)
-        overlaySegments.forEach { segment ->
-            val gutter = segment.gutter ?: return@forEach
-            val label = gutter.createDecoratorString()
-            if (label.isEmpty()) return@forEach
-
-            val displayOffset = segment.displayStart.coerceIn(0, displayLength - 1)
-            val lineIndex = layoutResult.getLineForOffset(displayOffset)
-            val lineTop = layoutResult.getLineTop(lineIndex)
-
+        markers.forEach { marker ->
             Text(
-                text = label,
+                text = marker.label,
                 style = markerStyle,
                 modifier = Modifier.offset {
-                    IntOffset(x = 0, y = lineTop.roundToInt())
+                    IntOffset(x = 0, y = marker.top.roundToInt())
                 }
             )
         }
     }
+}
+
+/** A list marker resolved to the vertical position of the line it belongs to. */
+private data class GutterMarker(val label: String, val top: Float)
+
+private fun buildGutterMarkers(
+    overlaySegments: List<EditorParagraphSegment>,
+    layoutResult: TextLayoutResult,
+    displayLength: Int,
+): List<GutterMarker> = overlaySegments.mapNotNull { segment ->
+    val label = segment.gutter?.createDecoratorString().orEmpty()
+    if (label.isEmpty()) return@mapNotNull null
+    val displayOffset = segment.displayStart.coerceIn(0, displayLength - 1)
+    val lineIndex = layoutResult.getLineForOffset(displayOffset)
+    GutterMarker(label = label, top = layoutResult.getLineTop(lineIndex))
 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -283,8 +283,13 @@ class TextKitState(
 
     private var annotatedString by mutableStateOf(AnnotatedString(text = ""))
 
-    private var editorSegments: List<EditorParagraphSegment> = emptyList()
-    private var editorOffsetMapping: OffsetMapping = OffsetMapping.Identity
+    // Snapshot state, not plain fields: the gutter overlay positions every list marker from these
+    // against `textLayoutResult`, which IS snapshot state. Untracked, the overlay recomposed only
+    // because some other state changed and then read whatever these happened to hold — so for a
+    // frame the markers could be drawn from a different generation than the layout they sit on,
+    // which reads as a blink while typing or removing items (#112).
+    private var editorSegments: List<EditorParagraphSegment> by mutableStateOf(emptyList())
+    private var editorOffsetMapping: OffsetMapping by mutableStateOf(OffsetMapping.Identity)
 
     private val viewerBlocksState = derivedStateOf {
         annotatedString // snapshot dependency for highlight/theme rebuilds
@@ -310,6 +315,13 @@ class TextKitState(
     internal val paragraphs get() = manager.getParagraphs()
 
     internal fun editorSegments(): List<EditorParagraphSegment> = editorSegments
+
+    /**
+     * Length of the display text [editorSegments] was built for. The gutter overlay compares it
+     * against the length the layout actually measured, so it can tell a stale layout from a current
+     * one instead of placing markers with mismatched coordinates (#112).
+     */
+    internal val editorDisplayLength: Int get() = annotatedString.length
 
     internal fun displayOffsetToFieldOffset(displayOffset: Int): Int {
         val displayLength = annotatedString.length


### PR DESCRIPTION
Closes #112

The gutter markers are drawn by an overlay that positions each one from `textLayoutResult`. Two things let the markers and that layout drift apart:

**The marker data wasn't observable.** `editorSegments` and `editorOffsetMapping` were plain fields, so Compose had no dependency on them — the overlay recomposed only because *other* state changed, and then read whatever the fields happened to hold. They are snapshot state now, which is what the blink while typing came down to.

**The overlay mixed generations.** Layout lags the segments by a frame, so right after an item is removed the segments already describe the shorter document while `layoutResult` still measures the longer one. Every marker offset is still *valid* against that older layout, so nothing clamps or throws — `getLineForOffset` just answers for the text that used to be there, and the whole gutter lands on the wrong rows for a frame. The overlay now compares the length the layout measured against the length of the display text the segments describe, and while the two disagree it repaints the last pairing that agreed instead of resolving new offsets against a stale layout.

One consequence worth naming: while the layout is catching up, the gutter shows the markers from the previous frame rather than recomputed ones. In testing this was not perceptible, but it is a deliberate trade — a frame of slightly stale marker positions instead of a frame of visibly wrong ones.

Verified by hand on the desktop app against the case in the issue — a long list, typing quickly and deleting items from the middle so the numbering shifts.
