### PR TITLE
fix: keep list reorder transactions out of a delete's window

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -298,8 +298,17 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
      * collapsed [TextRange] where the caret should land (the start of the deleted range).
      */
     fun deleteRange(range: TextRange): TextRange {
-        if (range.length > 0) transaction.delete(range.min, range.length)
-        return TextRange(range.min)
+        if (range.length <= 0) return TextRange(range.min)
+        // Routed through the text-removal path rather than deleting the pieces outright — the same
+        // reasoning as removeEmbedAt: a raw delete whose window swallows a paragraph's trailing
+        // line break merges the following paragraph into this one, stranding that paragraph's
+        // decorator mid-line. The text path resolves decorators for the removal window (#74, #82).
+        val action = TextEditorAction.TextRemoved(
+            offset = range.min,
+            length = range.length,
+            selection = TextRange(range.min),
+        )
+        return TextTransaction.onTextUpdated(action, this).second
     }
 
     // region Embedded blocks (tables, images, documents, …)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -294,8 +294,11 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
     ): TextRange = insertToken(MentionType.Mention, id, label, replaceRange, marks)
 
     /**
-     * Deletes the characters in [range]. Used to remove an atomic mention as a whole. Returns the
-     * collapsed [TextRange] where the caret should land (the start of the deleted range).
+     * Deletes the text in [range] through the decorator-aware removal path. The effective window
+     * can grow beyond [range]: when the deletion would otherwise clip a list marker, the path
+     * swallows the marker whole and renumbers the remaining items. Used to remove an atomic
+     * mention as a whole. Returns the collapsed [TextRange] the removal path places the caret at —
+     * normally the start of the deleted range.
      */
     fun deleteRange(range: TextRange): TextRange {
         if (range.length <= 0) return TextRange(range.min)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/utils/PositionalListItemUtils.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/utils/PositionalListItemUtils.kt
@@ -66,9 +66,12 @@ internal object PositionalListItemUtils {
         queue.add(root)
         while (queue.isNotEmpty()) {
             val item = queue.removeAt(0)
-            val decorator = item.richPiece.decorator?.copyValue(level = item.getLevel(0) + 1)
-            item.newRichPiece = item.richPiece.copy(decorator = decorator, length = decorator.createDecoratorString().length)
             queue.addAll(item.positionalListItems)
+            // A paragraph without a decorator (plain text, an embed placeholder) has no level to
+            // change. Building newRichPiece from the null decorator's empty string produces a
+            // zero-length piece whose Update transaction DELETES the paragraph's text.
+            val decorator = item.richPiece.decorator?.copyValue(level = item.getLevel(0) + 1) ?: continue
+            item.newRichPiece = item.richPiece.copy(decorator = decorator, length = decorator.createDecoratorString().length)
         }
     }
 
@@ -83,9 +86,11 @@ internal object PositionalListItemUtils {
         queue.add(root)
         while (queue.isNotEmpty()) {
             val item = queue.removeAt(0)
-            val decorator = item.richPiece.decorator?.copyValue(level = level ?: (item.getLevel() - 1))
-            item.newRichPiece = item.richPiece.copy(decorator = decorator, length = decorator.createDecoratorString().length)
             queue.addAll(item.positionalListItems)
+            // Same guard as increaseLevel: a decorator-less paragraph has no level, and the empty
+            // piece fabricated from a null decorator turns into a text-deleting Update.
+            val decorator = item.richPiece.decorator?.copyValue(level = level ?: (item.getLevel() - 1)) ?: continue
+            item.newRichPiece = item.richPiece.copy(decorator = decorator, length = decorator.createDecoratorString().length)
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
@@ -132,7 +132,13 @@ internal object TextDeletedTransaction {
         val deleteTransaction = TextTransactionsUtils.deleteTransaction(offset, length)
         transactions.add(deleteTransaction)
 
+        // The reorder decides from the PRE-delete lines, so it can emit an update for a decorator
+        // that lies inside the (possibly decorator-extended) delete window — a decorator the delete
+        // is removing. Applied together the two overlap and the delete carves through the freshly
+        // written marker, leaving a fragment mid-line. A transaction targeting the deleted window
+        // can never be meaningful; the surviving items' updates all target offsets outside it.
         val nextParagraphsTransactions = reorderListItemsOnUpdate(lines)
+            .filter { it.offsetInDocument < offset || it.offsetInDocument >= offset + length }
         transactions.addAll(nextParagraphsTransactions)
 
         return Pair(TextRange(offset), transactions)

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/DeleteRangeAcrossParagraphsTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/DeleteRangeAcrossParagraphsTest.kt
@@ -1,0 +1,48 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `deleteRange` is the programmatic delete used by the token/slash-command flows
+ * (`TextKitTokenState.commitCommand`, `deletePartialToken`). It used to call the piece table's raw
+ * delete, bypassing the decorator-aware removal path that typed deletes and `removeEmbedAt` go
+ * through — so a range that swallowed a paragraph's trailing line break merged the following list
+ * item into the line and stranded its decorator mid-line (the corruption class of #67/#74/#82).
+ */
+class DeleteRangeAcrossParagraphsTest {
+
+    @Test
+    fun a_range_over_the_trailing_break_keeps_the_next_item_marker_at_line_start() {
+        val editor = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"ab"}]},
+              {"type":"bulletList","content":[
+                {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"x"}]}]}
+              ]}
+            ]}"""
+        )
+        // Remove "b" plus the paragraph's line break — the window a widened token deletion produces.
+        editor.deleteRange(TextRange(1, 3))
+        editor.getParagraphs().forEach { paragraph ->
+            assertTrue(
+                paragraph.children.drop(1).none { it.decorator != null },
+                "decorator stranded mid-line: ${editor.text.replace("\n", "\\n").replace("\t", "\\t")}",
+            )
+        }
+        val json = editor.toJson()
+        assertEquals(json, editorFrom(json).toJson())
+    }
+
+    @Test
+    fun a_collapsed_range_is_a_no_op() {
+        val editor = editorFrom(
+            """{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"ab"}]}]}"""
+        )
+        val before = editor.toJson()
+        assertEquals(TextRange(1), editor.deleteRange(TextRange(1, 1)))
+        assertEquals(before, editor.toJson())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
@@ -12,10 +12,11 @@ import kotlin.test.assertTrue
 
 /**
  * Deterministic stress test: long, seeded sequences of every editing operation — typing, breaks,
- * deletes, replaces, multiline pastes, list toggles and type switches, styles, alignment and colour
- * — over regular paragraphs, ordered/unordered/task lists, deeply nested documents, and the
- * flattened forms headings and blockquotes load into (#115). This is the kind of churn that
- * surfaces an intermittent editing bug.
+ * deletes (typed and programmatic `deleteRange`), replaces, multiline pastes, list toggles and type
+ * switches, styles, alignment, colour, embed updates, and the read-only selection queries — over
+ * regular paragraphs, ordered/unordered/task lists, deeply nested documents, and the flattened
+ * forms headings and blockquotes load into (#115). This is the kind of churn that surfaces an
+ * intermittent editing bug.
  *
  * After every operation, six invariants hold:
  *
@@ -100,8 +101,8 @@ internal object EditingStress {
     /** Decides the next operation from [rng] and returns its description plus a thunk that runs it. */
     internal fun decideOp(editor: TextKitEditorManager, rng: Random): Pair<String, () -> Unit> {
         val len = editor.text.length
-        // 17 values for 16 explicit branches plus the colour op in `else`.
-        return when (rng.nextInt(17)) {
+        // 20 values for 19 explicit branches plus the colour op in `else`.
+        return when (rng.nextInt(20)) {
             0 -> {
                 val at = rng.nextInt(len + 1)
                 val text = randomText(rng)
@@ -209,6 +210,32 @@ internal object EditingStress {
                 "unembed @$at" to { editor.removeEmbedAt(embed.range); Unit }
             }
 
+            16 -> {
+                // The programmatic delete callers use — a separate entry point from deleteText.
+                val range = randomRange(rng, len)
+                "deleteRange $range" to { editor.deleteRange(range); Unit }
+            }
+
+            17 -> {
+                // Replaces the block payload behind an existing placeholder in place.
+                val at = if (len == 0) 0 else rng.nextInt(len)
+                val embed = editor.embedAt(at) ?: return "updateEmbed <none>" to {}
+                "updateEmbed @$at" to { editor.updateEmbedAt(embed.range, TABLE_BLOCK_ALT); Unit }
+            }
+
+            18 -> {
+                // Read-only queries the UI fires on every selection change: none may throw on any
+                // reachable state (a throw here is a crash in a real app).
+                val range = randomRange(rng, len)
+                "queries $range" to {
+                    editor.getLink(range.min, range.max)
+                    editor.getSearchMarkType(range)
+                    editor.checkDecorator(range.min, range.max)
+                    editor.marksAt(range)
+                    Unit
+                }
+            }
+
             else -> {
                 val range = randomRange(rng, len)
                 val color = if (rng.nextBoolean()) "#ff0000" else null
@@ -255,6 +282,8 @@ internal object EditingStress {
     private const val ALPHABET = "abc de"
 
     private const val TABLE_BLOCK = """{"type":"table","content":[{"type":"tableRow","content":[]}]}"""
+
+    private const val TABLE_BLOCK_ALT = """{"type":"table","content":[]}"""
 
     private val LIST_TYPES = listOf(
             TextEditorListItem.NumberedList,

--- a/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/EditingStressKnownSeedsTest.kt
+++ b/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/EditingStressKnownSeedsTest.kt
@@ -1,0 +1,20 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+
+/**
+ * Seeds outside the sweep's range that reproduced #120's corruption — a delete over an embed
+ * placeholder adjacent to list items leaving a duplicated or fragmented marker. Each replays the
+ * exact churn that manufactured the corrupting piece layout, so a regression in the delete path's
+ * reorder handling fails here with the seed and step named. (Seed 197, the variant inside the
+ * sweep's range, is covered by `EditingStressSweepTest`.)
+ */
+class EditingStressKnownSeedsTest {
+
+    @Test
+    fun seeds_that_reproduced_issue_120_stay_clean() {
+        intArrayOf(12994, 23942, 24674, 28998, 34398).forEach { seed ->
+            EditingStress.run(seed..seed, 30)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #120. Part of #46.

Two defects combined to produce the duplicated marker:

1. **Level changes fabricated pieces for decorator-less paragraphs.** `increaseLevel`/`decreaseLevel` build the item's new piece from `decorator?.copyValue(...)` — for a paragraph with no decorator (plain text, an embed placeholder) that's null, and the piece built from the null decorator's empty string is zero-length, so its Update transaction *deletes the paragraph's text*. In #120's state the reorder emitted exactly that against the embed placeholder. Both walks now skip items with no decorator — there is no level to change.
2. **The reorder could target a decorator inside the delete window.** `deleteOnMultipleParagraphs` extends the delete through a partially selected decorator, but `reorderListItemsOnUpdate` decides from the pre-extension lines, so it can emit an update for a marker the delete is removing — applied together, the delete carves through the freshly written decorator and leaves a fragment mid-line. Reorder transactions whose offset falls inside the final window are now dropped; updates for surviving items all target offsets outside it.

The stress harness grows to cover what found this: `deleteRange` (#118), `updateEmbedAt`, and the read-only selection queries join the mix (20 ops). `EditingStressKnownSeedsTest` pins the out-of-sweep seeds that reproduced the corruption; both it and the sweep were verified red against the unfixed code.

Verification: full sweep (400 × 250 × 4 docs) clean, a 30,000-seed × 30-op scan clean, all targets green. Deeper scans (60 ops on fresh seed ranges) still surface a few rarer variants of independent origin — I'll file those separately with their seeds.

Note: this branch includes #119's commit — the widened mix exercises `deleteRange`, so it needs that fix underneath. Merging #119 first makes this diff just the two fixes + tests.
