### PR TITLE
fix: stop a format merge from swallowing the next piece's first character

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/marks/MultiPieceFormatTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/marks/MultiPieceFormatTransaction.kt
@@ -128,14 +128,17 @@ internal object MultiPieceFormatTransaction {
             val transactionMarks = when {
                 canMergeWithPrevious(left.piece, currentModel.piece, finalMarks) -> {
                     val leftModel = TextEditorModel.create(left.piece)
-                    val length =
-                        leftModel.pieceLength - (range.min - leftModel.pieceStart) + currentModel.pieceLength
+                    // The length is the central piece's own portion — the merge adds the left
+                    // piece's length itself. Including the left remainder here counted it twice, so
+                    // the merged piece ran past its own text and swallowed the next piece's first
+                    // character (a swallowed line break then hides a paragraph boundary, leaving the
+                    // following item's marker mid-line).
                     transaction.getTransactionMarks(
                         leftModel,
                         currentModel,
                         null,
                         range.start,
-                        length,
+                        currentModel.pieceLength,
                         finalMarks
                     )
                 }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
@@ -90,7 +90,8 @@ internal object EditingStress {
     /** Decides the next operation from [rng] and returns its description plus a thunk that runs it. */
     private fun decideOp(editor: TextKitEditorManager, rng: Random): Pair<String, () -> Unit> {
         val len = editor.text.length
-        return when (rng.nextInt(16)) {
+        // 17 values for 16 explicit branches plus the colour op in `else`.
+        return when (rng.nextInt(17)) {
             0 -> {
                 val at = rng.nextInt(len + 1)
                 val text = randomText(rng)

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
@@ -90,7 +90,7 @@ internal object EditingStress {
     /** Decides the next operation from [rng] and returns its description plus a thunk that runs it. */
     private fun decideOp(editor: TextKitEditorManager, rng: Random): Pair<String, () -> Unit> {
         val len = editor.text.length
-        return when (rng.nextInt(12)) {
+        return when (rng.nextInt(16)) {
             0 -> {
                 val at = rng.nextInt(len + 1)
                 val text = randomText(rng)
@@ -165,12 +165,66 @@ internal object EditingStress {
                 "align $align $range" to { editor.setTextAlign(range, align); Unit }
             }
 
+            11 -> {
+                val range = randomRange(rng, len)
+                val href = if (rng.nextBoolean()) "https://example.dev" else ""
+                "link '$href' $range" to { editor.setLink(range, href); Unit }
+            }
+
+            12 -> {
+                // Tokens replace the trigger text the caller matched, which always lies inside one
+                // paragraph's own content — never across a decorator.
+                val range = contentRange(editor, rng) ?: return "mention <no content>" to {}
+                "mention $range" to { editor.insertMention(id = "u1", label = "Jorge", replaceRange = range); Unit }
+            }
+
+            13 -> {
+                val range = contentRange(editor, rng) ?: return "hashtag <no content>" to {}
+                "hashtag $range" to {
+                    editor.insertToken(nodeType = "hashtag", id = "h1", label = "kt", replaceRange = range)
+                    Unit
+                }
+            }
+
+            14 -> {
+                val at = rng.nextInt(len + 1)
+                "embed @$at" to { editor.insertEmbed("table", TABLE_BLOCK, label = "T", at = TextRange(at)); Unit }
+            }
+
+            15 -> {
+                // Removal takes the placeholder's own range, the way the caller gets it.
+                val at = if (len == 0) 0 else rng.nextInt(len)
+                val embed = editor.embedAt(at) ?: return "unembed <none>" to {}
+                "unembed @$at" to { editor.removeEmbedAt(embed.range); Unit }
+            }
+
             else -> {
                 val range = randomRange(rng, len)
                 val color = if (rng.nextBoolean()) "#ff0000" else null
                 "color $color $range" to { editor.setColor(range, color); Unit }
             }
         }
+    }
+
+    /**
+     * A range inside one paragraph's own content — what a token's caller passes, having matched the
+     * trigger text the user typed. Returns null while no paragraph has any content yet.
+     */
+    private fun contentRange(editor: TextKitEditorManager, rng: Random): TextRange? {
+        var offset = 0
+        val spans = editor.getParagraphs().map { paragraph ->
+            val start = offset
+            val length = paragraph.children.sumOf { it.text.length }
+            offset += length
+            val decorator = paragraph.children.first().decorator
+            val contentStart = start + if (decorator != null) paragraph.children.first().text.length else 0
+            val contentEnd = (start + length) - if (paragraph.children.last().text.endsWith("\n")) 1 else 0
+            contentStart to maxOf(contentStart, contentEnd)
+        }.filter { it.second > it.first }
+        if (spans.isEmpty()) return null
+        val (from, to) = spans[rng.nextInt(spans.size)]
+        val start = from + rng.nextInt(to - from)
+        return TextRange(start, minOf(to, start + rng.nextInt(0, 4)))
     }
 
     private fun randomText(rng: Random): String {
@@ -188,6 +242,8 @@ internal object EditingStress {
     }
 
     private const val ALPHABET = "abc de"
+
+    private const val TABLE_BLOCK = """{"type":"table","content":[{"type":"tableRow","content":[]}]}"""
 
     private val LIST_TYPES = listOf(
             TextEditorListItem.NumberedList,


### PR DESCRIPTION
Part of #46

Two changes that found and fix each other.

**The harness now covers links, mentions, hashtags and embeds.** These were the last operations missing from the op mix, and #46 lists hyperlinks and embeds explicitly. Token ranges are drawn from a paragraph's own content and embed removal uses the placeholder's own range, so the sweep exercises what the real callers pass rather than arbitrary offsets.

**It immediately found a bug, fixed here.** In `MultiPieceFormatTransaction`, the branch that merges a formatted piece with its left neighbour passed `leftRemainder + centralLength` as the length — but `getLeftPieceTransaction` adds the left piece's length itself, so the remainder was counted twice. The merged piece ran one character past its own text and swallowed the first character of the next piece:
```
removed  [dc\n]   ADDED@18+1 + ADDED@19+2   (3 chars)
inserted [dc\na]  ADDED@18+4                (4 chars)
```
When the swallowed character is a line break the paragraph boundary disappears, and the following item's marker ends up mid-line. This is the third site of the coordinate/length confusion fixed in #99 and #100.

The widened harness is the regression test: it fails on `main` at `seed=288 step=27 op 'unstyle Bold TextRange(18, 22)'` and passes with the fix. The bug needs a specific fragmented piece layout that 20,000 randomised short sequences never reached — 27 operations on that seed do — which is why the coverage and the fix land together rather than as a synthetic test.

With this, the sweep is clean across the whole editing surface: 400 seeds × 250 operations × 3 starting documents, typing, breaks, deletes, replaces, multiline pastes, list toggles and type switches, styles, alignment, colour, links, mentions, hashtags and embeds — no violations, and no transaction that changes the document's text while only marks should change.
