### PR TITLE
fix: never shear a list marker — deletes extend left, toggles key by offset

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
@@ -400,12 +400,13 @@ internal object ListItemTransaction {
         val newPositionalListItems = ListsConverter.fromPositionalListItems(startItems + prevElements + itemsWithChangedLevels)
         val flattenItems = PositionalListItemUtils.reorderItems(items = newPositionalListItems)
 
-        // Recover the newly decorated paragraphs by their document index — the flat list's layout
-        // is not positionally stable after reorderItems restructures the tree (a selection ending
-        // inside a following item's decorator shifted the layout, handing that item an Insert and
-        // stacking a second decorator onto it).
-        val insertIndices = nextElements.mapNotNull { if (it.richPiece.decorator == null) it.index else null }.toSet()
-        val selectedParagraphs = flattenItems.filter { it.index in insertIndices }
+        // Recover the newly decorated paragraphs by their DOCUMENT OFFSET — the only key stable
+        // across the rebuild. `index` is not: fromPositionalListItems re-indexes sequentially, and
+        // the task-list items handled separately above are absent from the rebuilt list, so the
+        // indices shift (a newly decorated paragraph after a task item then missed its Insert and
+        // fell to an Update that replaced its leading characters with the marker).
+        val insertOffsets = nextElements.mapNotNull { if (it.richPiece.decorator == null) it.offsetInDocument else null }.toSet()
+        val selectedParagraphs = flattenItems.filter { it.offsetInDocument in insertOffsets }
         val transactions = flattenItems.createTransactions(selectedParagraphs)
         val newRange = ListItemTextEditorRangeUtils.getTextEditorRangeForMultiRange(flattenItems, selectedIndices, range)
         return Pair(transactions, newRange)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDeletedTransaction.kt
@@ -121,6 +121,14 @@ internal object TextDeletedTransaction {
             if (!wouldOrphanOpeningDecorator) {
                 offset += decorSkip
                 length = maxOf(length - decorSkip, 0)
+            } else {
+                // Same left-extension as deleteTextAndDecorator: the item is going away whole, so
+                // never let the window start mid-decorator and shear the marker piece.
+                val extendLeft = offset - firstParagraph.startOffset
+                if (extendLeft > 0) {
+                    offset -= extendLeft
+                    length += extendLeft
+                }
             }
         }
 
@@ -181,8 +189,14 @@ internal object TextDeletedTransaction {
             val wouldOrphanOpeningDecorator = decorSkip > 0 &&
                 actionModel.length >= text.length - actionModel.offset
             if (wouldOrphanOpeningDecorator) {
-                val deleteTransaction = TextTransactionsUtils.deleteTransaction(actionModel.offset, actionModel.length)
-                Pair(TextRange(actionModel.offset), listOf(deleteTransaction))
+                // The delete reaches the end of the document, so the item goes as a whole. Extend
+                // the window LEFT to the decorator's start: a window that begins mid-decorator
+                // would otherwise shear the atomic marker piece and leave a truncated remnant
+                // ("\t") that surfaces mid-line on the next edit.
+                val start = minOf(actionModel.offset, paragraph.startOffset)
+                val length = actionModel.offset + actionModel.length - start
+                val deleteTransaction = TextTransactionsUtils.deleteTransaction(start, length)
+                Pair(TextRange(start), listOf(deleteTransaction))
             } else {
                 val newOffset = actionModel.offset + decorSkip
                 val newLength = maxOf(actionModel.length - decorSkip, 0)

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
@@ -495,7 +495,12 @@ class ListItemUiTest {
         state.onTextFieldChange(state.textFieldValue.copy(selection = TextRange(len, mid)))
         state.onTextFieldChange(TextFieldValue(text = afterDelete, selection = TextRange(mid)))
 
-        assertEquals(afterDelete, state.textFieldValue.text)
-        assertEquals(TextRange(mid), state.textFieldValue.selection)
+        // When the midpoint falls inside a list marker, the engine deletes the marker whole
+        // rather than shearing it, so the resulting text can be a prefix of the field's cut —
+        // never a text that still ends with a truncated marker.
+        val result = state.textFieldValue.text
+        assertTrue(afterDelete.startsWith(result), "engine rewrote past the field's cut: $result")
+        assertTrue(!result.endsWith("\t"), "sheared list marker survived the delete: $result")
+        assertTrue(state.textFieldValue.selection.max <= result.length)
     }
 }

--- a/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/EditingStressKnownSeedsTest.kt
+++ b/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/EditingStressKnownSeedsTest.kt
@@ -3,11 +3,15 @@ package com.jjrodcast.textkit
 import kotlin.test.Test
 
 /**
- * Seeds outside the sweep's range that reproduced #120's corruption — a delete over an embed
- * placeholder adjacent to list items leaving a duplicated or fragmented marker. Each replays the
- * exact churn that manufactured the corrupting piece layout, so a regression in the delete path's
- * reorder handling fails here with the seed and step named. (Seed 197, the variant inside the
- * sweep's range, is covered by `EditingStressSweepTest`.)
+ * Seeds outside the sweep's range that reproduced real corruption — pinned so a regression in the
+ * delete path or the list toggles fails here with the seed and step named.
+ *
+ * - #120: a delete over an embed placeholder adjacent to list items duplicated or fragmented a
+ *   marker (reorder transactions overlapping the delete window). Seed 197, the in-range variant,
+ *   is covered by `EditingStressSweepTest`.
+ * - #122: a delete starting inside a marker sheared the atomic decorator piece, and a list toggle
+ *   whose selection ended inside an embed placeholder replaced the placeholder's characters with
+ *   the marker (Insert/Update membership keyed on re-indexed positions).
  */
 class EditingStressKnownSeedsTest {
 
@@ -15,6 +19,13 @@ class EditingStressKnownSeedsTest {
     fun seeds_that_reproduced_issue_120_stay_clean() {
         intArrayOf(12994, 23942, 24674, 28998, 34398).forEach { seed ->
             EditingStress.run(seed..seed, 30)
+        }
+    }
+
+    @Test
+    fun seeds_that_reproduced_issue_122_stay_clean() {
+        intArrayOf(44852, 45717, 47417, 57326, 66142, 69496).forEach { seed ->
+            EditingStress.run(seed..seed, 60)
         }
     }
 }


### PR DESCRIPTION
Fixes #122.

The six seeds broke down into two defect classes, both ways an atomic list marker piece could be partially overwritten:

1. **A delete starting inside a marker sheared it.** When a delete reaches the end of the document, `deleteTextAndDecorator` (and the equivalent branch in `deleteOnMultipleParagraphs`) deliberately deletes through the opening marker rather than skipping it — but if the window *starts mid-marker*, the raw delete cut the decorator piece and left a stray `\t` remnant at a paragraph start, where the invariants can't see it until a later edit pushes it mid-line (the `replace remove=0` failures — the exposing op, not the cause). The item is going away as a whole, so the window now extends **left** to the marker's start instead of cutting through it. One existing test (`complexJsonV1_deleteBackwardSelectionOverListsDoesNotThrow`) asserted the sheared text byte-for-byte and is updated to assert the corrected contract: the result is a prefix of the field's cut and never ends in a truncated marker.
2. **A list toggle ending inside an embed placeholder replaced the placeholder's characters with the marker.** `applyMultipleParagraphsLevels` records which paragraphs are *newly* decorated (they must get an Insert) by their paragraph `index` — but `fromPositionalListItems` re-indexes the rebuilt list, and the task-list items handled separately are absent from it, so the index spaces shift. A newly decorated paragraph after a task item then missed its Insert and fell to an Update that replaced its leading characters with the marker text — shearing the *next* paragraph's marker when the lengths disagreed. The membership is now keyed by `offsetInDocument`, the only value stable across the rebuild.

`EditingStressKnownSeedsTest` grows a second pinned set with all six #122 seeds (verified red against the unfixed code). Full sweep clean, a 30,000-seed × 60-op scan clean — the scan depth that found these no longer finds anything — and all targets green.
