### PR TITLE
fix: keep list reorder transactions out of a replace's window too

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextUpdateTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextUpdateTransaction.kt
@@ -128,8 +128,12 @@ internal object TextUpdateTransaction {
         val deleteTransaction = updateTransaction(offset, model, length)
         transactions.add(deleteTransaction)
 
-        // Update next items
+        // Same rule as TextDeletedTransaction: the reorder decides from the PRE-replace lines, so
+        // it can emit an update for a decorator inside the (decorator-extended) removal window —
+        // a marker this replace is removing. Applied together the two overlap and leave a marker
+        // fragment mid-line; updates for surviving items all target offsets outside the window.
         val nextParagraphsTransactions = reorderListItemsOnUpdate(lines)
+            .filter { it.offsetInDocument < offset || it.offsetInDocument >= offset + length }
         transactions.addAll(nextParagraphsTransactions)
 
         return Pair(TextRange(offset + actionModel.text.length), transactions)

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
@@ -5,6 +5,7 @@ import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.components.TextEditorStyleItem
 import com.jjrodcast.textkit.editor.core.TextKitEditorManager
 import com.jjrodcast.textkit.editor.core.parser.TextAlign
+import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel.Companion.createDecoratorString
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -18,7 +19,7 @@ import kotlin.test.assertTrue
  * forms headings and blockquotes load into (#115). This is the kind of churn that surfaces an
  * intermittent editing bug.
  *
- * After every operation, six invariants hold:
+ * After every operation, seven invariants hold:
  *
  * 1. No operation throws (#82, #89, #95).
  * 2. A decorator piece only ever sits at the start of its paragraph — a mid-line decorator is the
@@ -30,6 +31,9 @@ import kotlin.test.assertTrue
  *    #87, #93, #99).
  * 6. The HTML and Markdown exporters accept every reachable state — `toJson` was the only exporter
  *    the sweep exercised before.
+ * 7. Every marker piece is exactly its decorator's canonical string (#122, #124) — a sheared or
+ *    stale-length marker at a paragraph start is invisible to the mid-line check until a later
+ *    edit moves it, which is why #122's failures surfaced ops away from their cause.
  *
  * A failure names the seed, step and operation, so a "random, can't reproduce" error becomes an
  * exact repro. The committed size keeps the run inside a couple of seconds on every target; raising
@@ -81,6 +85,19 @@ internal object EditingStress {
                 paragraph.children.drop(1).none { it.decorator != null },
                 "mid-line decorator at $where: $visible",
             )
+            // 7. A marker piece is exactly its decorator's canonical string. A partial overwrite
+            // (a shear, a stale-length rewrite) can leave a truncated marker AT a paragraph start,
+            // where the mid-line check cannot see it until a later edit moves it — #122's failures
+            // surfaced ops away from their cause for exactly this reason.
+            paragraph.children.forEach { child ->
+                child.decorator?.let { decorator ->
+                    assertEquals(
+                        decorator.createDecoratorString(),
+                        child.text,
+                        "sheared or rewritten marker at $where: $visible",
+                    )
+                }
+            }
         }
         val once = toJson()
         assertTrue(!once.contains("\\t"), "decorator text leaked into the export at $where: $once")
@@ -95,6 +112,27 @@ internal object EditingStress {
             toMarkdown()
         } catch (t: Throwable) {
             throw AssertionError("exporter threw at $where: ${t::class.simpleName}: ${t.message}", t)
+        }
+    }
+
+    /**
+     * The contract on every op that reports a caret: in bounds, and never strictly inside a list
+     * marker's span — a caret in the marker means the next keystroke types into the marker.
+     */
+    private fun TextKitEditorManager.assertCaret(caret: TextRange, what: String) {
+        assertTrue(
+            caret.min >= 0 && caret.max <= text.length,
+            "$what returned an out-of-bounds caret $caret (len=${text.length})",
+        )
+        getParagraphs().forEach { paragraph ->
+            paragraph.children.forEach { child ->
+                if (child.decorator != null) {
+                    assertTrue(
+                        caret.min <= child.start || caret.min >= child.end,
+                        "$what left the caret inside a marker: $caret in [${child.start},${child.end})",
+                    )
+                }
+            }
         }
     }
 
@@ -187,14 +225,17 @@ internal object EditingStress {
                 // Tokens replace the trigger text the caller matched, which always lies inside one
                 // paragraph's own content — never across a decorator.
                 val range = contentRange(editor, rng) ?: return "mention <no content>" to {}
-                "mention $range" to { editor.insertMention(id = "u1", label = "Jorge", replaceRange = range); Unit }
+                "mention $range" to {
+                    val caret = editor.insertMention(id = "u1", label = "Jorge", replaceRange = range)
+                    editor.assertCaret(caret, "insertMention")
+                }
             }
 
             13 -> {
                 val range = contentRange(editor, rng) ?: return "hashtag <no content>" to {}
                 "hashtag $range" to {
-                    editor.insertToken(nodeType = "hashtag", id = "h1", label = "kt", replaceRange = range)
-                    Unit
+                    val caret = editor.insertToken(nodeType = "hashtag", id = "h1", label = "kt", replaceRange = range)
+                    editor.assertCaret(caret, "insertToken")
                 }
             }
 
@@ -213,7 +254,12 @@ internal object EditingStress {
             16 -> {
                 // The programmatic delete callers use — a separate entry point from deleteText.
                 val range = randomRange(rng, len)
-                "deleteRange $range" to { editor.deleteRange(range); Unit }
+                "deleteRange $range" to {
+                    val caret = editor.deleteRange(range)
+                    // A collapsed range is a no-op that returns its input verbatim — the caller's
+                    // caret may already sit anywhere; only a real deletion owes a clamped caret.
+                    if (range.length > 0) editor.assertCaret(caret, "deleteRange")
+                }
             }
 
             17 -> {

--- a/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/EditingStressKnownSeedsTest.kt
+++ b/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/EditingStressKnownSeedsTest.kt
@@ -12,6 +12,8 @@ import kotlin.test.Test
  * - #122: a delete starting inside a marker sheared the atomic decorator piece, and a list toggle
  *   whose selection ended inside an embed placeholder replaced the placeholder's characters with
  *   the marker (Insert/Update membership keyed on re-indexed positions).
+ * - #124: a replace across list items — the reorder's update targeting a marker inside the
+ *   replace's removal window, the overlap #121 fixed on the delete path.
  */
 class EditingStressKnownSeedsTest {
 
@@ -26,6 +28,13 @@ class EditingStressKnownSeedsTest {
     fun seeds_that_reproduced_issue_122_stay_clean() {
         intArrayOf(44852, 45717, 47417, 57326, 66142, 69496).forEach { seed ->
             EditingStress.run(seed..seed, 60)
+        }
+    }
+
+    @Test
+    fun seeds_that_reproduced_issue_124_stay_clean() {
+        intArrayOf(83626, 103174, 107802, 125854, 127674).forEach { seed ->
+            EditingStress.run(seed..seed, 100)
         }
     }
 }


### PR DESCRIPTION
Fixes #124. Part of #46.

`updateOnMultipleParagraphs` appended `reorderListItemsOnUpdate`'s transactions unfiltered — the same overlap the delete path had before #121, reachable through `replaceText` when the removal window spans list items. The reorder's update for a marker inside the (decorator-extended) window now gets dropped, mirroring `TextDeletedTransaction`.

The harness hardening that found it comes along:

* **Invariant 7 — marker integrity**: every decorator piece's text must equal its decorator's canonical string, checked after every op. #122's failures surfaced ops away from their cause because a sheared marker at a paragraph *start* was invisible to the mid-line check; this closes that blind spot and catches the class at the corrupting step.
* **Caret contracts**: `insertMention` / `insertToken` / `deleteRange` must return an in-bounds caret outside any marker's span (no-op collapsed deletes exempt — returning the input unchanged is correct there).
* The five reproducing seeds join `EditingStressKnownSeedsTest`.

Full suite green; a 100,000-seed × 100-op scan with the strengthened invariants runs clean (that scan depth is what surfaced this).
