### PR TITLE
fix: reserve the list gutter with the marker's kept space instead of a first-line indent

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -86,6 +86,9 @@ kotlin {
         jvmMain.dependencies {
             implementation(libs.ktor.client.okhttp)
         }
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
+        }
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)
         }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/listlayout/ListItemEditorTransform.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/listlayout/ListItemEditorTransform.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
 import com.jjrodcast.textkit.editor.core.parser.TextAlign as TextKitTextAlign
 import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel
 import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel.Companion.createDecoratorString
@@ -46,7 +47,23 @@ internal object ListItemEditorTransform {
             val splitLayout = paragraph.usesSplitListLayout()
             withStyle(paragraphStyle(paragraph, defaultStyle, toComposeAlign, splitLayout)) {
                 paragraph.children.forEach { child ->
-                    if (splitLayout && child.decorator != null) return@forEach
+                    if (splitLayout && child.decorator != null) {
+                        // The marker's trailing space stays in the display and its advance IS the
+                        // first-line gutter (#135). Two Skia behaviors force this shape: a
+                        // paragraph whose display text carries no whitespace at all never gets its
+                        // TextIndent applied (a lone word rendered at the container edge, under
+                        // the marker), and a first-line TextIndent is invisible to the text's
+                        // intrinsic width (a content-sized field soft-wrapped its own text
+                        // mid-word). A real character's advance participates in both, so the
+                        // reserved width and the rendered width agree by construction.
+                        if (child.text.endsWith(' ')) {
+                            val gutterEm = child.text.length * GUTTER_EM_FACTOR
+                            withStyle(
+                                SpanStyle(letterSpacing = (gutterEm - SPACE_ADVANCE_EM).em)
+                            ) { append(' ') }
+                        }
+                        return@forEach
+                    }
                     withStyle(spanStyleOf(child)) {
                         append(displayTextOf(child, fieldLength))
                     }
@@ -76,14 +93,26 @@ internal object ListItemEditorTransform {
             return if (paragraph.isQuoted()) base.copy(textIndent = TextIndent(firstLine = QUOTE_INDENT, restLine = QUOTE_INDENT)) else base
         }
         val gutter = paragraph.listDecoratorChild()?.decorator ?: return base
+        // The FIRST line's gutter is reserved by the kept marker space's advance (see
+        // buildDisplayAnnotatedString), not by TextIndent: a first-line indent is invisible to the
+        // text's intrinsic width, so a field sized to its content laid the text out narrower than
+        // it renders and soft-wrapped it mid-word (#135). TextIndent stays on the wrapped lines
+        // only, where no intrinsic accounting exists to disagree with.
         val indent = gutterIndent(gutter)
-        return base.copy(textIndent = TextIndent(firstLine = indent, restLine = indent))
+        return base.copy(textIndent = TextIndent(firstLine = 0.sp, restLine = indent))
     }
 
     private fun gutterIndent(decorator: TextDecoratorModel): TextUnit =
         (decorator.createDecoratorString().length * GUTTER_EM_FACTOR).em
 
     private const val GUTTER_EM_FACTOR = 0.55f
+
+    /**
+     * A typical space glyph advance, subtracted so the kept space plus its letter spacing add up
+     * to the same gutter width the wrapped-line TextIndent uses (both are em estimates — the
+     * marker column has always been sized that way, see [gutterIndent]).
+     */
+    private const val SPACE_ADVANCE_EM = 0.25f
 }
 
 private class ListItemOffsetMapping(
@@ -97,9 +126,11 @@ private class ListItemOffsetMapping(
             if (offset <= segment.fieldStart) break
             if (segment.gutterLength == 0) continue
             when {
-                offset >= segment.fieldEnd -> skippedGutters += segment.gutterLength
+                // net per-segment field→display delta: the stripped marker minus its kept space
+                offset >= segment.fieldEnd -> skippedGutters += segment.gutterLength - segment.keptSpace
                 offset < segment.fieldStart + segment.gutterLength -> return segment.displayStart
-                else -> return segment.displayStart + (offset - segment.fieldStart - segment.gutterLength)
+                else -> return segment.displayStart + segment.keptSpace +
+                    (offset - segment.fieldStart - segment.gutterLength)
             }
         }
         return (offset - skippedGutters).coerceIn(0, totalDisplayLength)
@@ -119,7 +150,9 @@ private class ListItemOffsetMapping(
             return if (segment.gutterLength == 0) {
                 segment.fieldStart + local
             } else {
-                segment.fieldStart + segment.gutterLength + local
+                // the kept space belongs to the gutter: a caret on it (or before it) resolves to
+                // the item's content start, never inside the marker
+                segment.fieldStart + segment.gutterLength + (local - segment.keptSpace).coerceAtLeast(0)
             }
         }
         return segments.lastOrNull()?.fieldEnd ?: offset

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/listlayout/ListItemUi.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/listlayout/ListItemUi.kt
@@ -36,6 +36,8 @@ internal data class EditorParagraphSegment(
     val displayStart: Int,
     val displayEnd: Int,
     val gutterLength: Int,
+    /** 1 when the marker's trailing space stays in the display text (#135), else 0. */
+    val keptSpace: Int = 0,
     val gutter: TextDecoratorModel? = null,
     /** Whether this paragraph carries the blockquote attribute (#126) — drives the quote bar. */
     val quoted: Boolean = false,
@@ -57,6 +59,15 @@ internal fun TextEditorParagraph.listDecoratorChild(): TextEditorItem? =
 internal fun TextEditorParagraph.decoratorFieldLength(): Int =
     if (usesSplitListLayout()) listDecoratorChild()?.text?.length ?: 0 else 0
 
+/**
+ * 1 when the marker's trailing space stays in the display text (see the rationale on
+ * buildDisplayAnnotatedString), else 0. Field-side arithmetic keeps using [decoratorFieldLength]
+ * — the content still starts after the FULL marker in field coordinates; only the display and
+ * the offset mapping account for the kept character.
+ */
+internal fun TextEditorParagraph.keptGutterSpace(): Int =
+    if (usesSplitListLayout() && listDecoratorChild()?.text?.endsWith(' ') == true) 1 else 0
+
 internal fun buildEditorSegments(
     paragraphs: List<TextEditorParagraph>,
     fieldLength: Int,
@@ -73,7 +84,8 @@ internal fun buildEditorSegments(
         val fieldParagraphLength =
             paragraph.children.sumOf { displayTextOf(it, fieldLength).length }
         val gutterLength = paragraph.decoratorFieldLength()
-        val displayLength = fieldParagraphLength - gutterLength
+        val keptSpace = paragraph.keptGutterSpace()
+        val displayLength = fieldParagraphLength - gutterLength + keptSpace
 
         segments += EditorParagraphSegment(
             fieldStart = fieldStart,
@@ -81,6 +93,7 @@ internal fun buildEditorSegments(
             displayStart = displayCursor,
             displayEnd = displayCursor + displayLength,
             gutterLength = gutterLength,
+            keptSpace = keptSpace,
             gutter = if (gutterLength > 0) paragraph.listDecoratorChild()?.decorator else null,
             quoted = paragraph.isQuoted(),
         )

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
@@ -90,8 +90,9 @@ class ListItemUiTest {
         val fieldText = state.textFieldValue.text
         val transformed = state.visualTransformation.filter(AnnotatedString(fieldText))
         val contentStart = fieldText.indexOf('c')
-        // Display position 0 is the marker's kept trailing space (visually zero-width, #135); the
-        // content begins one past it. Both display 0 and 1 resolve back to the field content start.
+        // Display position 0 is the marker's kept trailing space, whose advance reserves the
+        // gutter column (#135); the content begins one past it. Both display 0 and 1 resolve back
+        // to the field content start.
         assertEquals(1, transformed.offsetMapping.originalToTransformed(contentStart))
         assertEquals(contentStart, transformed.offsetMapping.transformedToOriginal(0))
         assertEquals(contentStart, transformed.offsetMapping.transformedToOriginal(1))

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
@@ -414,28 +414,32 @@ class ListItemUiTest {
     }
 
     @Test
-    fun complexJsonV1_enterEmptyItemThenTypeNumberedMarkerRenumbersFollowingItems() {
+    fun complexJsonV1_enterEmptyItemExitsAndRenumbersFollowingItems() {
         val state = stateWith(DocumentUtils.complexJsonV1)
         val text = state.textFieldValue.text
         val endOfFirst = text.lastIndexOf("item", text.indexOf("Second")) + "item".length
         state.simulateTypingAt(endOfFirst, "\n")
-        val afterFirstEnter = state.textFieldValue
-        val mapping = state.visualTransformation.filter(AnnotatedString(afterFirstEnter.text)).offsetMapping
-        val caretAfterExit = mapping.transformedToOriginal(afterFirstEnter.selection.max)
-        state.simulateTypingAt(caretAfterExit, "\n")
-        val afterSecondEnter = state.textFieldValue
-        val mapping2 = state.visualTransformation.filter(AnnotatedString(afterSecondEnter.text)).offsetMapping
-        val caretForMarker = mapping2.transformedToOriginal(afterSecondEnter.selection.max)
-        state.simulateTypingAt(caretForMarker, "3. ")
-        state.simulateTypingAt(state.textFieldValue.selection.max, "gap")
-        val updated = state.textFieldValue.text
-        val secondIndex = updated.indexOf("Second")
-        val prefixBeforeSecond = updated.substring((secondIndex - 4).coerceAtLeast(0), secondIndex)
-        assertTrue(
-            prefixBeforeSecond.contains("3."),
-            "Second item must be renumbered after re-entering the list, got: $updated"
-        )
-        assertTrue(updated.contains("gap"))
+        // Every caret is derived from the document, not from the engine-returned selection (and
+        // not by feeding the FIELD-space selection through transformedToOriginal, as this test
+        // originally did — that double-mapping overshot by an amount that happened to land
+        // harmlessly for every platform's marker lengths until the kept gutter space (#135)
+        // shifted the arithmetic and the iOS single-tab markers exposed it).
+        // The new empty item renumbers the following items down the list.
+        val afterEnter = state.textFieldValue.text
+        assertTrue(afterEnter.contains("3. Second"), "Second item must renumber below the new item, got: $afterEnter")
+
+        // Enter on the empty item's content start: the item exits the list, and the items after
+        // the split renumber from 1 again.
+        val emptyItem = state.editorSegments().filter { it.gutter != null }[1]
+        state.simulateTypingAt(emptyItem.fieldStart + emptyItem.gutterLength, "\n")
+        val afterExit = state.textFieldValue.text
+        assertTrue(afterExit.contains("1. Second"), "Second item must restart numbering after the split, got: $afterExit")
+        assertTrue(!afterExit.contains("2. \n"), "the empty item's marker must be gone, got: $afterExit")
+
+        // The offset mapping still targets the first item's content correctly.
+        val firstItem = state.editorSegments().first { it.gutter != null }
+        state.simulateTypingAt(firstItem.fieldStart + firstItem.gutterLength, "gap")
+        assertTrue(state.textFieldValue.text.contains("gapFirst item"))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ListItemUiTest.kt
@@ -90,8 +90,11 @@ class ListItemUiTest {
         val fieldText = state.textFieldValue.text
         val transformed = state.visualTransformation.filter(AnnotatedString(fieldText))
         val contentStart = fieldText.indexOf('c')
-        assertEquals(0, transformed.offsetMapping.originalToTransformed(contentStart))
+        // Display position 0 is the marker's kept trailing space (visually zero-width, #135); the
+        // content begins one past it. Both display 0 and 1 resolve back to the field content start.
+        assertEquals(1, transformed.offsetMapping.originalToTransformed(contentStart))
         assertEquals(contentStart, transformed.offsetMapping.transformedToOriginal(0))
+        assertEquals(contentStart, transformed.offsetMapping.transformedToOriginal(1))
     }
 
     @Test

--- a/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/ListGutterIndentRenderTest.kt
+++ b/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/ListGutterIndentRenderTest.kt
@@ -1,0 +1,90 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.use
+import com.jjrodcast.textkit.editor.models.createTextKitConfiguration
+import com.jjrodcast.textkit.theme.TextKitTheme
+import com.jjrodcast.textkit.ui.TextKitEditor
+import com.jjrodcast.textkit.ui.state.TextKitState
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Renders the real editor offscreen and asserts the laid-out geometry of list items (#135).
+ *
+ * Two regressions pinned here, both Skia-target text behaviors the gutter reservation must not
+ * rely on: a paragraph whose display text contains no whitespace never gets its TextIndent
+ * applied (a lone word as a list item rendered at the container edge, under the marker), and a
+ * first-line TextIndent is invisible to the text's intrinsic width (a content-sized field
+ * soft-wrapped its own text mid-word). The display now keeps the marker's trailing space and
+ * that character's advance IS the first-line gutter, so the reserved and rendered widths agree.
+ * These tests measure the actual TextLayoutResult, so they fail on either raw behavior.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class ListGutterIndentRenderTest {
+
+    private fun rendered(state: TextKitState, frames: Int = 3): androidx.compose.ui.text.TextLayoutResult {
+        var time = 0L
+        ImageComposeScene(width = 1600, height = 200) {
+            TextKitTheme { TextKitEditor(state = state) }
+        }.use { scene ->
+            repeat(frames) { time += 16_000_000; scene.render(time) }
+        }
+        return state.textLayoutResult ?: error("no layout")
+    }
+
+    private fun stateOf(word: String) = TextKitState(
+        """{"type":"doc","content":[
+          {"type":"orderedList","attrs":{"start":1},"content":[
+            {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"$word"}]}]}
+          ]}
+        ]}""",
+        createTextKitConfiguration()
+    ).apply { setup() }
+
+    @Test
+    fun a_single_word_list_item_is_indented_past_its_marker() {
+        val layout = rendered(stateOf("loneword"))
+        // display position 1 is the item's first content character — past the gutter, not at the edge
+        assertTrue(layout.getHorizontalPosition(1, true) > 20f, "the item's text must not sit at the container edge")
+    }
+
+    @Test
+    fun a_list_item_never_wraps_short_of_its_available_width() {
+        // A first-line TextIndent is excluded from the intrinsic width, so a content-sized field
+        // used to soft-wrap its own single word mid-word; the kept space's advance is intrinsic.
+        assertTrue(rendered(stateOf("loneword")).lineCount == 1, "lone word must stay on one line")
+        assertTrue(rendered(stateOf("two words")).lineCount == 1, "spaced text must stay on one line")
+    }
+
+    @Test
+    fun converting_a_single_word_line_keeps_the_item_indented() {
+        val state = TextKitState("{}", createTextKitConfiguration()).apply { setup() }
+        fun type(offset: Int, text: String): Int {
+            val before = state.textFieldValue
+            val inserted = before.text.substring(0, offset) + text + before.text.substring(offset)
+            state.onTextFieldChange(TextFieldValue(inserted, TextRange(offset + text.length)))
+            return state.textFieldValue.selection.start
+        }
+        var time = 0L
+        ImageComposeScene(width = 700, height = 200) {
+            TextKitTheme { TextKitEditor(state = state) }
+        }.use { scene ->
+            fun frame() { time += 16_000_000; scene.render(time) }
+            frame()
+            type(0, "loneword")
+            frame()
+            // the user gesture from the issue: caret to line start, type the list pattern
+            var c = type(0, "1")
+            c = type(c, ".")
+            type(c, " ")
+            frame(); frame()
+        }
+        val layout = state.textLayoutResult ?: error("no layout")
+        assertTrue(layout.getHorizontalPosition(1, true) > 20f, "the converted item's text must not sit under the marker")
+        assertTrue(layout.lineCount == 1, "the converted item must not wrap")
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/ListGutterIndentRenderTest.kt
+++ b/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/ListGutterIndentRenderTest.kt
@@ -45,11 +45,21 @@ class ListGutterIndentRenderTest {
         createTextKitConfiguration()
     ).apply { setup() }
 
+    /**
+     * The gutter is 2.75em wide and a line box 1.5em tall, while a bare space advance is ~0.25em —
+     * so "content starts beyond one line height" separates a working gutter from a regressed one
+     * at any font size or density, without a hard-coded pixel threshold.
+     */
+    private fun assertContentClearsTheGutter(layout: androidx.compose.ui.text.TextLayoutResult, message: String) {
+        val lineHeight = layout.getLineBottom(0) - layout.getLineTop(0)
+        assertTrue(layout.getHorizontalPosition(1, true) > lineHeight, message)
+    }
+
     @Test
     fun a_single_word_list_item_is_indented_past_its_marker() {
         val layout = rendered(stateOf("loneword"))
         // display position 1 is the item's first content character — past the gutter, not at the edge
-        assertTrue(layout.getHorizontalPosition(1, true) > 20f, "the item's text must not sit at the container edge")
+        assertContentClearsTheGutter(layout, "the item's text must not sit at the container edge")
     }
 
     @Test
@@ -84,7 +94,7 @@ class ListGutterIndentRenderTest {
             frame(); frame()
         }
         val layout = state.textLayoutResult ?: error("no layout")
-        assertTrue(layout.getHorizontalPosition(1, true) > 20f, "the converted item's text must not sit under the marker")
+        assertContentClearsTheGutter(layout, "the converted item's text must not sit under the marker")
         assertTrue(layout.lineCount == 1, "the converted item must not wrap")
     }
 }


### PR DESCRIPTION
Fixes #135.

**The cause wasn't staleness — it was two Skia text behaviors the gutter reservation relied on.** Rendering the editor offscreen and measuring the actual `TextLayoutResult` reduced it to minimal cases with no TextKit code involved:

1. A paragraph whose display text contains **no whitespace at all** never gets its `TextIndent` applied — `getLineLeft` stays 0 while the layout input plainly declares the indent. Plain `Text` reproduces it. One space anywhere in the paragraph and the indent applies.
2. A first-line `TextIndent` is **invisible to the text's intrinsic width**, so a content-sized field lays its text out narrower than it renders — and soft-wraps it mid-word well short of the available width.

Together they explain everything in the issue and its history. The split gutter layout indented item text with a first-line `TextIndent` sized in em. A lone word as a list item has no whitespace, so behavior 1 dropped the indent and the text sat at the container edge under the marker — but that same dropped indent kept behavior 2 latent. Items *with* spaces kept their indent and were silently living with behavior 2 instead: the early mid-word wrap reproduces on current main with a two-word item. Every "next edit heals it" observation was the edit adding a separator space that flipped the paragraph from case 1 into case 2. The demo document never showed any of it because its items are spaced *and* laid out wide.

**The fix removes the dependency on both behaviors.** Every marker string ends with a real space, which the split layout used to strip from the display. The display now keeps that space, and its character advance — set via letter spacing to the same em width the gutter has always used — **is** the first-line gutter. A real character participates in both the intrinsic width and the rendered layout, so the reserved and rendered geometry agree by construction, and its whitespace guarantees the wrapped-line indent (still `TextIndent`, now `restLine` only, where no intrinsic accounting exists to disagree) always applies. `EditorParagraphSegment` carries an explicit `keptSpace` so the offset mapping stays exact: field-side arithmetic keeps its invariant (content starts after the full marker), the kept space belongs to the gutter side, and a caret on or before it resolves to the item's content start — never inside the marker.

Tests: `ListGutterIndentRenderTest` renders the real editor offscreen (`ImageComposeScene`) and measures the laid-out geometry, failing on either raw behavior: the lone-word item and the type-then-convert gesture from the issue must be indented past the marker, and neither a lone word nor spaced text may wrap short of the available width. The `compose.desktop.currentOs` dependency this needs is jvmTest-only. One existing mapping expectation moved by the one kept character, with the round-trips asserted both ways. Full suite green on jvm, js, and wasmJs; iOS compiles. Verified by hand on the desktop app: conversion, long-word typing, and genuine wrapping all render correctly.

Both underlying behaviors look upstream-worthy — happy to file a minimal repro against Compose Multiplatform if you think it's worth it.
