### PR TITLE
fix: keep blockquote content when a document is opened for editing

### DIFF
--- a/shared/karma.config.d/timeout.js
+++ b/shared/karma.config.d/timeout.js
@@ -1,0 +1,11 @@
+// Mocha's default 2s per-test cap is too tight for the deterministic stress smokes
+// (EditingStressTest, UndoRedoStressTest) on a cold CI runner — the suite completes but the
+// slowest smoke crosses 2s and is reported as a bare "Error". The full sweeps stay JVM-only;
+// this only gives the browser smokes room to finish.
+config.set({
+  client: {
+    mocha: {
+      timeout: 10000,
+    },
+  },
+});

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
@@ -9,7 +9,13 @@ import com.jjrodcast.textkit.editor.core.interfaces.TextEditorInitTransaction
 import com.jjrodcast.textkit.editor.core.models.TextEditorDocumentModel
 import com.jjrodcast.textkit.editor.core.models.TextEditorModel
 import com.jjrodcast.textkit.editor.core.parser.BaseParagraph
+import com.jjrodcast.textkit.editor.core.parser.BaseText
 import com.jjrodcast.textkit.editor.core.parser.Blockquote
+import com.jjrodcast.textkit.editor.core.parser.BulletedList
+import com.jjrodcast.textkit.editor.core.parser.ListItem
+import com.jjrodcast.textkit.editor.core.parser.OrderedList
+import com.jjrodcast.textkit.editor.core.parser.TaskList
+import com.jjrodcast.textkit.editor.core.parser.TaskListItem
 import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.parser.TEXT_EDITOR_JSON
@@ -73,9 +79,25 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
         pieceTable.build(document)
     }
 
-    /** Replaces a blockquote (at any nesting depth) with the blocks it contains. */
-    private fun BaseParagraph.unwrapBlockquotes(): List<BaseParagraph> =
-        if (this is Blockquote) content.flatMap { it.unwrapBlockquotes() } else listOf(this)
+    /**
+     * Replaces a blockquote (at any nesting depth) with the blocks it contains. Recurses into list
+     * items too: a blockquote inside a `listItem`/`taskItem` would otherwise survive to the piece
+     * table, render its text in the editor, and still be dropped by the export — content the user
+     * can see but that never saves.
+     */
+    private fun BaseParagraph.unwrapBlockquotes(): List<BaseParagraph> = when (this) {
+        is Blockquote -> content.flatMap { it.unwrapBlockquotes() }
+        is BulletedList -> listOf(copy(content = content.map { it.unwrapInsideItem() }))
+        is OrderedList -> listOf(copy(content = content.map { it.unwrapInsideItem() }))
+        is TaskList -> listOf(copy(content = content.map { it.unwrapInsideItem() }))
+        else -> listOf(this)
+    }
+
+    private fun BaseText.unwrapInsideItem(): BaseText = when (this) {
+        is ListItem -> copy(content = content.flatMap { it.unwrapBlockquotes() })
+        is TaskListItem -> copy(content = content.flatMap { it.unwrapBlockquotes() })
+        else -> this
+    }
 
     override fun fromDocument(document: TextEditorDocumentModel) {
         pieceTable.build(document)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
@@ -8,7 +8,8 @@ import com.jjrodcast.textkit.editor.core.converters.TextEditorConverter
 import com.jjrodcast.textkit.editor.core.interfaces.TextEditorInitTransaction
 import com.jjrodcast.textkit.editor.core.models.TextEditorDocumentModel
 import com.jjrodcast.textkit.editor.core.models.TextEditorModel
-import com.jjrodcast.textkit.editor.core.parser.BlockquoteType
+import com.jjrodcast.textkit.editor.core.parser.BaseParagraph
+import com.jjrodcast.textkit.editor.core.parser.Blockquote
 import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.parser.TEXT_EDITOR_JSON
@@ -60,7 +61,10 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
         val filteredContent = if (this.isViewer) {
             textEditorDocument.content
         } else {
-            textEditorDocument.content.filter { it.type != BlockquoteType.Blockquote }
+            // The editor has no blockquote editing, so the node itself cannot survive, but its
+            // paragraphs can: unwrap them in place of dropping the whole block, or opening a
+            // document for editing silently deletes every quoted line.
+            textEditorDocument.content.flatMap { it.unwrapBlockquotes() }
         }
         val document = TextEditorConverter.getAsTextWithMarks(
             TextEditorDocument(filteredContent),
@@ -68,6 +72,10 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
         )
         pieceTable.build(document)
     }
