### PR TITLE
fix: propagate the caller's minimum constraints into the outlined editor's decoration

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEditor.kt
@@ -205,7 +205,11 @@ fun TextKitEditorOutlined(
         textStyle = TextStyle(color = TextKitTheme.colors.onSurface),
         cursorBrush = SolidColor(TextKitTheme.colors.primary),
         decorationBox = { innerTextField ->
-            Box {
+            // Propagate the incoming minimum constraints: when the caller sizes the editor
+            // (Modifier.weight in a Column, fillMaxHeight, a fixed size), the decoration must fill
+            // that area — a plain Box measures its children loosely, so the outlined container
+            // wrapped its placeholder in a corner of the allotted space instead (issue #143).
+            Box(propagateMinConstraints = true) {
                 OutlinedTextFieldDefaults.DecorationBox(
                     value = state.textFieldValue.text,
                     innerTextField = innerTextField,

--- a/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/OutlinedEditorSizingTest.kt
+++ b/shared/src/jvmTest/kotlin/com/jjrodcast/textkit/OutlinedEditorSizingTest.kt
@@ -1,0 +1,49 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.use
+import com.jjrodcast.textkit.editor.models.createTextKitConfiguration
+import com.jjrodcast.textkit.theme.TextKitTheme
+import com.jjrodcast.textkit.ui.TextKitEditorOutlined
+import com.jjrodcast.textkit.ui.state.TextKitState
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The outlined editor must fill the area its caller gives it (#143): the decoration Box measured
+ * its children loosely, so under `Modifier.weight(1f)` — which hands the editor a minimum size —
+ * the outlined container wrapped its placeholder in a corner of the allotted space. The inner
+ * text field's layout constraints are the observable: when the decoration fills, the field is
+ * measured against (nearly) the full weighted area; when it wraps, against a placeholder-sized box.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class OutlinedEditorSizingTest {
+
+    @Test
+    fun a_weighted_outlined_editor_fills_its_allotted_area() {
+        val state = TextKitState("{}", createTextKitConfiguration()).apply { setup() }
+        var time = 0L
+        ImageComposeScene(width = 500, height = 860) {
+            TextKitTheme {
+                Column(Modifier.fillMaxSize()) {
+                    TextKitEditorOutlined(
+                        state = state,
+                        modifier = Modifier.weight(1f).padding(16.dp)
+                    )
+                }
+            }
+        }.use { scene -> repeat(3) { time += 16_000_000; scene.render(time) } }
+
+        // The propagated minimum reaches the inner field as a TIGHT width spanning the weighted
+        // area (the un-fixed decoration measured it against a placeholder-sized box instead). The
+        // field's height stays unbounded inside the decoration — the decoration itself clips.
+        val constraints = state.textLayoutResult?.layoutInput?.constraints ?: error("no layout")
+        assertTrue(constraints.minWidth > 300, "field must span the weighted width, got $constraints")
+    }
+}


### PR DESCRIPTION
Fixes #143.

Reproduced the report offscreen: a `TextKitEditorOutlined` given `Modifier.weight(1f)` in a `Column` takes its full allotted area as a layout node, but the visible field wraps its placeholder in the top-left corner — exactly the screenshot in the issue.

The cause is one layer down from the field: the decoration wraps `OutlinedTextFieldDefaults.DecorationBox` in a plain `Box`, and a plain `Box` measures its children *loosely* — the minimum size the caller handed the editor (a weight, `fillMaxHeight`, any fixed size) stopped at the Box and never reached the decoration, so the outlined container sized itself to its content. The Box now propagates its minimum constraints, and the decoration fills whatever the caller allots. Without an imposed minimum nothing changes: the unweighted editor still wraps to a single-row field, verified against the same offscreen scene.

Tests: `OutlinedEditorSizingTest` renders the weighted layout from the issue and asserts the inner text field is measured against the full weighted width (a tight constraint only the propagated minimum can produce — the un-fixed decoration measured it against a placeholder-sized box). Full suite green on jvm, js, and wasmJs; iOS compiles.


@magic-cucumber this should fix your report — if you can try the branch with your `weight(1f)` layout, a confirmation would be very welcome.
