### PR TITLE
feat: render image embeds from their url in the popup

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,8 @@ jetbrainsIconsCore = "1.7.3"
 jetbrainsIconsExtended = "1.7.3"
 foundationLayout = "1.11.4"
 mavenPublish = "0.37.0"
+coil = "3.2.0"
+ktor = "3.2.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -40,6 +42,11 @@ compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", v
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 wrappers-browser = { module = "org.jetbrains.kotlin-wrappers:kotlin-browser", version.ref = "kotlin-wrappers" }

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -6,3 +6,8 @@
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
   integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
+
+ws@8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -3302,6 +3302,11 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
+ws@8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
 ws@^8.18.0, ws@~8.21.0:
   version "8.21.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(libs.compose.uiToolingPreview)
+            implementation(libs.ktor.client.okhttp)
         }
         commonMain.dependencies {
             implementation(libs.compose.runtime)
@@ -73,12 +74,27 @@ kotlin {
             // Icons
             implementation(libs.jetbrains.compose.material.icons)
             implementation(libs.jetbrains.compose.material.icons.extended)
+
+            // Image loading for embed viewing (issue #127). coil-network-ktor3 registers its
+            // fetcher via Coil's service loader; each target below brings a Ktor engine.
+            implementation(libs.coil.compose)
+            implementation(libs.coil.network.ktor3)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }
+        jvmMain.dependencies {
+            implementation(libs.ktor.client.okhttp)
+        }
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
+        }
         jsMain.dependencies {
             implementation(libs.wrappers.browser)
+            implementation(libs.ktor.client.js)
+        }
+        wasmJsMain.dependencies {
+            implementation(libs.ktor.client.js)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/EmbedBlock.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/EmbedBlock.kt
@@ -57,6 +57,16 @@ internal fun JsonElement.embedType(): String =
     jsonObject["type"]?.jsonPrimitive?.contentOrNull ?: EmbedTokenType
 
 /**
+ * Reads `attrs.url` from an embed's raw JSON, or null when the payload has no attrs, no url, or is
+ * not valid JSON at all. Producers put the content's location here (an `image` node's source, a
+ * `document` node's file); the editor never interprets it beyond display.
+ */
+internal fun embedUrlOf(payload: String): String? = runCatching {
+    TEXT_EDITOR_JSON.parseToJsonElement(payload)
+        .jsonObject["attrs"]?.jsonObject?.get("url")?.jsonPrimitive?.contentOrNull
+}.getOrNull()?.takeIf { it.isNotBlank() }
+
+/**
  * Human-readable, display-only label for a placeholder (e.g. `📊 Tabla 1`). [indexByType] numbers
  * embeds of the same type in document order. This is what the user sees in the editor; the real
  * content lives in the payload.

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
@@ -66,9 +66,11 @@ private val DEMO_TABLE_JSON = """
     ]}
 """.trimIndent()
 
-// A demo local image embed. `src` names the bundled drawable (text_kit_banner.png); the popup maps it
-// to Res.drawable.text_kit_banner. Stored verbatim and round-tripped like any other embed.
-private const val DEMO_IMAGE_JSON = """{"type":"image","attrs":{"src":"text_kit_banner"}}"""
+// A demo image embed. The popup loads `attrs.url` (the producers' contract, #127) — this points at
+// the repo's own banner so the demo needs no third-party host; without a network the popup falls
+// back to the bundled banner drawable. Stored verbatim and round-tripped like any other embed.
+private const val DEMO_IMAGE_JSON =
+    """{"type":"image","attrs":{"url":"https://raw.githubusercontent.com/jjrodcast/TextKit/main/shared/src/commonMain/composeResources/drawable/text_kit_banner.png"}}"""
 
 // A demo document embed. Stored verbatim on the placeholder piece and re-emitted on toJson(); the
 // editor shows the "📄 Documento" chip and the popup renders this JSON (there is no custom document

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
@@ -46,8 +46,11 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.CircularProgressIndicator
+import coil3.compose.SubcomposeAsyncImage
 import com.jjrodcast.textkit.editor.core.TextKitEditorManager
 import com.jjrodcast.textkit.editor.core.parser.EmbedTypes
+import com.jjrodcast.textkit.editor.core.parser.embedUrlOf
 import com.jjrodcast.textkit.theme.TextKitTheme
 import com.jjrodcast.textkit.ui.state.TextKitState
 import com.jjrodcast.textkit.ui.table.TextKitEditableTable
@@ -192,12 +195,43 @@ private fun EmbedPopupContent(
             // its own scroll handles anything taller than the capped popup.
             Box(modifier = Modifier.weight(1f, fill = false)) {
                 when (embed.embedType) {
-                    EmbedTypes.Image -> Image(
-                        painter = painterResource(Res.drawable.text_kit_banner),
-                        contentDescription = null,
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp),
-                    )
+                    // View-only (#127): the node's attrs.url is the content's source. While it
+                    // loads a spinner holds the space; a missing or failing url falls back to the
+                    // banner so the popup never renders empty.
+                    EmbedTypes.Image -> {
+                        val url = remember(embed.rawJson) { embedUrlOf(embed.rawJson) }
+                        if (url == null) {
+                            Image(
+                                painter = painterResource(Res.drawable.text_kit_banner),
+                                contentDescription = null,
+                                contentScale = ContentScale.Fit,
+                                modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp),
+                            )
+                        } else {
+                            SubcomposeAsyncImage(
+                                model = url,
+                                contentDescription = null,
+                                contentScale = ContentScale.Fit,
+                                modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp),
+                                loading = {
+                                    Box(
+                                        modifier = Modifier.fillMaxWidth().heightIn(min = 96.dp),
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        CircularProgressIndicator()
+                                    }
+                                },
+                                error = {
+                                    Image(
+                                        painter = painterResource(Res.drawable.text_kit_banner),
+                                        contentDescription = null,
+                                        contentScale = ContentScale.Fit,
+                                        modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp),
+                                    )
+                                },
+                            )
+                        }
+                    }
 
                     EmbedTypes.Table -> TextKitEditableTable(
                         rawJson = embed.rawJson,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
@@ -203,14 +203,14 @@ private fun EmbedPopupContent(
                         if (url == null) {
                             Image(
                                 painter = painterResource(Res.drawable.text_kit_banner),
-                                contentDescription = null,
+                                contentDescription = embed.label,
                                 contentScale = ContentScale.Fit,
                                 modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp),
                             )
                         } else {
                             SubcomposeAsyncImage(
                                 model = url,
-                                contentDescription = null,
+                                contentDescription = embed.label,
                                 contentScale = ContentScale.Fit,
                                 modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp),
                                 loading = {
@@ -224,7 +224,7 @@ private fun EmbedPopupContent(
                                 error = {
                                     Image(
                                         painter = painterResource(Res.drawable.text_kit_banner),
-                                        contentDescription = null,
+                                        contentDescription = embed.label,
                                         contentScale = ContentScale.Fit,
                                         modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp),
                                     )

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmbedUrlTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmbedUrlTest.kt
@@ -1,0 +1,38 @@
+package com.jjrodcast.textkit
+
+import com.jjrodcast.textkit.editor.core.parser.embedUrlOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * `embedUrlOf` reads `attrs.url` from an embed's raw JSON — the source the popup renders for an
+ * `image` node (#127). It must be lenient: embeds are an opaque passthrough, so payloads with no
+ * attrs, no url, or malformed JSON yield null (the popup then falls back to the banner) rather
+ * than throwing.
+ */
+class EmbedUrlTest {
+
+    @Test
+    fun reads_the_url_attribute() {
+        assertEquals(
+            "https://example.dev/photo.png",
+            embedUrlOf("""{"type":"image","attrs":{"url":"https://example.dev/photo.png"}}"""),
+        )
+    }
+
+    @Test
+    fun missing_attrs_or_url_yield_null() {
+        assertNull(embedUrlOf("""{"type":"image"}"""))
+        assertNull(embedUrlOf("""{"type":"image","attrs":{}}"""))
+        assertNull(embedUrlOf("""{"type":"image","attrs":{"url":""}}"""))
+        assertNull(embedUrlOf("""{"type":"image","attrs":{"url":null}}"""))
+    }
+
+    @Test
+    fun malformed_payloads_yield_null_rather_than_throwing() {
+        assertNull(embedUrlOf("not json"))
+        assertNull(embedUrlOf("""["array","not","object"]"""))
+        assertNull(embedUrlOf(""))
+    }
+}


### PR DESCRIPTION
First half of #127 — images; the document card + callback comes separately.

The embed popup showed a hardcoded banner for `image` embeds, ignoring the node's source. It now loads `attrs.url` (the producers' contract) through Coil: a spinner while loading, the actual image at `ContentScale.Fit` under the popup's existing height cap, and the banner as fallback when the url is missing, blank, or fails to load — the popup never renders empty. View-only, as agreed: no edit affordance, Remove stays as-is.

**Dependencies**: `coil-compose` + `coil-network-ktor3` in `commonMain`, with a Ktor engine per target (OkHttp on Android/JVM, Darwin on iOS, Js on the web targets). The network fetcher registers through Coil's service loader, so there's no wiring beyond the dependencies. Yarn locks regenerated for the new JS packages.

`embedUrlOf` (the `attrs.url` reader) is deliberately lenient — embeds are an opaque passthrough, so a payload with no attrs, no url, or malformed JSON yields null (→ banner fallback) rather than throwing; `EmbedUrlTest` pins that.

The sample's demo image embed previously used a `src` attribute naming the bundled drawable; it now carries a real `url` (the repo's own banner via raw.githubusercontent) so the feature is demonstrable in the demo app without a third-party host — verified by hand on desktop: spinner → network-loaded image, and banner fallback offline.

One web-specific note: on the JS/Wasm targets image loading is subject to the browser's CORS policy, so a consumer's image host must allow cross-origin reads (raw.githubusercontent does, which is why the demo works). That's inherent to the browser, not to this change.

All targets compile and the suites pass.