+
+    /** Replaces a blockquote (at any nesting depth) with the blocks it contains. */
+    private fun BaseParagraph.unwrapBlockquotes(): List<BaseParagraph> =
+        if (this is Blockquote) content.flatMap { it.unwrapBlockquotes() } else listOf(this)
 
     override fun fromDocument(document: TextEditorDocumentModel) {
         pieceTable.build(document)

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteEditorLoadTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteEditorLoadTest.kt
@@ -59,6 +59,48 @@ class BlockquoteEditorLoadTest {
     }
 
     @Test
+    fun a_blockquote_inside_a_list_item_keeps_its_text() {
+        // The nested case is the treacherous one: an un-unwrapped blockquote here still reaches
+        // the piece table and RENDERS, but the export drops it — content the user can see that
+        // never saves.
+        val editor = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"bulletList","content":[
+                {"type":"listItem","content":[
+                  {"type":"paragraph","content":[{"type":"text","text":"item"}]},
+                  {"type":"blockquote","content":[
+                    {"type":"paragraph","content":[{"type":"text","text":"nested quote"}]}
+                  ]}
+                ]}
+              ]}
+            ]}"""
+        )
+        assertTrue(editor.text.contains("nested quote"))
+        val saved = editor.toJson()
+        assertTrue(saved.contains("nested quote"), "quoted text rendered but lost on save: $saved")
+        assertEquals(saved, editorFrom(saved).toJson())
+    }
+
+    @Test
+    fun a_blockquote_inside_a_task_item_keeps_its_text() {
+        val editor = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"taskList","content":[
+                {"type":"taskItem","attrs":{"checked":false},"content":[
+                  {"type":"paragraph","content":[{"type":"text","text":"task"}]},
+                  {"type":"blockquote","content":[
+                    {"type":"paragraph","content":[{"type":"text","text":"quoted note"}]}
+                  ]}
+                ]}
+              ]}
+            ]}"""
+        )
+        val saved = editor.toJson()
+        assertTrue(saved.contains("quoted note"), "quoted text rendered but lost on save: $saved")
+        assertEquals(saved, editorFrom(saved).toJson())
+    }
+
+    @Test
     fun a_list_inside_a_blockquote_stays_a_list() {
         val editor = editorFrom(
             """{"type":"doc","content":[

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteEditorLoadTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteEditorLoadTest.kt
@@ -1,0 +1,76 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Loading a document for editing must not lose blockquote content.
+ *
+ * `loadWith` used to drop blockquote nodes wholesale in editor mode — the node *and* every
+ * paragraph inside it — so opening a document with a quote and saving it deleted the quoted text.
+ * The editor still cannot edit a blockquote, so the node degrades to its inner paragraphs: the
+ * quote structure is lost (as it always was), but the text now survives.
+ */
+class BlockquoteEditorLoadTest {
+
+    @Test
+    fun blockquote_paragraphs_survive_an_editor_load() {
+        val editor = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"before"}]},
+              {"type":"blockquote","content":[
+                {"type":"paragraph","content":[{"type":"text","text":"quoted"}]},
+                {"type":"paragraph","content":[{"type":"text","text":"still quoted"}]}
+              ]},
+              {"type":"paragraph","content":[{"type":"text","text":"after"}]}
+            ]}"""
+        )
+        assertEquals("before\nquoted\nstill quoted\nafter", editor.text)
+    }
+
+    @Test
+    fun blockquote_content_survives_an_open_and_save() {
+        val editor = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"blockquote","content":[
+                {"type":"paragraph","content":[{"type":"text","text":"quoted"}]}
+              ]}
+            ]}"""
+        )
+        val saved = editor.toJson()
+        assertTrue(saved.contains("quoted"), "quoted text lost across open-and-save: $saved")
+        assertEquals(saved, editorFrom(saved).toJson())
+    }
+
+    @Test
+    fun nested_blockquotes_unwrap_to_every_inner_paragraph() {
+        val editor = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"blockquote","content":[
+                {"type":"paragraph","content":[{"type":"text","text":"outer"}]},
+                {"type":"blockquote","content":[
+                  {"type":"paragraph","content":[{"type":"text","text":"inner"}]}
+                ]}
+              ]}
+            ]}"""
+        )
+        assertEquals("outer\ninner", editor.text)
+    }
+
+    @Test
+    fun a_list_inside_a_blockquote_stays_a_list() {
+        val editor = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"blockquote","content":[
+                {"type":"bulletList","content":[
+                  {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"item"}]}]}
+                ]}
+              ]}
+            ]}"""
+        )
+        val json = editor.toJson()
+        assertTrue(json.contains("\"type\":\"bulletList\""), "list flattened away: $json")
+        assertTrue(json.contains("item"))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/DocumentLoadingTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/DocumentLoadingTest.kt
@@ -69,9 +69,11 @@ class DocumentLoadingTest {
     }
 
     @Test
-    fun editor_mode_strips_blockquotes_but_viewer_mode_keeps_them() {
+    fun editor_mode_unwraps_blockquotes_and_viewer_mode_keeps_them() {
+        // The editor cannot edit a blockquote, so the node degrades to its inner paragraphs —
+        // the structure is lost but the text survives an open-and-save.
         val asEditor = editorFrom(SampleDocuments.BLOCKQUOTE, isViewer = false)
-        assertEquals("before\nafter", asEditor.text)
+        assertEquals("before\nquoted text\nafter", asEditor.text)
         assertFalse(asEditor.isViewer)
 
         val asViewer = editorFrom(SampleDocuments.BLOCKQUOTE, isViewer = true)

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
@@ -307,8 +307,9 @@ internal object EditingStress {
                 {"type":"taskItem","attrs":{"checked":false},"content":[{"type":"paragraph","content":[{"type":"text","text":"t"}]}]}
               ]}
             ]}""",
