### PR TITLE
fix: demote an empty nested task item on Enter instead of dropping the change

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
@@ -21,7 +21,6 @@ import com.jjrodcast.textkit.editor.core.transactions.lists.models.TextEditorLis
 import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorAction
 import com.plangrid.pgfoundation.texteditor.core.validator.ListItemValidator
 import com.plangrid.pgfoundation.texteditor.core.validator.TextInputResult
-import com.jjrodcast.textkit.editor.utils.TABS
 import com.jjrodcast.textkit.editor.utils.isLineBreak
 import com.jjrodcast.textkit.editor.utils.replaceLineBreakWith
 
@@ -311,16 +310,42 @@ internal object TextInsertedTransaction {
             is TextDecoratorModel.NumberDecoratorModel -> PositionalListItemUtils.reorderItems(positionalListItems)
             is TextDecoratorModel.BulletDecoratorModel -> PositionalListItemUtils.reorderItems(positionalListItems, coerceLevel = false)
 
-            else -> positionalListItems
+            // createTransactions scans the list it is handed, not the trees inside it: a nested
+            // item's demotion is invisible unless the tree is flattened first. The two branches
+            // above only survive because reorderItems flattens as a side effect — a nested TASK
+            // item demoted here was silently dropped, turning Enter into a no-op (issue #133).
+            else -> positionalListItems.flatten()
         }
         transactions.addAll(flattenItems.createTransactions())
 
-        val length = currentDecorator.createDecoratorString().length
-        val nextLevelTabsLength = if (currentParagraph.startPiece.decorator.toLevel() > 1) TABS.length else length
-        val rangeOffset = (actionModel.offset - nextLevelTabsLength)
-            .coerceAtLeast(currentParagraph.startOffset)
+        return Pair(TextRange(caretAfterEmptyItemBreak(currentParagraph, transactions, actionModel)), transactions)
+    }
 
