### PR TITLE
feat: blockquotes survive editor mode — round trip via a non-marker decorator

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/ListsConverter.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/ListsConverter.kt
@@ -3,6 +3,7 @@ package com.jjrodcast.textkit.editor.core.converters
 import com.jjrodcast.textkit.editor.core.converters.models.PositionalListItem
 import com.jjrodcast.textkit.editor.core.converters.utils.flatten
 import com.jjrodcast.textkit.editor.core.models.MultiPieceParagraph
+import com.jjrodcast.textkit.editor.core.piecetable.models.RichPiece
 import com.jjrodcast.textkit.editor.utils.fastForEach
 import com.jjrodcast.textkit.editor.utils.fastMapIndexed
 
@@ -10,10 +11,19 @@ internal object ListsConverter {
 
     internal fun fromPieceMultiParagraph(multiparagraphs: MultiPieceParagraph): List<PositionalListItem> {
         val localListItems = multiparagraphs.paragraphs.fastMapIndexed { index, paragraph ->
-            PositionalListItem(index = index, richPiece = paragraph.startPiece, offsetInDocument = paragraph.startOffset)
+            PositionalListItem(index = index, richPiece = paragraph.startPiece.asListHead(), offsetInDocument = paragraph.startOffset)
         }
         return createLists(localListItems)
     }
+
+    /**
+     * The piece the list machinery may treat as a paragraph's head. A non-marker decorator (the
+     * blockquote attribute, #126) is stripped: to every list operation a quoted paragraph is a
+     * plain paragraph — treating its attributed CONTENT piece as a marker renumbers or replaces
+     * the quoted text itself.
+     */
+    private fun RichPiece.asListHead(): RichPiece =
+        if (decorator != null && !decorator.isMarker) copy(decorator = null) else this
 
     internal fun fromPositionalListItems(positionalListItems: List<PositionalListItem>): List<PositionalListItem> {
         val localListItems = positionalListItems.flatten().fastMapIndexed { index, item ->
@@ -24,7 +34,7 @@ internal object ListsConverter {
 
     internal fun convertToLocalListItems(multiparagraphs: MultiPieceParagraph): List<PositionalListItem> {
         return multiparagraphs.paragraphs.fastMapIndexed { index, paragraph ->
-            PositionalListItem(index = index, richPiece = paragraph.startPiece, offsetInDocument = paragraph.startOffset)
+            PositionalListItem(index = index, richPiece = paragraph.startPiece.asListHead(), offsetInDocument = paragraph.startOffset)
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/PieceTableConverter.kt
@@ -7,6 +7,7 @@ import com.jjrodcast.textkit.editor.core.models.TextEditorModel
 import com.jjrodcast.textkit.editor.core.models.TextEditorModel.Companion.getKey
 import com.jjrodcast.textkit.editor.core.models.TextEditorParagraphModel
 import com.jjrodcast.textkit.editor.core.parser.BaseParagraph
+import com.jjrodcast.textkit.editor.core.parser.Blockquote
 import com.jjrodcast.textkit.editor.core.parser.BaseText
 import com.jjrodcast.textkit.editor.core.parser.BulletedList
 import com.jjrodcast.textkit.editor.core.parser.EmbedTokenType
@@ -262,14 +263,42 @@ internal object PieceTableConverter {
                 elements = elements,
                 startIndex = value,
                 endIndex = nodes[index + 1]
-            )
+            ) to elements[value].isQuoted
         }
         val lastContent = createParagraphModel(
             elements = elements,
             startIndex = nodes.last(),
             endIndex = elements.size
-        )
-        return TextEditorDocument(partialContent + lastContent)
+        ) to elements[nodes.last()].isQuoted
+        return TextEditorDocument(groupBlockquotes(partialContent + lastContent))
+    }
+
+    /** Whether this paragraph's pieces carry the blockquote attribute (#126). */
+    private val PositionalParagraph.isQuoted: Boolean
+        get() = textStyled.any { it.piece.decorator is TextDecoratorModel.BlockquoteDecorator }
+
+    /**
+     * Groups consecutive quoted plain paragraphs back into `blockquote` nodes (#126). Membership is
+     * the blockquote attribute any of the paragraph's pieces carries; adjacency defines the node,
+     * so two blockquotes with nothing between them normalize into one — the same result their
+     * rendering already shows. Only plain paragraphs join a quote; a list or embed ends it.
+     */
+    private fun groupBlockquotes(content: List<Pair<BaseParagraph, Boolean>>): List<BaseParagraph> {
+        val result = arrayListOf<BaseParagraph>()
+        val run = arrayListOf<BaseParagraph>()
+        fun flush() {
+            if (run.isEmpty()) return
+            result.add(Blockquote(content = ArrayList(run)))
+            run.clear()
+        }
+        content.fastForEach { (node, quoted) ->
+            if (quoted && node is Paragraph) run.add(node) else {
+                flush()
+                result.add(node)
+            }
+        }
+        flush()
+        return result
     }
 
     /**
@@ -362,7 +391,10 @@ internal object PieceTableConverter {
         val finalIndices = arrayListOf<Int>()
         while (currentIndex < elements.size) {
             val item = elements[currentIndex]
-            val decorator = item.textStyled.firstOrNull()?.piece?.decorator
+            // Marker decorators only: a blockquote-attributed paragraph is a plain paragraph and
+            // must be its own node — letting the attribute group consecutive quoted paragraphs
+            // collapses them into one node that keeps only the first paragraph's content.
+            val decorator = item.textStyled.firstOrNull()?.piece?.decorator?.takeIf { it.isMarker }
             if (decorator == null) {
                 finalIndices.add(currentIndex)
                 currentIndex += 1

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/TextEditorConverter.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/TextEditorConverter.kt
@@ -131,7 +131,14 @@ internal object TextEditorConverter {
             }
 
             is Paragraph -> {
-                if (this.content.isEmpty()) items.add(TextEditorModel.create(EMPTY))
+                // An empty quoted paragraph must keep the blockquote attribute on its (only) piece
+                // or its membership is lost across a reload (#126).
+                if (this.content.isEmpty()) items.add(
+                    TextEditorModel.create(
+                        EMPTY,
+                        decorator = decorator as? TextDecoratorModel.BlockquoteDecorator
+                    )
+                )
                 else {
                     this.content.fastForEach { text ->
                         items.addAll(

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/utils/PositionalListItemUtils.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/converters/utils/PositionalListItemUtils.kt
@@ -23,7 +23,10 @@ internal object PositionalListItemUtils {
         val items = ListsConverter.convertToLocalListItems(lines)
         val level = lines.paragraphsInSelectedRange.first().startPiece.decorator.toLevel()
         items.fastForEach {
-            if (it.index in indices) {
+            // Only real marker pieces switch type: fabricating a marker onto a content head (a
+            // quoted or plain paragraph caught in the range, #126) replaces its text with the
+            // marker string.
+            if (it.index in indices && it.richPiece.isDecorator) {
                 val count = it.richPiece.decorator?.toCount() ?: 0
                 it.newRichPiece = it.richPiece.copy(decorator = listItem.toTextDecoratorModel(count, level))
             }
@@ -37,7 +40,8 @@ internal object PositionalListItemUtils {
         val targetOffset = lines.paragraphs[index].startOffset
         val items = ListsConverter.fromPieceMultiParagraph(MultiPieceParagraph(paragraphs, lines.start, lines.end))
         items.fastForEach {
-            if (it.offsetInDocument == targetOffset) {
+            // Same marker guard as replaceDecorators (#126).
+            if (it.offsetInDocument == targetOffset && it.richPiece.isDecorator) {
                 val count = it.richPiece.decorator?.toCount() ?: 0
                 it.newRichPiece = it.richPiece.copy(decorator = listItem.toTextDecoratorModel(count, level))
             }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/PieceParagraph.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/PieceParagraph.kt
@@ -49,7 +49,9 @@ internal data class PieceParagraph(
 
     val piecesOutOfRange get() = piecesPartitioned.second
 
-    val isListItem get() = startPiece.decorator != null
+    // Marker-based: a quoted paragraph (blockquote attribute on its content pieces) is not a list
+    // item — it has no marker piece to skip, renumber or protect.
+    val isListItem get() = startPiece.isDecorator
 
     val paragraphType get() = startPiece.decorator.toTextEditorListItem()
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/TextEditorModel.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/models/TextEditorModel.kt
@@ -27,7 +27,11 @@ internal data class TextEditorModel(
 
     companion object {
 
-        internal fun TextEditorModel?.getKey(): String = if (this?.piece?.decorator != null) this.piece.decorator.key else NONE_KEY
+        // Marker keys only: the key groups consecutive same-kind LIST paragraphs into one node.
+        // A blockquote decorator is a paragraph attribute, and letting its key group adjacent
+        // quoted paragraphs would collapse them into one node that keeps only the first paragraph.
+        internal fun TextEditorModel?.getKey(): String =
+            this?.piece?.decorator?.takeIf { it.isMarker }?.key ?: NONE_KEY
 
         fun create(
             text: String,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/models/RichPiece.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/models/RichPiece.kt
@@ -25,7 +25,9 @@ internal data class RichPiece(
     val isLineBreak: Boolean = false,
     val endsWithLineBreak: Boolean = false
 ) : Piece() {
-    val isDecorator get() = decorator != null
+    // Marker pieces only: a blockquote decorator is a paragraph attribute on ordinary content
+    // pieces, not an atomic marker — the editing paths' decorator handling must not apply to it.
+    val isDecorator get() = decorator?.isMarker == true
 
     val isToken get() = token != null
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/models/TextDecoratorModel.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/piecetable/models/TextDecoratorModel.kt
@@ -27,6 +27,14 @@ sealed class TextDecoratorModel {
         return getDecoratorString().length
     }
 
+    /**
+     * Whether this decorator is a visible MARKER occupying its own atomic piece at the start of a
+     * paragraph (list bullets/numbers/task boxes). A blockquote decorator is the opposite: an
+     * invisible paragraph attribute riding on ordinary content pieces — its text is the quoted
+     * content itself, so the editing paths must treat those pieces as plain text, never as markers.
+     */
+    val isMarker: Boolean get() = this !is BlockquoteDecorator
+
     private fun getDecoratorString() = when (this) {
         is NumberDecoratorModel -> "$count$DOT$SPACE"
         is BulletDecoratorModel -> {
@@ -132,8 +140,10 @@ sealed class TextDecoratorModel {
             }
         }
 
-        internal fun TextDecoratorModel?.toLevel(defaultLevel: Int = 1) = when (this) {
-            null -> defaultLevel
+        internal fun TextDecoratorModel?.toLevel(defaultLevel: Int = 1) = when {
+            // A non-marker decorator (blockquote attribute) has no list level — its -1 sentinel
+            // must never feed level arithmetic, where it indexes the tabs cache negatively.
+            this == null || !isMarker -> defaultLevel
             else -> level
         }
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/TextEditorTransaction.kt
@@ -67,10 +67,13 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
         val filteredContent = if (this.isViewer) {
             textEditorDocument.content
         } else {
-            // The editor has no blockquote editing, so the node itself cannot survive, but its
-            // paragraphs can: unwrap them in place of dropping the whole block, or opening a
-            // document for editing silently deletes every quoted line.
-            textEditorDocument.content.flatMap { it.unwrapBlockquotes() }
+            // Top-level blockquotes survive an editor load the same way they do in the viewer
+            // (#126) — their content pieces carry the BlockquoteDecorator attribute, and the
+            // export groups them back into blockquote nodes. A blockquote nested inside a
+            // listItem/taskItem still unwraps into its item's paragraphs: the list machinery has
+            // no representation for it, and an un-unwrapped nested quote renders but never saves
+            // (#120's sibling case).
+            textEditorDocument.content.map { it.unwrapNestedBlockquotes() }
         }
         val document = TextEditorConverter.getAsTextWithMarks(
             TextEditorDocument(filteredContent),
@@ -80,22 +83,27 @@ internal class TextEditorTransaction(private val configuration: TextKitConfigura
     }
 
     /**
-     * Replaces a blockquote (at any nesting depth) with the blocks it contains. Recurses into list
-     * items too: a blockquote inside a `listItem`/`taskItem` would otherwise survive to the piece
-     * table, render its text in the editor, and still be dropped by the export — content the user
-     * can see but that never saves.
+     * Unwraps blockquotes nested inside list items into their item's paragraphs — the list
+     * machinery has no representation for a quote, and an un-unwrapped nested quote renders in the
+     * editor but never saves. Top-level blockquotes are left intact (#126): their content carries
+     * the decorator attribute and round-trips.
      */
-    private fun BaseParagraph.unwrapBlockquotes(): List<BaseParagraph> = when (this) {
-        is Blockquote -> content.flatMap { it.unwrapBlockquotes() }
-        is BulletedList -> listOf(copy(content = content.map { it.unwrapInsideItem() }))
-        is OrderedList -> listOf(copy(content = content.map { it.unwrapInsideItem() }))
-        is TaskList -> listOf(copy(content = content.map { it.unwrapInsideItem() }))
-        else -> listOf(this)
+    private fun BaseParagraph.unwrapNestedBlockquotes(): BaseParagraph = when (this) {
+        is BulletedList -> copy(content = content.map { it.unwrapInsideItem() })
+        is OrderedList -> copy(content = content.map { it.unwrapInsideItem() })
+        is TaskList -> copy(content = content.map { it.unwrapInsideItem() })
+        else -> this
+    }
+
+    /** Flattens a blockquote (at any depth) into the blocks it contains — nested-in-list use only. */
+    private fun BaseParagraph.flattenBlockquotes(): List<BaseParagraph> = when (this) {
+        is Blockquote -> content.flatMap { it.flattenBlockquotes() }
+        else -> listOf(unwrapNestedBlockquotes())
     }
 
     private fun BaseText.unwrapInsideItem(): BaseText = when (this) {
-        is ListItem -> copy(content = content.flatMap { it.unwrapBlockquotes() })
-        is TaskListItem -> copy(content = content.flatMap { it.unwrapBlockquotes() })
+        is ListItem -> copy(content = content.flatMap { it.flattenBlockquotes() })
+        is TaskListItem -> copy(content = content.flatMap { it.flattenBlockquotes() })
         else -> this
     }
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/lists/ListItemTransaction.kt
@@ -123,7 +123,9 @@ internal object ListItemTransaction {
     }
 
     private fun PieceParagraph.addDecoratorIfNull(currListItem: TextEditorDecoratorItem): PieceParagraph {
-        if (startPiece.decorator != null) return this
+        // Marker check, not raw decorator: a quoted paragraph (blockquote attribute on its content
+        // pieces, #126) is a plain paragraph to the list machinery and gets its marker prepended.
+        if (startPiece.isDecorator) return this
         val level = if (currListItem in listOf(BulletedList, CheckList)) 0 else 1
         val newDecorator = currListItem.toTextDecoratorModel(count = 0, level = level)
         val newModel = TextEditorModel.create(

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteEditorLoadTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteEditorLoadTest.kt
@@ -5,12 +5,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * Loading a document for editing must not lose blockquote content.
- *
- * `loadWith` used to drop blockquote nodes wholesale in editor mode — the node *and* every
- * paragraph inside it — so opening a document with a quote and saving it deleted the quoted text.
- * The editor still cannot edit a blockquote, so the node degrades to its inner paragraphs: the
- * quote structure is lost (as it always was), but the text now survives.
+ * Loading a document for editing must not lose blockquote content (#115). Top-level quotes now
+ * round-trip whole (#126, see `BlockquoteRoundTripTest`); a quote nested inside a list item still
+ * degrades to its item's paragraphs — the list machinery has no representation for it — but the
+ * text always survives.
  */
 class BlockquoteEditorLoadTest {
 

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteRoundTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteRoundTripTest.kt
@@ -1,5 +1,9 @@
 package com.jjrodcast.textkit
 
+import com.jjrodcast.textkit.editor.core.parser.TEXT_EDITOR_JSON
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -35,11 +39,11 @@ class BlockquoteRoundTripTest {
         val editor = editorFrom(QUOTE_DOC)
         editor.typeText(editor.text.indexOf("quoted") + 3, "XY")
         val saved = editor.toJson()
-        assertTrue(saved.contains("\"type\":\"blockquote\""))
-        // The typed characters live in the quoted paragraph, so they must serialize inside the node.
-        val quoteStart = saved.indexOf("\"type\":\"blockquote\"")
-        assertTrue(saved.substringBefore("\"type\":\"blockquote\"").contains("before"))
-        assertTrue(saved.contains("quoXYted") || saved.contains("XY"), saved)
+        // The typed characters must serialize INSIDE the blockquote node's subtree, not merely
+        // somewhere in the document.
+        val quote = TEXT_EDITOR_JSON.parseToJsonElement(saved).jsonObject["content"]!!.jsonArray
+            .first { it.jsonObject["type"]?.jsonPrimitive?.content == "blockquote" }
+        assertTrue(quote.toString().contains("XY"), "typed text left the quote: $saved")
         assertEquals(saved, editorFrom(saved).toJson())
     }
 

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteRoundTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteRoundTripTest.kt
@@ -1,0 +1,86 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Editor-mode blockquote round trip (#126): a top-level blockquote survives open-and-save. Its
+ * content pieces carry the `BlockquoteDecorator` attribute — an invisible, non-marker decorator —
+ * and the export groups consecutive attributed paragraphs back into a `blockquote` node.
+ */
+class BlockquoteRoundTripTest {
+
+    private val QUOTE_DOC = """{"type":"doc","content":[
+      {"type":"paragraph","content":[{"type":"text","text":"before"}]},
+      {"type":"blockquote","content":[
+        {"type":"paragraph","content":[{"type":"text","text":"quoted"}]},
+        {"type":"paragraph","content":[{"type":"text","text":"still quoted"}]}
+      ]},
+      {"type":"paragraph","content":[{"type":"text","text":"after"}]}
+    ]}"""
+
+    @Test
+    fun a_blockquote_survives_an_editor_open_and_save() {
+        val editor = editorFrom(QUOTE_DOC)
+        assertEquals("before\nquoted\nstill quoted\nafter", editor.text)
+        val saved = editor.toJson()
+        assertTrue(saved.contains("\"type\":\"blockquote\""), "structure lost: $saved")
+        assertTrue(saved.contains("still quoted"))
+        assertEquals(saved, editorFrom(saved).toJson())
+    }
+
+    @Test
+    fun typing_inside_a_quoted_paragraph_stays_inside_the_quote() {
+        val editor = editorFrom(QUOTE_DOC)
+        editor.typeText(editor.text.indexOf("quoted") + 3, "XY")
+        val saved = editor.toJson()
+        assertTrue(saved.contains("\"type\":\"blockquote\""))
+        // The typed characters live in the quoted paragraph, so they must serialize inside the node.
+        val quoteStart = saved.indexOf("\"type\":\"blockquote\"")
+        assertTrue(saved.substringBefore("\"type\":\"blockquote\"").contains("before"))
+        assertTrue(saved.contains("quoXYted") || saved.contains("XY"), saved)
+        assertEquals(saved, editorFrom(saved).toJson())
+    }
+
+    @Test
+    fun an_empty_quoted_paragraph_keeps_its_membership() {
+        val editor = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"blockquote","content":[
+                {"type":"paragraph","content":[{"type":"text","text":"a"}]},
+                {"type":"paragraph","content":[]},
+                {"type":"paragraph","content":[{"type":"text","text":"b"}]}
+              ]},
+              {"type":"paragraph","content":[{"type":"text","text":"tail"}]}
+            ]}"""
+        )
+        val saved = editor.toJson()
+        assertEquals(saved, editorFrom(saved).toJson())
+        // One quote node holding all three paragraphs — the empty one must not split it.
+        assertEquals(1, Regex("\"type\":\"blockquote\"").findAll(saved).count(), saved)
+    }
+
+    @Test
+    fun adjacent_blockquotes_normalize_into_one() {
+        // Known normalization: adjacency defines the exported node, matching what the rendering
+        // already shows for back-to-back quotes.
+        val editor = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"blockquote","content":[{"type":"paragraph","content":[{"type":"text","text":"one"}]}]},
+              {"type":"blockquote","content":[{"type":"paragraph","content":[{"type":"text","text":"two"}]}]}
+            ]}"""
+        )
+        val saved = editor.toJson()
+        assertEquals(1, Regex("\"type\":\"blockquote\"").findAll(saved).count(), saved)
+        assertTrue(saved.contains("one") && saved.contains("two"))
+        assertEquals(saved, editorFrom(saved).toJson())
+    }
+
+    @Test
+    fun viewer_and_editor_now_agree_on_quotes() {
+        val asEditor = editorFrom(QUOTE_DOC, isViewer = false)
+        val asViewer = editorFrom(QUOTE_DOC, isViewer = true)
+        assertEquals(asViewer.text, asEditor.text)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/DocumentLoadingTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/DocumentLoadingTest.kt
@@ -69,9 +69,9 @@ class DocumentLoadingTest {
     }
 
     @Test
-    fun editor_mode_unwraps_blockquotes_and_viewer_mode_keeps_them() {
-        // The editor cannot edit a blockquote, so the node degrades to its inner paragraphs —
-        // the structure is lost but the text survives an open-and-save.
+    fun editor_mode_and_viewer_mode_both_keep_blockquotes() {
+        // Top-level quotes survive both modes (#126): the content pieces carry the blockquote
+        // attribute and the export regroups them.
         val asEditor = editorFrom(SampleDocuments.BLOCKQUOTE, isViewer = false)
         assertEquals("before\nquoted text\nafter", asEditor.text)
         assertFalse(asEditor.isViewer)

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
@@ -85,7 +85,7 @@ internal object EditingStress {
             // attribute riding on ordinary content pieces, legal anywhere in the line.
             assertTrue(
                 paragraph.children.drop(1).none { it.decorator?.isMarker == true },
-                "mid-line decorator at $where: $visible",
+                "mid-line marker at $where: $visible",
             )
             // 7. A marker piece is exactly its decorator's canonical string. A partial overwrite
             // (a shear, a stale-length rewrite) can leave a truncated marker AT a paragraph start,

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EditingStressTest.kt
@@ -15,9 +15,9 @@ import kotlin.test.assertTrue
  * Deterministic stress test: long, seeded sequences of every editing operation — typing, breaks,
  * deletes (typed and programmatic `deleteRange`), replaces, multiline pastes, list toggles and type
  * switches, styles, alignment, colour, embed updates, and the read-only selection queries — over
- * regular paragraphs, ordered/unordered/task lists, deeply nested documents, and the flattened
- * forms headings and blockquotes load into (#115). This is the kind of churn that surfaces an
- * intermittent editing bug.
+ * regular paragraphs, ordered/unordered/task lists, deeply nested documents, flattened headings
+ * (#115) and live blockquotes (#126 — their paragraphs carry the non-marker quote attribute
+ * through every op). This is the kind of churn that surfaces an intermittent editing bug.
  *
  * After every operation, seven invariants hold:
  *
@@ -81,8 +81,10 @@ internal object EditingStress {
     internal fun TextKitEditorManager.assertInvariants(where: String) {
         val visible = text.replace("\n", "\\n").replace("\t", "\\t")
         getParagraphs().forEach { paragraph ->
+            // Marker decorators only: the blockquote decorator (#126) is an invisible paragraph
+            // attribute riding on ordinary content pieces, legal anywhere in the line.
             assertTrue(
-                paragraph.children.drop(1).none { it.decorator != null },
+                paragraph.children.drop(1).none { it.decorator?.isMarker == true },
                 "mid-line decorator at $where: $visible",
             )
             // 7. A marker piece is exactly its decorator's canonical string. A partial overwrite
@@ -90,7 +92,7 @@ internal object EditingStress {
             // where the mid-line check cannot see it until a later edit moves it — #122's failures
             // surfaced ops away from their cause for exactly this reason.
             paragraph.children.forEach { child ->
-                child.decorator?.let { decorator ->
+                child.decorator?.takeIf { it.isMarker }?.let { decorator ->
                     assertEquals(
                         decorator.createDecoratorString(),
                         child.text,
@@ -126,7 +128,7 @@ internal object EditingStress {
         )
         getParagraphs().forEach { paragraph ->
             paragraph.children.forEach { child ->
-                if (child.decorator != null) {
+                if (child.decorator?.isMarker == true) {
                     assertTrue(
                         caret.min <= child.start || caret.min >= child.end,
                         "$what left the caret inside a marker: $caret in [${child.start},${child.end})",


### PR DESCRIPTION
First phase of #126 — the round trip. Editing semantics (Enter/Backspace/toggle behaviour *on* quotes) and the UI toggle come as the follow-ups discussed there.

**A blockquote is not a marker** — that's the whole design. List bullets, numbers and task boxes are visible markers occupying their own atomic piece at the start of a line; the quote decorator is an invisible paragraph attribute riding on ordinary content pieces. Every layer that special-cases "decorator" actually means "marker", so `TextDecoratorModel` gains `isMarker` (false for `BlockquoteDecorator`) and the predicates consult it: `RichPiece.isDecorator`, `PieceParagraph.isListItem`, the node-grouping key, `toLevel` (whose `-1` sentinel otherwise indexes the tabs cache negatively), the positional-item builder (which now strips non-marker heads), the type-switch guards in `replaceDecorator(s)`, and `addDecoratorIfNull`. To the editing engine, quoted text is now plain text.

With that in place the round trip is small:

* **Load** (editor mode) keeps top-level blockquotes exactly as the viewer does — content pieces tagged with the attribute. A quote nested inside a `listItem`/`taskItem` still unwraps into the item's paragraphs (the list machinery has no representation for it; its text survives, per #115).
* **Export** groups consecutive quote-tagged plain paragraphs back into a `blockquote` node. Adjacency defines the node, so back-to-back quotes normalize into one — the same thing their rendering already shows. An empty quoted paragraph keeps its membership (the loader now tags its line-break piece).

Editing inside a quote behaves as ordinary text editing, and membership survives it: typing, deleting, styling, undo/redo all round-trip (a list toggle on quoted text converts the paragraph and drops the quote — full quote-editing semantics are the next phase).

`BlockquoteRoundTripTest` pins the contract (round trip, typing stays quoted, empty-paragraph membership, adjacent-quote normalization, editor/viewer agreement); the #115-era tests keep their text-preservation assertions with updated names. The stress harness's quote start document now exercises a **live** blockquote through all 20 ops and seven invariants — during development it caught five distinct corruption classes (a paragraph silently dropped by node grouping, empty-paragraph membership loss, a negative-level crash, and marker fabrication onto quoted text through two paths) before any of them could ship.

Verification: full sweeps (400 × 250, editing and undo/redo) clean, a 30,000-seed × 60-op scan clean, all targets green.