-            // Headings and a blockquote around a list. Both flatten into styled paragraphs on load
-            // (see PieceTableConverter), so the churn runs over the flattened form.
+            // Headings and a blockquote, alongside a list. Headings flatten into styled paragraphs
+            // and the blockquote unwraps into its inner paragraphs on load (see
+            // TextEditorTransaction.loadWith), so the churn runs over those flattened forms.
             """{"type":"doc","content":[
               {"type":"heading","attrs":{"level":1},"content":[{"type":"text","text":"Title"}]},
               {"type":"paragraph","content":[{"type":"text","text":"intro"}]},

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
@@ -13,10 +13,11 @@ import kotlin.test.assertTrue
 /**
  * Deterministic stress test: long, seeded sequences of every editing operation — typing, breaks,
  * deletes, replaces, multiline pastes, list toggles and type switches, styles, alignment and colour
- * — over regular paragraphs, ordered/unordered/task lists and deeply nested documents. This is the
- * kind of churn that surfaces an intermittent editing bug.
+ * — over regular paragraphs, ordered/unordered/task lists, deeply nested documents, and the
+ * flattened forms headings and blockquotes load into (#115). This is the kind of churn that
+ * surfaces an intermittent editing bug.
  *
- * After every operation, five invariants hold:
+ * After every operation, six invariants hold:
  *
  * 1. No operation throws (#82, #89, #95).
  * 2. A decorator piece only ever sits at the start of its paragraph — a mid-line decorator is the
@@ -26,6 +27,8 @@ import kotlin.test.assertTrue
  * 4. The export carries no empty text nodes and no empty list nodes (#81).
  * 5. The export is a fixed point: `toJson()` → load → `toJson()` is unchanged (#57–#61, #79, #81,
  *    #87, #93, #99).
+ * 6. The HTML and Markdown exporters accept every reachable state — `toJson` was the only exporter
+ *    the sweep exercised before.
  *
  * A failure names the seed, step and operation, so a "random, can't reproduce" error becomes an
  * exact repro. The committed size keeps the run inside a couple of seconds on every target; raising
@@ -85,6 +88,13 @@ internal object EditingStress {
             assertTrue(!once.contains("\"content\":[],\"type\":\"$type\""), "empty $type at $where: $once")
         }
         assertEquals(once, editorFrom(once).toJson(), "toJson not idempotent at $where")
+        // 6. The other exporters accept every reachable state.
+        try {
+            toHtml()
+            toMarkdown()
+        } catch (t: Throwable) {
+            throw AssertionError("exporter threw at $where: ${t::class.simpleName}: ${t.message}", t)
+        }
     }
 
     /** Decides the next operation from [rng] and returns its description plus a thunk that runs it. */
@@ -295,6 +305,20 @@ internal object EditingStress {
               ]},
               {"type":"taskList","content":[
                 {"type":"taskItem","attrs":{"checked":false},"content":[{"type":"paragraph","content":[{"type":"text","text":"t"}]}]}
+              ]}
+            ]}""",
+            // Headings and a blockquote around a list. Both flatten into styled paragraphs on load
+            // (see PieceTableConverter), so the churn runs over the flattened form.
+            """{"type":"doc","content":[
+              {"type":"heading","attrs":{"level":1},"content":[{"type":"text","text":"Title"}]},
+              {"type":"paragraph","content":[{"type":"text","text":"intro"}]},
+              {"type":"heading","attrs":{"level":3},"content":[{"type":"text","text":"Section"}]},
+              {"type":"blockquote","content":[
+                {"type":"paragraph","content":[{"type":"text","text":"quoted"}]},
+                {"type":"paragraph","content":[{"type":"text","text":"still quoted"}]}
+              ]},
+              {"type":"bulletList","content":[
+                {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"item"}]}]}
               ]}
             ]}""",
         )


### PR DESCRIPTION
Fixes #115. Part of #46.

`loadWith` dropped `blockquote` nodes wholesale in editor mode, so opening a document with a quote and saving it silently deleted the quoted text. The node itself still can't survive — the editor has no blockquote editing — but its paragraphs can: this unwraps a blockquote (at any nesting depth) into the blocks it contains, the same degradation headings already get. Structure is lost, content isn't. Viewer mode is unchanged.

`DocumentLoadingTest.editor_mode_strips_blockquotes_but_viewer_mode_keeps_them` asserted the deleting behaviour and is updated to assert the unwrap. New `BlockquoteEditorLoadTest` covers the plain, nested, and list-in-quote cases plus the open-and-save round trip.

The harness grows with it, since this is what surfaced the bug:

* a fourth start document with headings and a blockquote, so the sweep churns the flattened forms;
* a sixth invariant: `toHtml()` and `toMarkdown()` accept every reachable state — the JSON fixed point was the only exporter the sweep exercised.

Full sweep (400 seeds × 250 ops × 4 docs) clean; all targets green.
