### PR TITLE
fix: route deleteRange through the decorator-aware removal path

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -298,8 +298,17 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
      * collapsed [TextRange] where the caret should land (the start of the deleted range).
      */
     fun deleteRange(range: TextRange): TextRange {
-        if (range.length > 0) transaction.delete(range.min, range.length)
-        return TextRange(range.min)
+        if (range.length <= 0) return TextRange(range.min)
+        // Routed through the text-removal path rather than deleting the pieces outright — the same
+        // reasoning as removeEmbedAt: a raw delete whose window swallows a paragraph's trailing
+        // line break merges the following paragraph into this one, stranding that paragraph's
+        // decorator mid-line. The text path resolves decorators for the removal window (#74, #82).
+        val action = TextEditorAction.TextRemoved(
+            offset = range.min,
+            length = range.length,
+            selection = TextRange(range.min),
+        )
+        return TextTransaction.onTextUpdated(action, this).second
     }
 
     // region Embedded blocks (tables, images, documents, …)

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/DeleteRangeAcrossParagraphsTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/DeleteRangeAcrossParagraphsTest.kt
@@ -1,0 +1,48 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `deleteRange` is the programmatic delete used by the token/slash-command flows
+ * (`TextKitTokenState.commitCommand`, `deletePartialToken`). It used to call the piece table's raw
+ * delete, bypassing the decorator-aware removal path that typed deletes and `removeEmbedAt` go
+ * through — so a range that swallowed a paragraph's trailing line break merged the following list
+ * item into the line and stranded its decorator mid-line (the corruption class of #67/#74/#82).
+ */
+class DeleteRangeAcrossParagraphsTest {
+
+    @Test
+    fun a_range_over_the_trailing_break_keeps_the_next_item_marker_at_line_start() {
+        val editor = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"ab"}]},
+              {"type":"bulletList","content":[
+                {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"x"}]}]}
+              ]}
+            ]}"""
+        )
+        // Remove "b" plus the paragraph's line break — the window a widened token deletion produces.
+        editor.deleteRange(TextRange(1, 3))
+        editor.getParagraphs().forEach { paragraph ->
+            assertTrue(
+                paragraph.children.drop(1).none { it.decorator != null },
+                "decorator stranded mid-line: ${editor.text.replace("\n", "\\n").replace("\t", "\\t")}",
+            )
+        }
+        val json = editor.toJson()
+        assertEquals(json, editorFrom(json).toJson())
+    }
+
+    @Test
+    fun a_collapsed_range_is_a_no_op() {
+        val editor = editorFrom(
+            """{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"ab"}]}]}"""
+        )
+        val before = editor.toJson()
+        assertEquals(TextRange(1), editor.deleteRange(TextRange(1, 1)))
+        assertEquals(before, editor.toJson())
+    }
+}


### PR DESCRIPTION
Fixes #118.

`deleteRange` called the piece table's raw delete, bypassing the decorator resolution every other removal goes through — a range swallowing a paragraph's trailing line break stranded the next list item's marker mid-line. It now dispatches a `TextEditorAction.TextRemoved` through `TextTransaction.onTextUpdated`, the same shape as the `removeEmbedAt` fix (#105), and returns the caret the removal path computes.

`DeleteRangeAcrossParagraphsTest` covers the corrupting window (verified red against the previous implementation) and pins the collapsed-range no-op contract.