-        return Pair(TextRange(rangeOffset), transactions)
+    /**
+     * The caret after Enter on an empty list item, derived from the transactions that were
+     * actually emitted rather than from the demotion the caller assumed (issue #133; the previous
+     * arithmetic subtracted a fixed tab-pair width for any nested item — when the transactions did nothing
+     * the caret stepped back INTO the marker, when they deleted the marker whole it landed one
+     * character short of the emptied line, and when they removed more than assumed it went past
+     * the document end — #131's clamp, seed 46382). The caret belongs at the item's content
+     * start: its old position at [TextEditorAction.TextAdded.offset], shifted by exactly what the
+     * transactions change at or before the item's paragraph.
+     */
+    private fun caretAfterEmptyItemBreak(
+        currentParagraph: PieceParagraph,
+        transactions: List<TextEditorListItemTransaction>,
+        actionModel: TextEditorAction.TextAdded
+    ): Int {
+        val delta = transactions
+            .filter { it.offsetInDocument <= currentParagraph.startOffset }
+            .sumOf { transaction ->
+                when (val type = transaction.type) {
+                    is TextEditorDecoratorTransactionType.Update -> type.model.text.length - type.length
+                    is TextEditorDecoratorTransactionType.Delete -> -type.length
+                    is TextEditorDecoratorTransactionType.Insert -> type.model.text.length
+                }
+            }
+        return (actionModel.offset + delta).coerceAtLeast(currentParagraph.startOffset)
     }
 
     /**

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyListItemEnterTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/EmptyListItemEnterTest.kt
@@ -1,0 +1,125 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Enter on an EMPTY list item walks the item back out — one level down when nested, out of the
+ * list at the top level — and leaves the caret at the item's content start (issue #133: a nested
+ * task item's demotion was silently dropped, leaving the caret stranded inside the marker; the
+ * caret is now derived from the transactions that were actually emitted).
+ */
+class EmptyListItemEnterTest {
+
+    private fun show(s: String) = s.replace("\n", "\\n").replace("\t", "\\t")
+
+    /** Caret must sit at the content start of the line it was on — same line, after its marker. */
+    private fun assertCaretAtContentStart(e: com.jjrodcast.textkit.editor.core.TextKitEditorManager, caret: Int, lineIndex: Int) {
+        val lineStart = e.text.split("\n").take(lineIndex).sumOf { it.length + 1 }
+        val paragraph = e.getParagraphs().getOrNull(lineIndex)
+        val expected = paragraph?.children?.firstOrNull()
+            ?.let { if (it.decorator?.isMarker == true) it.end else lineStart }
+            ?: lineStart
+        assertEquals(expected, caret, "caret in '${show(e.text)}'")
+    }
+
+    @Test
+    fun enter_demotes_an_empty_task_item_nested_under_a_bullet() {
+        val e = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"bulletList","content":[
+                {"type":"listItem","content":[
+                  {"type":"paragraph","content":[{"type":"text","text":"a"}]},
+                  {"type":"taskList","content":[
+                    {"type":"taskItem","attrs":{"checked":false},"content":[{"type":"paragraph","content":[]}]}
+                  ]}
+                ]}
+              ]}
+            ]}"""
+        )
+        val before = e.text
+        val r = e.typeText(e.text.length, "\n")
+        assertTrue(e.text != before, "Enter must not be a no-op")
+        assertTrue(e.text.length < before.length, "the item demotes — the marker loses a level")
+        assertCaretAtContentStart(e, r.start, 1)
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+
+    @Test
+    fun enter_demotes_an_empty_task_item_nested_under_an_ordered_item() {
+        val e = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"orderedList","attrs":{"start":1},"content":[
+                {"type":"listItem","content":[
+                  {"type":"paragraph","content":[{"type":"text","text":"a"}]},
+                  {"type":"taskList","content":[
+                    {"type":"taskItem","attrs":{"checked":false},"content":[{"type":"paragraph","content":[]}]}
+                  ]}
+                ]}
+              ]}
+            ]}"""
+        )
+        val before = e.text
+        val r = e.typeText(e.text.length, "\n")
+        assertTrue(e.text != before, "Enter must not be a no-op")
+        assertCaretAtContentStart(e, r.start, 1)
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+
+    @Test
+    fun enter_unwraps_an_empty_bullet_nested_under_a_task_item() {
+        val e = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"taskList","content":[
+                {"type":"taskItem","attrs":{"checked":false},"content":[
+                  {"type":"paragraph","content":[{"type":"text","text":"a"}]},
+                  {"type":"bulletList","content":[
+                    {"type":"listItem","content":[{"type":"paragraph","content":[]}]}
+                  ]}
+                ]}
+              ]}
+            ]}"""
+        )
+        val r = e.typeText(e.text.length, "\n")
+        assertCaretAtContentStart(e, r.start, 1)
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+
+    @Test
+    fun enter_still_demotes_an_empty_bullet_nested_under_a_bullet() {
+        val e = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"bulletList","content":[
+                {"type":"listItem","content":[
+                  {"type":"paragraph","content":[{"type":"text","text":"a"}]},
+                  {"type":"bulletList","content":[
+                    {"type":"listItem","content":[{"type":"paragraph","content":[]}]}
+                  ]}
+                ]}
+              ]}
+            ]}"""
+        )
+        val before = e.text
+        val r = e.typeText(e.text.length, "\n")
+        assertTrue(e.text.length < before.length)
+        assertCaretAtContentStart(e, r.start, 1)
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+
+    @Test
+    fun enter_unwraps_an_empty_top_level_task_item() {
+        val e = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"p"}]},
+              {"type":"taskList","content":[
+                {"type":"taskItem","attrs":{"checked":false},"content":[{"type":"paragraph","content":[]}]}
+              ]}
+            ]}"""
+        )
+        val r = e.typeText(e.text.length, "\n")
+        assertTrue(!e.toJson().contains("taskList"), e.toJson())
+        assertCaretAtContentStart(e, r.start, 1)
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+}


### PR DESCRIPTION
Fixes #133.

Two changes in `TextInsertedTransaction.addLineBreakOnEmptyListItem`:

**1. The demotion reaches the document.** `createTransactions` scans the list it is handed, not the trees inside it — so a *nested* item marked modified by `decreaseLevels` was invisible unless the tree was flattened first. The bullet and numbered branches only survived because `reorderItems` flattens as a side effect; the task branch handed over the nested tree and the demotion was silently dropped, turning Enter into a permanent no-op. That branch now flattens explicitly.

**2. The caret is derived, not assumed.** The old arithmetic subtracted a fixed tab-pair width for any nested item — right only when the transactions demoted exactly one level. When they did nothing, the caret stepped back *into* the marker; when they removed the marker whole, it landed one character short of the emptied line; and when they removed more than assumed, it went past the document end (the corruption #131's clamp defends against, pinned seed 46382). The caret is now computed from the transactions that were actually emitted: the item's old content start shifted by exactly what changes at or before its paragraph.

Tests: `EmptyListItemEnterTest` pins both shapes from the issue (task under bullet and under ordered, bullet under task), the top-level task unwrap, and the already-working nested-bullet demote as a control — each asserting the caret lands at the emptied line's content start. As a broader acceptance check I ran the #46 harness with the new caret invariant (same visual line, never inside a marker) over ~30k Enter-on-empty-item trials on churned documents: zero failures, where main fails within the first few thousand. Full suite green on jvm, js, and wasmJs; iOS compiles.
