### PR TITLE
fix: draw gutter markers with the field's line metrics so they sit on the item baseline

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/listlayout/ListItemEditorTransform.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/listlayout/ListItemEditorTransform.kt
@@ -195,7 +195,10 @@ internal fun ListItemEditorGutterOverlay(
     if (markers.isEmpty()) return
 
     Box(modifier = modifier) {
-        val markerStyle = textStyle.copy(color = textColor)
+        // The same line metrics the field's paragraphs use: the marker is positioned at the line
+        // box TOP, and the field centers its glyphs inside the 1.5em line box — without matching
+        // metrics the marker rendered at the box top, visibly above its own item's baseline (#137).
+        val markerStyle = textStyle.copy(color = textColor).withListLineMetrics()
         markers.forEach { marker ->
             Text(
                 text = marker.label,


### PR DESCRIPTION
Fixes #137.

The editor's paragraphs render with a 1.5em line height, center-aligned, so text glyphs sit centered inside a taller line box. The gutter overlay pins each marker `Text` at the line box's top (`getLineTop`) — but that `Text` carried only the base text style, no line metrics, so its glyph rendered at the top of the box while the item's text rendered at the center: every marker floated visibly above its own line's baseline.

The overlay's marker style now goes through the same `withListLineMetrics()` the viewer already uses — identical line height and line-height style to the field's paragraphs — so marker and text share one line box geometry and land on the same baseline.

Verified by rendering the editor offscreen and comparing the marker and text rows pixel-level. Full suite green on jvm, js, and wasmJs; iOS compiles.
