### PR TITLE
fix: consume the pattern's in-document characters when a typed list marker converts

### DIFF
--- a/shared/src/androidMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.android.kt
+++ b/shared/src/androidMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.android.kt
@@ -27,7 +27,7 @@ actual object TextDecoratorTransaction {
         paragraph: PieceParagraph,
         actionModel: TextEditorAction.TextAdded
     ): TextEditorListItemTransaction {
-        val deleteLength = inputResult.model.text.length - (inputResult.model.piece.decorator?.key?.length ?: 0)
+        val deleteLength = TextTransactionsUtils.patternTextInDocumentLength(paragraph)
 
         return TextTransactionsUtils.updateTransaction(
             paragraph.startOffset,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextInsertedTransaction.kt
@@ -2,6 +2,7 @@ package com.jjrodcast.textkit.editor.core.transactions.text
 
 import androidx.compose.ui.text.TextRange
 import com.jjrodcast.textkit.editor.components.TextEditorListItem
+import com.jjrodcast.textkit.editor.core.TextKitEditorManager
 import com.jjrodcast.textkit.editor.core.converters.ListsConverter
 import com.jjrodcast.textkit.editor.core.converters.models.PositionalListItem
 import com.jjrodcast.textkit.editor.core.converters.utils.PositionalListItemUtils
@@ -40,7 +41,8 @@ internal object TextInsertedTransaction {
 
     internal fun addText(
         lines: MultiPieceParagraph,
-        actionModel: TextEditorAction.TextAdded
+        actionModel: TextEditorAction.TextAdded,
+        manager: TextKitEditorManager
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         // The decorator is presentation-only and atomic, so an insert whose offset falls in a
         // decorator region must not splice into it (issue #69; the replace path got the same rule
@@ -64,7 +66,8 @@ internal object TextInsertedTransaction {
                 // piecesInSelectedRange routing sees the content position, not the decorator.
                 return addText(
                     lines.atOffset(contentStart),
-                    actionModel.copy(offset = contentStart, selection = TextRange(contentStart + actionModel.text.length))
+                    actionModel.copy(offset = contentStart, selection = TextRange(contentStart + actionModel.text.length)),
+                    manager
                 )
             }
         }
@@ -82,7 +85,7 @@ internal object TextInsertedTransaction {
         return if (updatedSelectedParagraph != null && isAddingTextToListItem) {
             insertTextInListParagraph(updatedSelectedParagraph, lines, actionModel)
         } else {
-            insertTextInParagraph(updatedSelectedParagraph, lines, actionModel)
+            insertTextInParagraph(updatedSelectedParagraph, lines, actionModel, manager)
         }
     }
 
@@ -145,7 +148,8 @@ internal object TextInsertedTransaction {
     private fun insertTextInParagraph(
         paragraph: PieceParagraph?,
         lines: MultiPieceParagraph,
-        actionModel: TextEditorAction.TextAdded
+        actionModel: TextEditorAction.TextAdded,
+        manager: TextKitEditorManager
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         return when {
             paragraph == null -> insertTextInParagraph(
@@ -160,28 +164,39 @@ internal object TextInsertedTransaction {
                 lines.quoteDecoratorAt(actionModel.offset),
             )
 
-            else -> insertTextInNonEmptyParagraph(paragraph, lines, actionModel)
+            else -> insertTextInNonEmptyParagraph(paragraph, lines, actionModel, manager)
         }
     }
 
     private fun insertTextInNonEmptyParagraph(
         paragraph: PieceParagraph,
         lines: MultiPieceParagraph,
-        actionModel: TextEditorAction.TextAdded
+        actionModel: TextEditorAction.TextAdded,
+        manager: TextKitEditorManager
     ): Pair<TextRange, List<TextEditorListItemTransaction>> {
         // We need to validate if the text added matches with the regex
         val input = matchesListItemPattern(paragraph, actionModel)
         // It matches the regex, so we need to insert the decorator, otherwise just add the text
         return if (input != null) {
+            // The caller's window is built around the collapsed caret, and a caret on an EMPTY
+            // line resolves backward — the paragraph being converted lands in the window's
+            // single-next-paragraph fallback slot and the list items after it are cut off, so the
+            // renumber pass never saw them (issue #138). Fetch the neighborhood from the converted
+            // paragraph's own span instead: it selects the paragraph itself, so the window carries
+            // the full list context on both sides.
+            val reorderLines = manager.transaction.getLineContentWithNeighborParagraphs(
+                paragraph.startOffset,
+                paragraph.endOffset + paragraph.endPiece.length,
+            )
             val insertedDecorator = input.model.piece?.decorator
             val leveledNumberedDecorator = if (insertedDecorator is TextDecoratorModel.NumberDecoratorModel) {
-                val listLevel = numberedListLevelAdjacentTo(lines, paragraph)
+                val listLevel = numberedListLevelAdjacentTo(reorderLines, paragraph)
                 insertedDecorator.copyValue(level = listLevel)
             } else {
                 null
             }
             val reorderedItems = if (leveledNumberedDecorator != null) {
-                TextTransactionsUtils.numberedListReorderAfterPatternInsert(lines, paragraph, leveledNumberedDecorator)
+                TextTransactionsUtils.numberedListReorderAfterPatternInsert(reorderLines, paragraph, leveledNumberedDecorator)
             } else {
                 emptyList()
             }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransaction.kt
@@ -71,7 +71,7 @@ object TextTransaction {
         val (selection, transactions) = when (actionModel) {
             is TextEditorAction.TextAdded -> {
                 val lines = manager.transaction.getLineContentWithNeighborParagraphs(actionModel.offset, actionModel.offset)
-                TextInsertedTransaction.addText(lines, actionModel)
+                TextInsertedTransaction.addText(lines, actionModel, manager)
             }
 
             is TextEditorAction.TextRemoved -> {

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransactionsUtils.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransactionsUtils.kt
@@ -11,6 +11,7 @@ import com.jjrodcast.textkit.editor.core.models.MultiPieceParagraph
 import com.jjrodcast.textkit.editor.core.models.PieceParagraph
 import com.jjrodcast.textkit.editor.core.models.TextEditorModel
 import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel
+import com.jjrodcast.textkit.editor.utils.replaceLineBreakWith
 import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel.Companion.createDecoratorString
 import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel.Companion.toLevel
 import com.jjrodcast.textkit.editor.core.transactions.lists.models.TextEditorDecoratorTransactionType
@@ -54,6 +55,26 @@ internal object TextTransactionsUtils {
      * sequence (e.g. exiting an empty item with Enter, then typing `3. `), renumber the connected
      * block so following siblings stay in order.
      */
+    /**
+     * The characters a just-matched list pattern already occupies in [paragraph] — what the marker
+     * update must consume from the document. The validated line is the paragraph's literal text
+     * plus the inserted text, so the document's share is exactly the paragraph's text (the marker
+     * text for a task item being revalidated, mirroring the selection in matchesListItemPattern),
+     * line breaks excluded. The previous per-platform arithmetic derived this from the NEW marker
+     * string minus its key — i.e. the tab-prefix length — which equals the typed characters only
+     * for a one-character trigger at level one: an insert carrying the whole pattern found nothing
+     * to consume at the offset and instead swallowed the line's terminating break and sheared the
+     * first character off the next item's marker (issue #138).
+     */
+    internal fun patternTextInDocumentLength(paragraph: PieceParagraph): Int {
+        val paragraphText = if (paragraph.startPiece.decorator is TextDecoratorModel.TaskDecoratorModel) {
+            paragraph.startText
+        } else {
+            paragraph.text
+        }
+        return paragraphText.replaceLineBreakWith("").length
+    }
+
     internal fun numberedListReorderAfterPatternInsert(
         lines: MultiPieceParagraph,
         paragraph: PieceParagraph,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransactionsUtils.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextTransactionsUtils.kt
@@ -51,11 +51,6 @@ internal object TextTransactionsUtils {
     }
 
     /**
-     * After the user types a numbered-list marker on a plain paragraph that sits in a numbered
-     * sequence (e.g. exiting an empty item with Enter, then typing `3. `), renumber the connected
-     * block so following siblings stay in order.
-     */
-    /**
      * The characters a just-matched list pattern already occupies in [paragraph] — what the marker
      * update must consume from the document. The validated line is the paragraph's literal text
      * plus the inserted text, so the document's share is exactly the paragraph's text (the marker
@@ -75,6 +70,11 @@ internal object TextTransactionsUtils {
         return paragraphText.replaceLineBreakWith("").length
     }
 
+    /**
+     * After the user types a numbered-list marker on a plain paragraph that sits in a numbered
+     * sequence (e.g. exiting an empty item with Enter, then typing `3. `), renumber the connected
+     * block so following siblings stay in order.
+     */
     internal fun numberedListReorderAfterPatternInsert(
         lines: MultiPieceParagraph,
         paragraph: PieceParagraph,

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/PatternInsertOnEmptyLineTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/PatternInsertOnEmptyLineTest.kt
@@ -1,5 +1,7 @@
 package com.jjrodcast.textkit
 
+import com.jjrodcast.textkit.editor.utils.TABS
+import com.jjrodcast.textkit.editor.utils.TASK_DECORATOR_UNCHECKED_INTERACTIVE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -25,7 +27,8 @@ class PatternInsertOnEmptyLineTest {
       ]}
     ]}"""
 
-    private val healed = "\t\t1. First\n\t\t2. \n\t\t3. Second"
+    // Marker strings are platform-relative: the tab unit and the task glyph differ per target.
+    private val healed = "${TABS}1. First\n${TABS}2. \n${TABS}3. Second"
 
     @Test
     fun a_single_insert_of_the_whole_pattern_converts_without_shearing() {
@@ -52,7 +55,7 @@ class PatternInsertOnEmptyLineTest {
         val emptyLine = e.text.indexOf('\n') + 1
         e.typeText(emptyLine, "-[] ")
         val saved = e.toJson()
-        assertEquals("\t\t1. First\n\t\t-[] \n\t\t1. Second", e.text)
+        assertEquals("${TABS}1. First\n$TABS$TASK_DECORATOR_UNCHECKED_INTERACTIVE\n${TABS}1. Second", e.text)
         assertEquals(saved, editorFrom(saved).toJson())
     }
 
@@ -64,7 +67,7 @@ class PatternInsertOnEmptyLineTest {
         var c = e.typeText(e.text.length, "3").end
         c = e.typeText(c, ".").end
         e.typeText(c, " ")
-        assertEquals("plain\n\t\t3. ", e.text)
+        assertEquals("plain\n${TABS}3. ", e.text)
         assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
     }
 }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/PatternInsertOnEmptyLineTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/PatternInsertOnEmptyLineTest.kt
@@ -1,0 +1,70 @@
+package com.jjrodcast.textkit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Converting a line by typing a list pattern must consume exactly the pattern characters the
+ * document already holds (#138): the update's delete length was derived from the new marker's
+ * tab prefix, which matches the typed characters only for a one-character trigger at level one —
+ * an insert carrying the whole pattern (a paste) found nothing to consume and instead swallowed
+ * the line's terminating break and sheared the first character off the next item's marker. The
+ * renumber pass also lost the items after the caret when the converted line was empty, because
+ * the collapsed-caret window resolves backward there; it now derives from the converted
+ * paragraph's own span.
+ */
+class PatternInsertOnEmptyLineTest {
+
+    private val doc = """{"type":"doc","content":[
+      {"type":"orderedList","attrs":{"start":1},"content":[
+        {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"First"}]}]}
+      ]},
+      {"type":"paragraph","content":[]},
+      {"type":"orderedList","attrs":{"start":1},"content":[
+        {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"Second"}]}]}
+      ]}
+    ]}"""
+
+    private val healed = "\t\t1. First\n\t\t2. \n\t\t3. Second"
+
+    @Test
+    fun a_single_insert_of_the_whole_pattern_converts_without_shearing() {
+        val e = editorFrom(doc)
+        val emptyLine = e.text.indexOf('\n') + 1
+        e.typeText(emptyLine, "3. ")
+        assertEquals(healed, e.text)
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+
+    @Test
+    fun typing_the_pattern_char_by_char_matches_the_single_insert() {
+        val e = editorFrom(doc)
+        var c = e.typeText(e.text.indexOf('\n') + 1, "3").end
+        c = e.typeText(c, ".").end
+        e.typeText(c, " ")
+        assertEquals(healed, e.text)
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+
+    @Test
+    fun a_task_pattern_insert_above_an_item_converts_without_shearing() {
+        val e = editorFrom(doc)
+        val emptyLine = e.text.indexOf('\n') + 1
+        e.typeText(emptyLine, "-[] ")
+        val saved = e.toJson()
+        assertEquals("\t\t1. First\n\t\t-[] \n\t\t1. Second", e.text)
+        assertEquals(saved, editorFrom(saved).toJson())
+    }
+
+    @Test
+    fun typing_the_pattern_at_the_document_end_still_converts() {
+        // Typed character by character: the space triggers with "3." already in the document, the
+        // case the old delete-length arithmetic was tuned to — it must keep working.
+        val e = editorFrom("""{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"plain"}]},{"type":"paragraph","content":[]}]}""")
+        var c = e.typeText(e.text.length, "3").end
+        c = e.typeText(c, ".").end
+        e.typeText(c, " ")
+        assertEquals("plain\n\t\t3. ", e.text)
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+}

--- a/shared/src/iosMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.ios.kt
+++ b/shared/src/iosMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.ios.kt
@@ -24,7 +24,7 @@ actual object TextDecoratorTransaction {
         paragraph: PieceParagraph,
         actionModel: TextEditorAction.TextAdded
     ): TextEditorListItemTransaction {
-        val deleteLength = getDeleteLength(inputResult, actionModel.text.length)
+        val deleteLength = TextTransactionsUtils.patternTextInDocumentLength(paragraph)
 
         return TextTransactionsUtils.updateTransaction(
             paragraph.startOffset,
@@ -33,17 +33,4 @@ actual object TextDecoratorTransaction {
         )
     }
 
-    private fun getDeleteLength(inputResult: TextInputResult, textLength: Int): Int {
-        return when (val decorator = inputResult.model.piece.decorator) {
-            is TextDecoratorModel.TaskDecoratorModel -> {
-                if (decorator.checked) {
-                    TASK_DECORATOR_COMMON.length - textLength
-                } else {
-                    TASK_DECORATOR_UNCHECKED_COMMON.length - textLength
-                }
-            }
-
-            else -> inputResult.model.text.length - (inputResult.model.piece.decorator?.key?.length ?: 0)
-        }
-    }
 }

--- a/shared/src/iosMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.ios.kt
+++ b/shared/src/iosMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.ios.kt
@@ -6,8 +6,6 @@ import com.jjrodcast.textkit.editor.core.models.PieceParagraph
 import com.jjrodcast.textkit.editor.core.piecetable.models.TextDecoratorModel
 import com.jjrodcast.textkit.editor.core.transactions.lists.models.TextEditorListItemTransaction
 import com.jjrodcast.textkit.editor.core.transactions.models.TextEditorAction
-import com.jjrodcast.textkit.editor.utils.TASK_DECORATOR_COMMON
-import com.jjrodcast.textkit.editor.utils.TASK_DECORATOR_UNCHECKED_COMMON
 import com.plangrid.pgfoundation.texteditor.core.validator.TextInputResult
 
 actual object TextDecoratorTransaction {

--- a/shared/src/jvmMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.jvm.kt
@@ -27,7 +27,7 @@ actual object TextDecoratorTransaction {
         paragraph: PieceParagraph,
         actionModel: TextEditorAction.TextAdded
     ): TextEditorListItemTransaction {
-        val deleteLength = inputResult.model.text.length - (inputResult.model.piece.decorator?.key?.length ?: 0)
+        val deleteLength = TextTransactionsUtils.patternTextInDocumentLength(paragraph)
 
         return TextTransactionsUtils.updateTransaction(
             paragraph.startOffset,

--- a/shared/src/webMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.web.kt
+++ b/shared/src/webMain/kotlin/com/jjrodcast/textkit/editor/core/transactions/text/TextDecoratorTransaction.web.kt
@@ -27,7 +27,7 @@ actual object TextDecoratorTransaction {
         paragraph: PieceParagraph,
         actionModel: TextEditorAction.TextAdded
     ): TextEditorListItemTransaction {
-        val deleteLength = inputResult.model.text.length - (inputResult.model.piece.decorator?.key?.length ?: 0)
+        val deleteLength = TextTransactionsUtils.patternTextInDocumentLength(paragraph)
 
         return TextTransactionsUtils.updateTransaction(
             paragraph.startOffset,


### PR DESCRIPTION
Fixes #138.

**Two defects met in the pattern-conversion path.**

**1. The marker update deleted the wrong thing.** When a typed `n. ` pattern converts a line into a list item, the update that swaps the literal text for the marker computed its delete length as *new marker string minus its key* — i.e. the tab-prefix length. That equals the characters actually sitting in the document only for a one-character trigger at level one with a two-tab indent unit: three coincidences. An insert carrying the whole pattern at once (a paste, or any programmatic insert) has *nothing* in the document to consume, so the update deleted two characters of what followed instead — the empty line's terminating break and the first tab of the next item's marker, which is precisely the shear from the issue. The delete length is now the principled value: the validated line's literal text already in the paragraph (the whole line *is* the pattern when the validator matches), so a paste consumes zero, char-by-char typing consumes the typed prefix, and nested levels and iOS's one-tab indent unit stop depending on the coincidences. All four platform actuals now share one helper — the iOS actual had already grown a corrected special case for task markers, which this subsumes.

**2. The renumber pass couldn't see past an empty line.** The reorder that renumbers following items worked on the caller's caret window — and a collapsed caret on an *empty* line resolves backward, so the paragraph being converted sat in the window's single-next-paragraph fallback slot and the items after it were cut off: the pasted pattern converted but the list below kept its old numbers. The neighborhood is now refetched from the converted paragraph's own span, which selects the paragraph itself and carries the full list context on both sides. Char-by-char and single-insert conversion now produce byte-identical results.

Tests: `PatternInsertOnEmptyLineTest` pins the paste shape from the issue (exact text plus round trip), char-by-char equivalence, the task-pattern variant, and the document-end conversion the old arithmetic was tuned to. Full suite green on jvm, js, and wasmJs (stress sweep and pinned seeds included); iOS compiles.
