### PR TITLE
Blockquote exit gestures: Enter on an empty quoted line, Backspace at quote start

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransaction.kt
@@ -18,7 +18,24 @@ object TextTransaction {
     fun onTextUpdated(
         actionModel: TextEditorAction,
         manager: TextKitEditorManager
+    ): Pair<Boolean, TextRange> = onTextUpdated(actionModel, manager, quoteAware = true)
+
+    /**
+     * [quoteAware] gates the two quote-boundary conventions below. They model a *gesture* — a
+     * typed Enter, a typed Backspace — so the multiline paste replay, which re-enters this
+     * function segment by segment, dispatches with `false`: a pasted blank line inside a quote
+     * must survive as a blank quoted line, not get swallowed as an "exit".
+     */
+    private fun onTextUpdated(
+        actionModel: TextEditorAction,
+        manager: TextKitEditorManager,
+        quoteAware: Boolean
     ): Pair<Boolean, TextRange> {
+        if (quoteAware) {
+            exitQuoteOnEmptyLine(actionModel, manager)?.let { return Pair(true, it) }
+            unwrapQuoteOnBoundaryDelete(actionModel, manager)?.let { return Pair(true, it) }
+        }
+
         // A single insert that carries line breaks amid other text (a paste) must become one
         // paragraph per break — the per-transaction logic below only splits a *lone* line break, and
         // would otherwise leave the breaks embedded in one text node. Replay it as the discrete
@@ -42,7 +59,7 @@ object TextTransaction {
                             length = actionModel.removeLength,
                             selection = TextRange(actionModel.offset),
                         )
-                        insertOffset = onTextUpdated(removal, manager).second.end
+                        insertOffset = onTextUpdated(removal, manager, quoteAware = false).second.end
                     }
                     val marks = manager.getSearchMarkType(TextRange(insertOffset)).marks
                     return insertMultiline(insertOffset, actionModel.text, marks, manager)
@@ -91,6 +108,57 @@ object TextTransaction {
     }
 
     /**
+     * Enter on an EMPTY quoted line exits the quote instead of extending it (#126): the empty
+     * paragraph drops its quote attribute and the break is swallowed, the same way Enter on an
+     * empty list item removes the marker rather than opening yet another item. Returns the caret
+     * (unchanged — the line the user is on just turned plain), or `null` when the convention does
+     * not apply and the ordinary insert should run.
+     */
+    private fun exitQuoteOnEmptyLine(
+        actionModel: TextEditorAction,
+        manager: TextKitEditorManager
+    ): TextRange? {
+        if (actionModel !is TextEditorAction.TextAdded || !actionModel.text.isLineBreak()) return null
+        val offset = actionModel.offset
+        // At the document end there is no paragraph at the offset to be empty AND quoted — the
+        // trailing line past the last break has no pieces, and its export is already plain.
+        if (offset >= manager.text.length) return null
+        if (manager.transaction.quoteDecoratorAt(offset) == null) return null
+        // The forward window [offset, offset+1) is the same resolution quoteDecoratorAt used, so
+        // this is the paragraph whose quote was found — empty means it is just its own terminator.
+        val line = manager.transaction.getLineContent(offset, offset + 1)
+            .paragraphsInSelectedRange.firstOrNull() ?: return null
+        if (!line.text.isLineBreak()) return null
+        manager.transaction.updateBlockquote(TextRange(offset, offset + 1), quoted = false)
+        return TextRange(offset)
+    }
+
+    /**
+     * Backspace at the start of a quote unwraps its first line instead of merging (#126): deleting
+     * the lone break between an unquoted line and a quoted one would pull the previous line INTO
+     * the quote. The quote's first paragraph steps out and the break survives; the next backspace
+     * then merges two plain lines the ordinary way. (A forward Delete at the end of the previous
+     * line produces the same action and gets the same treatment — the two are indistinguishable
+     * here, and unwrap-first is the safer of the two merges.) Returns the caret at the now-plain
+     * line's start, or `null` when the ordinary delete should run.
+     */
+    private fun unwrapQuoteOnBoundaryDelete(
+        actionModel: TextEditorAction,
+        manager: TextKitEditorManager
+    ): TextRange? {
+        if (actionModel !is TextEditorAction.TextRemoved || actionModel.length != 1) return null
+        val offset = actionModel.offset
+        if (manager.text.getOrNull(offset)?.isLineBreak() != true) return null
+        if (offset + 1 >= manager.text.length) return null
+        val transaction = manager.transaction
+        // Only at the quote's first line: a break already inside the quote merges normally.
+        if (transaction.quoteDecoratorAt(offset) != null) return null
+        if (transaction.quoteDecoratorAt(offset + 1) == null) return null
+        transaction.updateBlockquote(TextRange(offset + 1, offset + 2), quoted = false)
+        return TextRange(offset + 1)
+    }
+
+    /**
      * Replays [text] as the discrete inserts it would produce when typed: each run of ordinary text
      * and each line break is inserted on its own, in order, through [onTextUpdated] — so every break
      * splits a paragraph the way a lone typed break already does. The offset advances by each
@@ -112,7 +180,7 @@ object TextTransaction {
                 offset = offset,
                 selection = TextRange(offset + segment.length),
             )
-            val (applied, resultSelection) = onTextUpdated(action, manager)
+            val (applied, resultSelection) = onTextUpdated(action, manager, quoteAware = false)
             changed = changed || applied
             selection = resultSelection
             // Advance to where the engine actually left the caret rather than assuming

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteGesturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/BlockquoteGesturesTest.kt
@@ -1,0 +1,108 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The two quote-boundary gestures (#126): Enter on an empty quoted line exits the quote, and
+ * Backspace at the start of a quote unwraps its first line instead of pulling the previous line
+ * into the quote. Both are modeled at the transaction entry point, so they hold for any caller
+ * that types the gesture — and deliberately NOT for the multiline paste replay.
+ */
+class BlockquoteGesturesTest {
+
+    private val doc = """{"type":"doc","content":[
+      {"type":"paragraph","content":[{"type":"text","text":"one"}]},
+      {"type":"blockquote","content":[{"type":"paragraph","content":[{"type":"text","text":"quoted"}]}]},
+      {"type":"paragraph","content":[{"type":"text","text":"after"}]}
+    ]}"""
+
+    @Test
+    fun enter_on_an_empty_quoted_line_exits_the_quote() {
+        val e = editorFrom(doc)
+        val endOfQuote = e.text.indexOf("quoted") + 6
+        val first = e.typeText(endOfQuote, "\n")
+        assertTrue(e.isBlockquote(TextRange(first.start, first.start + 1)))
+
+        val textBefore = e.text
+        val second = e.typeText(first.start, "\n")
+        // The break is swallowed: the empty line turns plain instead of extending the quote.
+        assertEquals(textBefore, e.text)
+        assertEquals(first.start, second.start)
+        assertFalse(e.isBlockquote(TextRange(second.start, second.start + 1)))
+
+        val saved = e.toJson()
+        assertEquals(1, Regex("\"type\":\"blockquote\"").findAll(saved).count(), saved)
+        assertTrue(saved.contains("quoted"))
+        assertEquals(saved, editorFrom(saved).toJson())
+    }
+
+    @Test
+    fun backspace_at_quote_start_unwraps_before_merging() {
+        val e = editorFrom(doc)
+        val quoteStart = e.text.indexOf("quoted")
+        val textBefore = e.text
+
+        val caret = e.deleteText(quoteStart - 1, 1)
+        // First backspace: nothing is deleted, the quote's first line steps out.
+        assertEquals(textBefore, e.text)
+        assertEquals(quoteStart, caret.start)
+        assertFalse(e.isBlockquote(TextRange(quoteStart, quoteStart + 1)))
+        assertFalse(e.toJson().contains("blockquote"))
+
+        // Second backspace: an ordinary plain-with-plain merge.
+        e.deleteText(quoteStart - 1, 1)
+        assertEquals("onequoted\nafter", e.text)
+        assertFalse(e.toJson().contains("blockquote"))
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+
+    @Test
+    fun backspace_between_two_quoted_lines_still_merges() {
+        val e = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"blockquote","content":[
+                {"type":"paragraph","content":[{"type":"text","text":"first"}]},
+                {"type":"paragraph","content":[{"type":"text","text":"second"}]}
+              ]}
+            ]}"""
+        )
+        val secondStart = e.text.indexOf("second")
+        e.deleteText(secondStart - 1, 1)
+        assertEquals("firstsecond", e.text)
+        assertTrue(e.isBlockquote(TextRange(0, e.text.length)))
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+
+    @Test
+    fun pasted_blank_lines_inside_a_quote_survive() {
+        val e = editorFrom(doc)
+        val endOfQuote = e.text.indexOf("quoted") + 6
+        val emptyLine = e.typeText(endOfQuote, "\n")
+
+        // A paste replays its breaks with the Enter-exit disabled: the blank line it carries must
+        // land as a blank quoted line, not get swallowed as an "exit".
+        e.typeText(emptyLine.start, "alpha\n\nbeta")
+        assertTrue(e.text.contains("alpha\n\nbeta"))
+        val blankAt = e.text.indexOf("alpha") + 6
+        assertTrue(e.isBlockquote(TextRange(blankAt, blankAt + 1)))
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+
+    @Test
+    fun undo_restores_the_quote_after_the_enter_exit() {
+        val e = editorFrom(doc)
+        val endOfQuote = e.text.indexOf("quoted") + 6
+        val first = e.typeText(endOfQuote, "\n")
+        val before = e.toJson()
+
+        val point = e.captureHistoryPoint(TextRange(first.start))
+        e.typeText(first.start, "\n")
+        e.pushHistory(point)
+        e.undo(TextRange(first.start))
+        assertEquals(before, e.toJson())
+    }
+}


### PR DESCRIPTION
Part of #126 — the two boundary conventions deferred from #131.

With #131 merged, a quote behaves well while you're typing inside it, but there's no way to type your way *out* of one, and Backspace at its edge does the wrong thing:

- Enter on an empty quoted line just stacks up more empty quoted paragraphs — the quote grows forever.
- Backspace at the start of a quote merges the *previous* line into the quote: plain `one` + quoted `two` becomes one quoted line, so the unquoted text you backspaced from gets absorbed.

This models the two standard editor gestures at the transaction entry point (`TextTransaction.onTextUpdated`), so they hold for any caller that types them:

- **Enter on an empty quoted line exits the quote.** The break is swallowed and the empty paragraph drops its quote attribute — the same shape as Enter on an empty list item removing its marker.
- **Backspace at the start of a quote unwraps its first line.** Nothing is deleted on the first press: the quote's first paragraph steps out and turns plain; the next Backspace merges two plain lines the ordinary way. Backspace between two lines *inside* a quote still merges normally. (A forward Delete at the end of the previous line produces the same action and gets the same treatment — the two are indistinguishable at this level, and unwrap-first is the safer merge.)

One deliberate exception: the multiline paste replay re-enters the entry point segment by segment with the gestures disabled — a pasted blank line inside a quote must survive as a blank quoted line, not get swallowed as an "exit".

Tests: `BlockquoteGesturesTest` covers the exit, the unwrap plus the follow-up merge, the inside-quote merge staying intact, the paste exception, and undo restoring the quote after an exit. Full suite green on jvm, js, and wasmJs (stress sweep and pinned seeds included); iOS compiles.
