### PR TITLE
feat: document embeds get a card with an Open action

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="url_label">Url</string>
     <string name="edit_label">Edit</string>
     <string name="remove_label">Remove</string>
+    <string name="open_label">Open</string>
     <string name="left_align_text">Left align</string>
     <string name="center_align_text">Center align</string>
     <string name="right_align_text">Right align</string>

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/EmbedBlock.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/EmbedBlock.kt
@@ -61,9 +61,19 @@ internal fun JsonElement.embedType(): String =
  * not valid JSON at all. Producers put the content's location here (an `image` node's source, a
  * `document` node's file); the editor never interprets it beyond display.
  */
-internal fun embedUrlOf(payload: String): String? = runCatching {
+internal fun embedUrlOf(payload: String): String? = embedAttrOf(payload, "url")
+
+/** Reads `attrs.name` from an embed's raw JSON — a `document` node's display name. */
+internal fun embedNameOf(payload: String): String? = embedAttrOf(payload, "name")
+
+/**
+ * Reads one string attribute from an embed's raw JSON, or null when the payload has no attrs, no
+ * such key, a blank value, or is not valid JSON at all — embeds are an opaque passthrough, so a
+ * malformed payload degrades to "attribute absent", never to an exception.
+ */
+private fun embedAttrOf(payload: String, key: String): String? = runCatching {
     TEXT_EDITOR_JSON.parseToJsonElement(payload)
-        .jsonObject["attrs"]?.jsonObject?.get("url")?.jsonPrimitive?.contentOrNull
+        .jsonObject["attrs"]?.jsonObject?.get(key)?.jsonPrimitive?.contentOrNull
 }.getOrNull()?.takeIf { it.isNotBlank() }
 
 /**

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/sample/TextKitSample.kt
@@ -73,8 +73,8 @@ private const val DEMO_IMAGE_JSON =
     """{"type":"image","attrs":{"url":"https://raw.githubusercontent.com/jjrodcast/TextKit/main/shared/src/commonMain/composeResources/drawable/text_kit_banner.png"}}"""
 
 // A demo document embed. Stored verbatim on the placeholder piece and re-emitted on toJson(); the
-// editor shows the "📄 Documento" chip and the popup renders this JSON (there is no custom document
-// renderer, so it falls back to showing the stored attrs).
+// editor shows the "📄 Documento" chip and the popup renders a card from attrs (name + url) with an
+// Open action that hands the url to the host app or the platform (#127).
 private const val DEMO_DOCUMENT_JSON =
     """{"type":"document","attrs":{"name":"Reporte Q3.pdf","url":"https://example.com/reporte-q3.pdf"}}"""
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
@@ -46,10 +46,14 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.rounded.Description
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextOverflow
 import coil3.compose.SubcomposeAsyncImage
 import com.jjrodcast.textkit.editor.core.TextKitEditorManager
 import com.jjrodcast.textkit.editor.core.parser.EmbedTypes
+import com.jjrodcast.textkit.editor.core.parser.embedNameOf
 import com.jjrodcast.textkit.editor.core.parser.embedUrlOf
 import com.jjrodcast.textkit.theme.TextKitTheme
 import com.jjrodcast.textkit.ui.state.TextKitState
@@ -58,6 +62,7 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import textkit.shared.generated.resources.Res
 import textkit.shared.generated.resources.close_text
+import textkit.shared.generated.resources.open_label
 import textkit.shared.generated.resources.remove_label
 import textkit.shared.generated.resources.text_kit_banner
 import kotlin.math.roundToInt
@@ -85,9 +90,14 @@ fun TextKitEmbedPopup(
     onClose: () -> Unit = { state.dismissEmbedPopup() },
     onRemove: () -> Unit = { state.removeActiveEmbed() },
     onSync: (String) -> Unit = { state.updateActiveEmbed(it) },
+    onOpenDocument: ((url: String) -> Unit)? = null,
 ) {
     val embed = state.activeEmbed ?: return
     val anchor = state.activeEmbedBoundingBox() ?: return
+    // Documents delegate opening to the host app; when it provides no handler, hand the url to the
+    // platform (browser tab / system viewer) via Compose's UriHandler.
+    val uriHandler = LocalUriHandler.current
+    val openDocument: (String) -> Unit = { url -> onOpenDocument?.invoke(url) ?: uriHandler.openUri(url) }
 
     BoxWithConstraints(modifier.fillMaxSize()) {
         val density = LocalDensity.current
@@ -125,6 +135,7 @@ fun TextKitEmbedPopup(
             onClose = onClose,
             onRemove = onRemove,
             onSync = onSync,
+            onOpenDocument = openDocument,
             onDrag = { state.dragEmbedPopup(it) },
             maxHeight = availableHeight,
             modifier = Modifier
@@ -140,6 +151,7 @@ private fun EmbedPopupContent(
     onClose: () -> Unit,
     onRemove: () -> Unit,
     onSync: (String) -> Unit,
+    onOpenDocument: (String) -> Unit,
     onDrag: (Offset) -> Unit,
     maxHeight: Dp,
     modifier: Modifier = Modifier,
@@ -237,6 +249,46 @@ private fun EmbedPopupContent(
                         rawJson = embed.rawJson,
                         onSync = onSync,
                     )
+
+                    // View-only (#127): a card from the node's attributes; opening is delegated to
+                    // the host app (or the platform) rather than bundling a document renderer.
+                    EmbedTypes.Document -> {
+                        val url = remember(embed.rawJson) { embedUrlOf(embed.rawJson) }
+                        val name = remember(embed.rawJson) { embedNameOf(embed.rawJson) } ?: embed.label
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Icon(
+                                Icons.Rounded.Description,
+                                contentDescription = null,
+                                tint = TextKitTheme.colors.onSurfaceVariant,
+                                modifier = Modifier.size(32.dp).padding(end = 8.dp),
+                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = name,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                if (url != null) {
+                                    Text(
+                                        text = url,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = TextKitTheme.colors.onSurfaceVariant,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                            }
+                            if (url != null) {
+                                TextButton(onClick = { onOpenDocument(url) }) {
+                                    Text(stringResource(Res.string.open_label))
+                                }
+                            }
+                        }
+                    }
 
                     // Any other embed: show the stored JSON so it is at least inspectable.
                     else -> {

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmbedUrlTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmbedUrlTest.kt
@@ -1,5 +1,6 @@
 package com.jjrodcast.textkit
 
+import com.jjrodcast.textkit.editor.core.parser.embedNameOf
 import com.jjrodcast.textkit.editor.core.parser.embedUrlOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -34,5 +35,16 @@ class EmbedUrlTest {
         assertNull(embedUrlOf("not json"))
         assertNull(embedUrlOf("""["array","not","object"]"""))
         assertNull(embedUrlOf(""))
+    }
+
+    @Test
+    fun reads_the_name_attribute_with_the_same_leniency() {
+        assertEquals(
+            "Reporte Q3.pdf",
+            embedNameOf("""{"type":"document","attrs":{"name":"Reporte Q3.pdf","url":"https://example.dev/q3.pdf"}}"""),
+        )
+        assertNull(embedNameOf("""{"type":"document","attrs":{"url":"https://example.dev/q3.pdf"}}"""))
+        assertNull(embedNameOf("""{"type":"document","attrs":{"name":""}}"""))
+        assertNull(embedNameOf("not json"))
     }
 }


### PR DESCRIPTION
Fixes #127 — the document half; images landed in #128.

Document embeds fell through to the popup's raw-JSON dump. They now render a proper card from the node's attributes — document icon, `attrs.name` (falling back to the placeholder's label), the url in muted text — with an **Open** action when a url is present.

**Opening is delegated, per the discussion above**: `TextKitEmbedPopup` gains `onOpenDocument: ((url) -> Unit)?` so the consuming app decides what opening means (its own viewer, a browser tab, a share sheet). When no handler is set, the url goes to the platform via Compose's `LocalUriHandler` — which exists on every target, so the default needed no platform-specific code and the library stays free of document-rendering dependencies.

`embedNameOf` joins `embedUrlOf` on a shared lenient attr reader (no attrs / missing key / blank / malformed JSON all degrade to null, never an exception — `EmbedUrlTest` extended). Unknown embed types keep the raw-JSON fallback view. The sample's demo document already carried `name` + `url`, so the card is demonstrable in the demo app as-is — verified by hand on desktop: card renders, Open hands the url to the browser.

All targets compile and the suites pass.

### Screenshots

The placeholder chip in the editor:

![Document embed placeholder chip](https://raw.githubusercontent.com/LaatonWalaBhoot/TextKit/assets-pr-129/embed-document-chip.png)

The popup's card with the Open action:

![Document card with Open action](https://raw.githubusercontent.com/LaatonWalaBhoot/TextKit/assets-pr-129/embed-document-card.png)
