### PR TITLE
feat: import GitHub Flavored Markdown as document JSON

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/markdown/MarkdownParser.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/markdown/MarkdownParser.kt
@@ -52,7 +52,7 @@ fun markdownToJson(markdown: String): String =
 internal class MarkdownParser {
 
     fun parse(markdown: String): TextEditorDocument =
-        TextEditorDocument(parseBlocks(markdown.replace("\r\n", "\n").split("\n")))
+        TextEditorDocument(parseBlocks(markdown.replace("\r\n", "\n").replace('\r', '\n').split("\n")))
 
     // ── Blocks ───────────────────────────────────────────────────────────────
 
@@ -411,7 +411,9 @@ internal class MarkdownParser {
         if (tag.isEmpty() || !(tag[0].isLetter() || tag[0] == '/')) return 0
 
         val name = tag.trimStart('/').substringBefore(' ').trimEnd('/').lowercase()
-        if (name == "br") {
+        // Only an opening/void <br> is a break; a stray closing </br> is invalid HTML and is
+        // stripped like any other unknown tag.
+        if (name == "br" && !tag.startsWith("/")) {
             flush()
             out += HardBreak(marks = marks)
             return tagEnd - i + 1

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/markdown/MarkdownParser.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/markdown/MarkdownParser.kt
@@ -1,0 +1,543 @@
+package com.jjrodcast.textkit.editor.core.markdown
+
+import com.jjrodcast.textkit.editor.core.parser.BaseParagraph
+import com.jjrodcast.textkit.editor.core.parser.BaseText
+import com.jjrodcast.textkit.editor.core.parser.Blockquote
+import com.jjrodcast.textkit.editor.core.parser.BoldMark
+import com.jjrodcast.textkit.editor.core.parser.BulletedList
+import com.jjrodcast.textkit.editor.core.parser.EmbedBlock
+import com.jjrodcast.textkit.editor.core.parser.EmbedTypes
+import com.jjrodcast.textkit.editor.core.parser.HardBreak
+import com.jjrodcast.textkit.editor.core.parser.Heading
+import com.jjrodcast.textkit.editor.core.parser.HeadingAttrs
+import com.jjrodcast.textkit.editor.core.parser.HeadingLevels
+import com.jjrodcast.textkit.editor.core.parser.HighlightMark
+import com.jjrodcast.textkit.editor.core.parser.ItalicMark
+import com.jjrodcast.textkit.editor.core.parser.LinkAttrs
+import com.jjrodcast.textkit.editor.core.parser.LinkMark
+import com.jjrodcast.textkit.editor.core.parser.ListAttrs
+import com.jjrodcast.textkit.editor.core.parser.ListItem
+import com.jjrodcast.textkit.editor.core.parser.Mark
+import com.jjrodcast.textkit.editor.core.parser.OrderedList
+import com.jjrodcast.textkit.editor.core.parser.Paragraph
+import com.jjrodcast.textkit.editor.core.parser.StrikeMark
+import com.jjrodcast.textkit.editor.core.parser.TEXT_EDITOR_JSON
+import com.jjrodcast.textkit.editor.core.parser.TaskList
+import com.jjrodcast.textkit.editor.core.parser.TaskListAttrs
+import com.jjrodcast.textkit.editor.core.parser.TaskListItem
+import com.jjrodcast.textkit.editor.core.parser.Text
+import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
+import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Converts GitHub Flavored Markdown to the editor's document JSON — the inverse of
+ * `MarkdownSerializer`, targeting exactly the subset that exporter emits so that
+ * `markdownToJson(toMarkdown())` preserves every structure the two sides share.
+ *
+ * Like the export, the import is **lossy but text-safe**: anything the subset does not cover
+ * degrades to its plain text, never to dropped content. Concretely — unknown inline HTML tags are
+ * stripped around their content (`<u>`/`<mark>`/`<br>` are recognized, restoring underline,
+ * highlight and hard breaks), a code span keeps its inner text, an inline image degrades to its
+ * alt text, and any line no block rule claims is a paragraph. Soft line breaks inside a paragraph
+ * join with a space, the CommonMark rendering.
+ */
+fun markdownToJson(markdown: String): String =
+    TEXT_EDITOR_JSON.encodeToString(TextEditorDocument.serializer(), MarkdownParser().parse(markdown))
+
+internal class MarkdownParser {
+
+    fun parse(markdown: String): TextEditorDocument =
+        TextEditorDocument(parseBlocks(markdown.replace("\r\n", "\n").split("\n")))
+
+    // ── Blocks ───────────────────────────────────────────────────────────────
+
+    private fun parseBlocks(lines: List<String>): List<BaseParagraph> {
+        val blocks = mutableListOf<BaseParagraph>()
+        var i = 0
+        while (i < lines.size) {
+            val line = lines[i]
+            when {
+                line.isBlank() -> i++
+
+                isTable(lines, i) -> i = parseTable(lines, i, blocks)
+
+                HEADING.matches(line) -> {
+                    val (hashes, rest) = HEADING.find(line)!!.destructured
+                    val level = hashes.length.coerceIn(HeadingLevels.H1, HeadingLevels.H6)
+                    blocks += Heading(attrs = HeadingAttrs(level = level), content = inline(rest))
+                    i++
+                }
+
+                isQuote(line) -> i = parseQuote(lines, i, blocks)
+
+                listMarker(line, indent = 0) != null -> i = parseList(lines, i, indent = 0, blocks)
+
+                IMAGE_LINE.matches(line) -> {
+                    val (alt, dest) = IMAGE_LINE.find(line)!!.destructured
+                    blocks += imageEmbed(unescape(alt), unescapeDestination(dest))
+                    i++
+                }
+
+                else -> i = parseParagraph(lines, i, blocks)
+            }
+        }
+        return blocks
+    }
+
+    private fun parseParagraph(lines: List<String>, start: Int, blocks: MutableList<BaseParagraph>): Int {
+        var i = start
+        val run = mutableListOf<String>()
+        while (i < lines.size) {
+            val line = lines[i]
+            if (line.isBlank() || HEADING.matches(line) || isQuote(line) ||
+                listMarker(line, indent = 0) != null || isTable(lines, i)
+            ) break
+            run += line.trim()
+            i++
+        }
+        // Soft breaks join with a space (CommonMark); an explicit <br> in the text becomes a
+        // HardBreak in the inline pass.
+        val content = inline(run.joinToString(separator = " "))
+        if (content.isNotEmpty()) blocks += Paragraph(content = content)
+        return i
+    }
+
+    // ── Blockquote ───────────────────────────────────────────────────────────
+
+    private fun isQuote(line: String) = line.startsWith(">")
+
+    /** Consecutive `> `-prefixed lines (a bare `>` is a blank line inside the quote) unwrap one
+     *  marker level and re-enter the block parser, so nested structure stays quoted. */
+    private fun parseQuote(lines: List<String>, start: Int, blocks: MutableList<BaseParagraph>): Int {
+        var i = start
+        val inner = mutableListOf<String>()
+        while (i < lines.size && isQuote(lines[i])) {
+            inner += lines[i].removePrefix(">").removePrefix(" ")
+            i++
+        }
+        val content = parseBlocks(inner)
+        if (content.isNotEmpty()) blocks += Blockquote(content = content)
+        return i
+    }
+
+    // ── Lists ────────────────────────────────────────────────────────────────
+
+    private enum class ListKind { Bullet, Ordered, Task }
+
+    private data class ListRow(val kind: ListKind, val checked: Boolean, val number: Int, val lead: String)
+
+    /** The marker at exactly [indent] leading spaces, or null when the line is not a list row. */
+    private fun listMarker(line: String, indent: Int): ListRow? {
+        if (line.length <= indent || !line.startsWith(" ".repeat(indent))) return null
+        val body = line.substring(indent)
+        if (body.startsWith(" ")) return null
+        TASK.find(body)?.let { return ListRow(ListKind.Task, it.groupValues[1].lowercase() == "x", 0, it.groupValues[2]) }
+        BULLET.find(body)?.let { return ListRow(ListKind.Bullet, false, 0, it.groupValues[1]) }
+        ORDERED.find(body)?.let { return ListRow(ListKind.Ordered, false, it.groupValues[1].toIntOrNull() ?: 1, it.groupValues[2]) }
+        return null
+    }
+
+    /**
+     * A run of list rows at [indent]. Every row's continuation — the lines indented one level
+     * deeper, whether they follow directly (a tight sublist) or after a blank line (any other
+     * nested block) — is dedented and re-enters the block parser as the item's further content.
+     * Consecutive rows of the same kind group into one list node; a kind switch starts a new list.
+     */
+    private fun parseList(lines: List<String>, start: Int, indent: Int, blocks: MutableList<BaseParagraph>): Int {
+        var i = start
+        var kind: ListKind? = null
+        var startNumber = 1
+        val items = mutableListOf<BaseText>()
+
+        fun flush() {
+            when (kind) {
+                ListKind.Bullet -> blocks += BulletedList(content = items.toList())
+                ListKind.Ordered -> blocks += OrderedList(attrs = ListAttrs(start = startNumber), content = items.toList())
+                ListKind.Task -> blocks += TaskList(content = items.toList())
+                null -> Unit
+            }
+            items.clear()
+        }
+
+        while (i < lines.size) {
+            val row = listMarker(lines[i], indent) ?: break
+            i++
+            val continuation = mutableListOf<String>()
+            val deeper = indent + NESTED_INDENT
+            while (i < lines.size) {
+                val next = lines[i]
+                when {
+                    next.length > deeper && next.startsWith(" ".repeat(deeper)) -> {
+                        continuation += next.substring(deeper)
+                        i++
+                    }
+                    // A blank line continues the item only when deeper-indented content follows.
+                    next.isBlank() && i + 1 < lines.size &&
+                        lines[i + 1].length > deeper && lines[i + 1].startsWith(" ".repeat(deeper)) -> {
+                        continuation += ""
+                        i++
+                    }
+                    else -> break
+                }
+            }
+            val children = mutableListOf<BaseParagraph>(Paragraph(content = inline(row.lead)))
+            children += parseBlocks(continuation)
+
+            if (kind != null && kind != row.kind) flush()
+            if (items.isEmpty()) startNumber = row.number.coerceAtLeast(1)
+            kind = row.kind
+            items += when (row.kind) {
+                ListKind.Task -> TaskListItem(attrs = TaskListAttrs(checked = row.checked), content = children)
+                else -> ListItem(content = children)
+            }
+        }
+        flush()
+        return i
+    }
+
+    // ── Tables ───────────────────────────────────────────────────────────────
+
+    /** A `|` row directly followed by a `--- | ---` delimiter row opens a GFM table. */
+    private fun isTable(lines: List<String>, i: Int): Boolean =
+        i + 1 < lines.size && lines[i].trimStart().startsWith("|") && DELIMITER_ROW.matches(lines[i + 1])
+
+    private fun parseTable(lines: List<String>, start: Int, blocks: MutableList<BaseParagraph>): Int {
+        var i = start
+        val rows = mutableListOf<List<String>>()
+        while (i < lines.size && lines[i].trimStart().startsWith("|")) {
+            if (i != start + 1) rows += splitCells(lines[i])
+            i++
+        }
+        val columns = rows.maxOfOrNull { it.size } ?: return i
+        val raw = buildJsonObject {
+            put("type", EmbedTypes.Table)
+            put("content", buildJsonArray {
+                rows.forEachIndexed { rowIndex, cells ->
+                    add(tableRow(cells, columns, header = rowIndex == 0))
+                }
+            })
+        }
+        blocks += EmbedBlock(embedType = EmbedTypes.Table, id = EmbedTypes.Table, raw = raw)
+        return i
+    }
+
+    private fun tableRow(cells: List<String>, columns: Int, header: Boolean): JsonElement = buildJsonObject {
+        put("type", "tableRow")
+        put("content", buildJsonArray {
+            repeat(columns) { index ->
+                add(buildJsonObject {
+                    put("type", if (header) "tableHeader" else "tableCell")
+                    put("attrs", buildJsonObject {
+                        put("colspan", 1)
+                        put("rowspan", 1)
+                        put("colwidth", JsonNull)
+                    })
+                    put("content", buildJsonArray {
+                        add(
+                            TEXT_EDITOR_JSON.encodeToJsonElement(
+                                Paragraph.serializer(),
+                                Paragraph(content = inline(cells.getOrElse(index) { "" })),
+                            )
+                        )
+                    })
+                })
+            }
+        })
+    }
+
+    /** The cells of one `| a | b |` row; edge pipes are dropped, escaped `\|` stays literal. */
+    private fun splitCells(line: String): List<String> {
+        val cells = mutableListOf<String>()
+        val sb = StringBuilder()
+        var i = 0
+        val row = line.trim().removePrefix("|").removeSuffix("|")
+        while (i < row.length) {
+            val ch = row[i]
+            when {
+                ch == '\\' && i + 1 < row.length -> {
+                    sb.append(ch).append(row[i + 1])
+                    i += 2
+                }
+                ch == '|' -> {
+                    cells += sb.toString().trim()
+                    sb.clear()
+                    i++
+                }
+                else -> {
+                    sb.append(ch)
+                    i++
+                }
+            }
+        }
+        cells += sb.toString().trim()
+        return cells
+    }
+
+    // ── Embeds ───────────────────────────────────────────────────────────────
+
+    private fun imageEmbed(alt: String, src: String): EmbedBlock {
+        val raw = buildJsonObject {
+            put("type", EmbedTypes.Image)
+            put("attrs", buildJsonObject {
+                put("src", src)
+                put("alt", alt)
+            })
+        }
+        return EmbedBlock(embedType = EmbedTypes.Image, id = EmbedTypes.Image, raw = raw)
+    }
+
+    // ── Inline ───────────────────────────────────────────────────────────────
+
+    private fun inline(text: String): List<BaseText> {
+        val out = mutableListOf<BaseText>()
+        parseInline(text, 0, text.length, emptySet(), out)
+        return out
+    }
+
+    private fun parseInline(s: String, start: Int, end: Int, marks: Set<Mark>, out: MutableList<BaseText>) {
+        val sb = StringBuilder()
+        fun flush() {
+            if (sb.isNotEmpty()) {
+                out += Text(text = sb.toString(), marks = marks)
+                sb.clear()
+            }
+        }
+
+        var i = start
+        while (i < end) {
+            val ch = s[i]
+            when {
+                ch == '\\' && i + 1 < end -> {
+                    sb.append(s[i + 1])
+                    i += 2
+                }
+
+                ch == '&' -> {
+                    val entity = ENTITIES.entries.firstOrNull { s.startsWith(it.key, i) }
+                    if (entity != null) {
+                        sb.append(entity.value)
+                        i += entity.key.length
+                    } else {
+                        sb.append(ch)
+                        i++
+                    }
+                }
+
+                ch == '<' -> {
+                    val consumed = htmlToken(s, i, end, marks, out, sb, ::flush)
+                    if (consumed > 0) i += consumed else { sb.append(ch); i++ }
+                }
+
+                ch == '`' -> {
+                    // A code span's inner text verbatim — the editor has no code mark, so the
+                    // content survives as plain text (the documented degrade).
+                    val close = indexOfUnescaped(s, '`', i + 1, end)
+                    if (close >= 0) {
+                        sb.append(s, i + 1, close)
+                        i = close + 1
+                    } else {
+                        sb.append(ch)
+                        i++
+                    }
+                }
+
+                ch == '!' && i + 1 < end && s[i + 1] == '[' -> {
+                    // An inline image degrades to its alt text (block-level images are embeds).
+                    val link = linkSpan(s, i + 1, end)
+                    if (link != null) {
+                        parseInline(s, i + 2, link.labelEnd, marks, out.alsoFlush(sb, marks))
+                        i = link.destEnd + 1
+                    } else {
+                        sb.append(ch)
+                        i++
+                    }
+                }
+
+                ch == '[' -> {
+                    val link = linkSpan(s, i, end)
+                    if (link != null) {
+                        flush()
+                        val href = unescapeDestination(s.substring(link.destStart, link.destEnd))
+                        parseInline(s, i + 1, link.labelEnd, marks + LinkMark(LinkAttrs(href = href)), out)
+                        i = link.destEnd + 1
+                    } else {
+                        sb.append(ch)
+                        i++
+                    }
+                }
+
+                ch == '*' || ch == '_' || ch == '~' -> {
+                    val run = delimiterRun(s, i, end, ch)
+                    val consumed = if (run > 0) emphasis(s, i, end, ch, run, marks, out, sb, ::flush) else 0
+                    if (consumed > 0) i += consumed else { sb.append(ch); i++ }
+                }
+
+                else -> {
+                    sb.append(ch)
+                    i++
+                }
+            }
+        }
+        flush()
+    }
+
+    private fun MutableList<BaseText>.alsoFlush(sb: StringBuilder, marks: Set<Mark>): MutableList<BaseText> {
+        if (sb.isNotEmpty()) {
+            this += Text(text = sb.toString(), marks = marks)
+            sb.clear()
+        }
+        return this
+    }
+
+    /** `<br>`, `<u>…</u>`, `<mark>…</mark>` are meaningful; any other tag is stripped around its
+     *  content. Returns the characters consumed, or 0 when this `<` is not a tag at all. */
+    private fun htmlToken(
+        s: String,
+        i: Int,
+        end: Int,
+        marks: Set<Mark>,
+        out: MutableList<BaseText>,
+        sb: StringBuilder,
+        flush: () -> Unit,
+    ): Int {
+        val tagEnd = s.indexOf('>', i + 1)
+        if (tagEnd < 0 || tagEnd >= end) return 0
+        val tag = s.substring(i + 1, tagEnd)
+        if (tag.isEmpty() || !(tag[0].isLetter() || tag[0] == '/')) return 0
+
+        val name = tag.trimStart('/').substringBefore(' ').trimEnd('/').lowercase()
+        if (name == "br") {
+            flush()
+            out += HardBreak(marks = marks)
+            return tagEnd - i + 1
+        }
+        val mark = when (name) {
+            "u" -> UnderlineMark()
+            "mark" -> HighlightMark()
+            else -> null
+        }
+        if (mark != null && !tag.startsWith("/")) {
+            val close = s.indexOf("</$name>", tagEnd + 1)
+            if (close in 0 until end) {
+                flush()
+                parseInline(s, tagEnd + 1, close, marks + mark, out)
+                return close + name.length + 3 - i
+            }
+        }
+        // Unknown tag (or an unmatched known one): strip the tag, keep the content flowing.
+        return tagEnd - i + 1
+    }
+
+    private data class LinkSpan(val labelEnd: Int, val destStart: Int, val destEnd: Int)
+
+    /** `[label](dest)` starting at [i] (which must hold `[`), or null when it does not close. */
+    private fun linkSpan(s: String, i: Int, end: Int): LinkSpan? {
+        val labelEnd = indexOfUnescaped(s, ']', i + 1, end)
+        if (labelEnd < 0 || labelEnd + 1 >= end || s[labelEnd + 1] != '(') return null
+        val destEnd = indexOfUnescaped(s, ')', labelEnd + 2, end)
+        if (destEnd < 0) return null
+        return LinkSpan(labelEnd = labelEnd, destStart = labelEnd + 2, destEnd = destEnd)
+    }
+
+    /**
+     * An emphasis span: `**`/`__` bold, `*`/`_` italic, `~~` strikethrough. The opener must touch
+     * the following text and the closer the preceding text; an `_` opener additionally requires a
+     * non-word character before it, so snake_case stays literal. Returns the characters consumed,
+     * or 0 when no valid closer exists and the delimiter is literal text.
+     */
+    private fun emphasis(
+        s: String,
+        i: Int,
+        end: Int,
+        ch: Char,
+        run: Int,
+        marks: Set<Mark>,
+        out: MutableList<BaseText>,
+        sb: StringBuilder,
+        flush: () -> Unit,
+    ): Int {
+        val length = if (ch == '~') 2 else minOf(run, 2)
+        if (ch == '~' && run < 2) return 0
+        if (i + length >= end || s[i + length].isWhitespace()) return 0
+        if (ch == '_' && i > 0 && s[i - 1].isLetterOrDigit()) return 0
+
+        val delimiter = ch.toString().repeat(length)
+        var close = indexOfUnescaped(s, ch, i + length, end)
+        while (close >= 0) {
+            if (s.startsWith(delimiter, close) && !s[close - 1].isWhitespace()) break
+            close = indexOfUnescaped(s, ch, close + 1, end)
+        }
+        if (close < 0 || close == i + length) return 0
+
+        val mark = when {
+            ch == '~' -> StrikeMark()
+            length == 2 -> BoldMark()
+            else -> ItalicMark()
+        }
+        flush()
+        parseInline(s, i + length, close, marks + mark, out)
+        return close + length - i
+    }
+
+    private fun delimiterRun(s: String, i: Int, end: Int, ch: Char): Int {
+        var run = 0
+        while (i + run < end && s[i + run] == ch) run++
+        return run
+    }
+
+    /** The first [target] at or after [from] that is not backslash-escaped, or -1. */
+    private fun indexOfUnescaped(s: String, target: Char, from: Int, end: Int): Int {
+        var i = from
+        while (i < end) {
+            when {
+                s[i] == '\\' -> i += 2
+                s[i] == target -> return i
+                else -> i++
+            }
+        }
+        return -1
+    }
+
+    private fun unescape(text: String): String = buildString {
+        var i = 0
+        while (i < text.length) {
+            if (text[i] == '\\' && i + 1 < text.length) {
+                append(text[i + 1])
+                i += 2
+            } else {
+                append(text[i])
+                i++
+            }
+        }
+    }
+
+    private fun unescapeDestination(dest: String): String = unescape(dest.trim())
+
+    private companion object {
+        val HEADING = Regex("""^(#{1,6}) (.*)$""")
+        // Literal `]` stays escaped everywhere: the JS RegExp `u` flag rejects a lone bracket
+        // that the JVM engine accepts ("Lone quantifier brackets").
+        val TASK = Regex("""^- \[([ xX])\] (.*)$""")
+        val BULLET = Regex("""^[-*+] (.*)$""")
+        val ORDERED = Regex("""^(\d+)[.)] (.*)$""")
+        val IMAGE_LINE = Regex("""^!\[(.*)\]\((.*)\)\s*$""")
+        val DELIMITER_ROW = Regex("""^\s*\|?[\s:\-|]*-[\s:\-|]*\|?\s*$""")
+
+        /** One nesting level of the exporter's indented item content. */
+        const val NESTED_INDENT = 4
+
+        val ENTITIES = mapOf(
+            "&amp;" to "&",
+            "&lt;" to "<",
+            "&gt;" to ">",
+            "&quot;" to "\"",
+            "&#39;" to "'",
+            "&nbsp;" to " ",
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MarkdownImportTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MarkdownImportTest.kt
@@ -13,6 +13,7 @@ import com.jjrodcast.textkit.editor.core.parser.HighlightMark
 import com.jjrodcast.textkit.editor.core.parser.ItalicMark
 import com.jjrodcast.textkit.editor.core.parser.LinkMark
 import com.jjrodcast.textkit.editor.core.parser.ListItem
+import com.jjrodcast.textkit.editor.core.parser.Mark
 import com.jjrodcast.textkit.editor.core.parser.OrderedList
 import com.jjrodcast.textkit.editor.core.parser.Paragraph
 import com.jjrodcast.textkit.editor.core.parser.StrikeMark
@@ -47,6 +48,15 @@ class MarkdownImportTest {
         assertEquals(1, assertIs<Heading>(doc.content[0]).attrs.level)
         assertEquals(6, assertIs<Heading>(doc.content[1]).attrs.level)
         assertEquals("One", (assertIs<Heading>(doc.content[0]).content.single() as Text).text)
+    }
+
+    @Test
+    fun lone_carriage_returns_are_line_endings_and_a_closing_br_is_not_a_break() {
+        val doc = parse("one\rtwo\r\nthree")
+        assertEquals(1, doc.content.size)
+        assertEquals("one two three", (assertIs<Paragraph>(doc.content[0]).content.single() as Text).text)
+        val p = firstParagraph("a</br>b")
+        assertEquals("ab", (p.content.single() as Text).text)
     }
 
     @Test
@@ -120,9 +130,9 @@ class MarkdownImportTest {
     @Test
     fun emphasis_marks_nest_and_combine() {
         val p = firstParagraph("**bold _both_** and ~~gone~~")
-        assertEquals(setOf<Any>(BoldMark()), (p.content[0] as Text).marks)
+        assertEquals(setOf<Mark>(BoldMark()), (p.content[0] as Text).marks)
         assertEquals(setOf(BoldMark(), ItalicMark()), (p.content[1] as Text).marks)
-        assertEquals(setOf<Any>(StrikeMark()), (p.content[3] as Text).marks)
+        assertEquals(setOf<Mark>(StrikeMark()), (p.content[3] as Text).marks)
     }
 
     @Test
@@ -142,8 +152,8 @@ class MarkdownImportTest {
     @Test
     fun the_html_fallbacks_restore_their_marks() {
         val p = firstParagraph("<u>under</u> and <mark>lit</mark>")
-        assertEquals(setOf<Any>(UnderlineMark()), (p.content[0] as Text).marks)
-        assertEquals(setOf<Any>(HighlightMark()), (p.content[2] as Text).marks)
+        assertEquals(setOf<Mark>(UnderlineMark()), (p.content[0] as Text).marks)
+        assertEquals(setOf<Mark>(HighlightMark()), (p.content[2] as Text).marks)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MarkdownImportTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/MarkdownImportTest.kt
@@ -1,0 +1,235 @@
+package com.jjrodcast.textkit
+
+import com.jjrodcast.textkit.editor.core.export.MarkdownSerializer
+import com.jjrodcast.textkit.editor.core.markdown.MarkdownParser
+import com.jjrodcast.textkit.editor.core.markdown.markdownToJson
+import com.jjrodcast.textkit.editor.core.parser.Blockquote
+import com.jjrodcast.textkit.editor.core.parser.BoldMark
+import com.jjrodcast.textkit.editor.core.parser.BulletedList
+import com.jjrodcast.textkit.editor.core.parser.EmbedBlock
+import com.jjrodcast.textkit.editor.core.parser.HardBreak
+import com.jjrodcast.textkit.editor.core.parser.Heading
+import com.jjrodcast.textkit.editor.core.parser.HighlightMark
+import com.jjrodcast.textkit.editor.core.parser.ItalicMark
+import com.jjrodcast.textkit.editor.core.parser.LinkMark
+import com.jjrodcast.textkit.editor.core.parser.ListItem
+import com.jjrodcast.textkit.editor.core.parser.OrderedList
+import com.jjrodcast.textkit.editor.core.parser.Paragraph
+import com.jjrodcast.textkit.editor.core.parser.StrikeMark
+import com.jjrodcast.textkit.editor.core.parser.TaskList
+import com.jjrodcast.textkit.editor.core.parser.Text
+import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The Markdown importer (#142, phase 1): GFM subset → document model, the inverse of
+ * [MarkdownSerializer]. The per-construct tests pin the mapping; the fixed-point tests assert
+ * that for exporter-canonical Markdown, `export(parse(M)) == M` — every structure the two sides
+ * share survives a full round trip.
+ */
+class MarkdownImportTest {
+
+    private fun parse(md: String) = MarkdownParser().parse(md)
+
+    private fun firstParagraph(md: String): Paragraph {
+        val doc = parse(md)
+        return assertIs<Paragraph>(doc.content.first())
+    }
+
+    // ── Blocks ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun headings_map_their_level() {
+        val doc = parse("# One\n\n###### Six")
+        assertEquals(1, assertIs<Heading>(doc.content[0]).attrs.level)
+        assertEquals(6, assertIs<Heading>(doc.content[1]).attrs.level)
+        assertEquals("One", (assertIs<Heading>(doc.content[0]).content.single() as Text).text)
+    }
+
+    @Test
+    fun paragraph_lines_join_with_a_space_and_br_hard_breaks() {
+        val p = firstParagraph("first line\nsecond line")
+        assertEquals("first line second line", (p.content.single() as Text).text)
+
+        val withBreak = firstParagraph("above<br>below")
+        assertEquals(3, withBreak.content.size)
+        assertIs<HardBreak>(withBreak.content[1])
+    }
+
+    @Test
+    fun blockquote_groups_consecutive_lines_and_keeps_inner_blocks() {
+        val doc = parse("> quoted one\n>\n> # Quoted heading")
+        val quote = assertIs<Blockquote>(doc.content.single())
+        assertIs<Paragraph>(quote.content[0])
+        assertEquals(2, quote.content.size)
+        assertIs<Heading>(quote.content[1])
+    }
+
+    @Test
+    fun the_three_list_kinds_parse_with_their_attributes() {
+        val doc = parse("- a\n- b\n\n3. c\n4. d\n\n- [x] done\n- [ ] open")
+        val bullets = assertIs<BulletedList>(doc.content[0])
+        assertEquals(2, bullets.content.size)
+        val ordered = assertIs<OrderedList>(doc.content[1])
+        assertEquals(3, ordered.attrs.start)
+        val tasks = assertIs<TaskList>(doc.content[2])
+        assertTrue(tasks.items[0].attrs.checked)
+        assertTrue(!tasks.items[1].attrs.checked)
+    }
+
+    @Test
+    fun a_tight_sublist_nests_inside_its_item() {
+        val doc = parse("- parent\n    - child")
+        val list = assertIs<BulletedList>(doc.content.single())
+        val item = assertIs<ListItem>(list.content.single())
+        assertIs<Paragraph>(item.content[0])
+        val nested = assertIs<BulletedList>(item.content[1])
+        assertEquals("child", (assertIs<Paragraph>(assertIs<ListItem>(nested.content.single()).content[0]).content.single() as Text).text)
+    }
+
+    @Test
+    fun a_kind_switch_starts_a_new_list() {
+        val doc = parse("- bullet\n1. number")
+        assertIs<BulletedList>(doc.content[0])
+        assertIs<OrderedList>(doc.content[1])
+    }
+
+    @Test
+    fun a_table_becomes_the_editor_table_embed() {
+        val doc = parse("| Name | Age |\n| --- | --- |\n| Juan | 5 |")
+        val embed = assertIs<EmbedBlock>(doc.content.single())
+        assertEquals("table", embed.embedType)
+        val raw = embed.raw.toString()
+        assertTrue(raw.contains("tableHeader") && raw.contains("tableCell"))
+        assertTrue(raw.contains("Name") && raw.contains("Juan"))
+    }
+
+    @Test
+    fun a_lone_image_line_becomes_the_image_embed() {
+        val doc = parse("![the alt](https://example.com/a.png)")
+        val embed = assertIs<EmbedBlock>(doc.content.single())
+        assertEquals("image", embed.embedType)
+        assertTrue(embed.raw.toString().contains("https://example.com/a.png"))
+    }
+
+    // ── Inline ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun emphasis_marks_nest_and_combine() {
+        val p = firstParagraph("**bold _both_** and ~~gone~~")
+        assertEquals(setOf<Any>(BoldMark()), (p.content[0] as Text).marks)
+        assertEquals(setOf(BoldMark(), ItalicMark()), (p.content[1] as Text).marks)
+        assertEquals(setOf<Any>(StrikeMark()), (p.content[3] as Text).marks)
+    }
+
+    @Test
+    fun snake_case_stays_literal() {
+        val p = firstParagraph("value of snake_case_name here")
+        assertEquals("value of snake_case_name here", (p.content.single() as Text).text)
+    }
+
+    @Test
+    fun links_carry_their_destination() {
+        val p = firstParagraph("see [the docs](https://example.com/x) now")
+        val linked = p.content[1] as Text
+        assertEquals("the docs", linked.text)
+        assertEquals("https://example.com/x", (linked.marks.single() as LinkMark).attrs.href)
+    }
+
+    @Test
+    fun the_html_fallbacks_restore_their_marks() {
+        val p = firstParagraph("<u>under</u> and <mark>lit</mark>")
+        assertEquals(setOf<Any>(UnderlineMark()), (p.content[0] as Text).marks)
+        assertEquals(setOf<Any>(HighlightMark()), (p.content[2] as Text).marks)
+    }
+
+    @Test
+    fun escapes_entities_and_degrades_keep_the_text() {
+        assertEquals("*not bold* & <kept>", (firstParagraph("""\*not bold\* &amp; &lt;kept&gt;""").content.single() as Text).text)
+        // a code span keeps its inner text; an unknown tag is stripped around its content
+        assertEquals("code here", (firstParagraph("`code` <span style=\"x\">here</span>").content.single() as Text).text)
+        // an inline image degrades to its alt text
+        assertEquals("before alt after", (firstParagraph("before ![alt](u) after").content.joinToString("") { (it as Text).text }))
+    }
+
+    // ── Integration ──────────────────────────────────────────────────────────
+
+    @Test
+    fun the_imported_json_loads_into_the_editor() {
+        val e = editorFrom(markdownToJson("# Title\n\nplain **bold**\n\n- item\n\n> quoted"))
+        assertTrue(e.text.contains("Title"))
+        assertTrue(e.text.contains("bold"))
+        assertTrue(e.text.contains("item"))
+        assertTrue(e.text.contains("quoted"))
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+
+    // ── Round trip ───────────────────────────────────────────────────────────
+
+    /** For exporter-canonical Markdown, parse → export must be the identity. */
+    private fun assertFixedPoint(markdown: String) {
+        assertEquals(markdown, MarkdownSerializer().serialize(parse(markdown)), "fixed point broken for:\n$markdown")
+    }
+
+    @Test
+    fun canonical_markdown_is_a_fixed_point_of_parse_then_export() {
+        assertFixedPoint("plain paragraph")
+        assertFixedPoint("# Heading")
+        assertFixedPoint("**bold** and _italic_ and ~~strike~~")
+        assertFixedPoint("a [link](https://example.com/x) here")
+        assertFixedPoint("<u>under</u> and <mark>lit</mark>")
+        assertFixedPoint("- one\n- two")
+        assertFixedPoint("1. one\n2. two")
+        assertFixedPoint("- [ ] open\n- [x] done")
+        assertFixedPoint("- parent\n    - child")
+        assertFixedPoint("> quoted line")
+        assertFixedPoint("first\n\nsecond")
+        assertFixedPoint("![alt](https://example.com/a.png)")
+        assertFixedPoint("| a | b |\n| --- | --- |\n| c | d |")
+    }
+
+    @Test
+    fun an_exported_document_survives_import_and_re_export() {
+        val e = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"intro "},{"type":"text","text":"bold","marks":[{"type":"bold"}]}]},
+              {"type":"blockquote","content":[{"type":"paragraph","content":[{"type":"text","text":"quoted"}]}]},
+              {"type":"orderedList","attrs":{"start":1},"content":[
+                {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"first"}]}]},
+                {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"second"}]}]}
+              ]},
+              {"type":"taskList","content":[
+                {"type":"taskItem","attrs":{"checked":true},"content":[{"type":"paragraph","content":[{"type":"text","text":"do"}]}]}
+              ]}
+            ]}"""
+        )
+        val markdown = e.toMarkdown()
+        assertEquals(markdown, MarkdownSerializer().serialize(parse(markdown)))
+    }
+
+    /**
+     * The importer is a boundary: it must accept anything without throwing, and its output must
+     * always load. Seeded, so a failure names its seed.
+     */
+    @Test
+    fun hostile_input_never_throws_and_always_loads() {
+        val alphabet = "ab \n\t*_~`[]()|>#-!<>&\\\"'x1."
+        for (seed in 0 until 500) {
+            val rng = kotlin.random.Random(seed)
+            val garbage = buildString { repeat(rng.nextInt(80)) { append(alphabet[rng.nextInt(alphabet.length)]) } }
+            val json = try {
+                markdownToJson(garbage)
+            } catch (t: Throwable) {
+                throw AssertionError("parser threw at seed=$seed input='${garbage.replace("\n", "\\n")}'", t)
+            }
+            try {
+                editorFrom(json)
+            } catch (t: Throwable) {
+                throw AssertionError("import output failed to load at seed=$seed input='${garbage.replace("\n", "\\n")}'", t)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of #142 — phase 1, the parser and converter. Pure engine code, no UI; the entry point is `markdownToJson(markdown): String`, whose output is regular document JSON for `load()`.

**Scope** — exactly the subset `toMarkdown()` emits, inverted:

- **Blocks:** ATX headings, paragraphs, blockquotes (consecutive `>` lines group; nested blocks stay quoted), bulleted/ordered/task lists with nesting by the exporter's 4-space indent (tight sublists and blank-line-separated nested blocks both continue their item), GFM pipe tables (header row → `tableHeader`, body → `tableCell`) and lone `![alt](src)` lines as the table/image embeds.
- **Inline:** `**bold**`, `_italic_` (with a snake_case guard), `~~strike~~`, `[text](dest)` links, backslash escapes and HTML entities — plus the exporter's own fallbacks recognized on the way back in: `<u>`, `<mark>`, `<br>`, so underline, highlight and hard breaks survive a full round trip.
- **Degrade contract, mirroring the export's:** lossy but text-safe. A code span keeps its inner text, an inline image its alt text, an unknown HTML tag is stripped around its content, and any line no block rule claims is a paragraph. Soft breaks inside a paragraph join with a space (the CommonMark rendering).

**Tests** (17): per-construct mappings; an integration check that imported JSON loads and re-exports stably; a seeded 500-case fuzz asserting the importer never throws and its output always loads; and the property that ties the two sides together — **for exporter-canonical Markdown, `export(parse(M)) == M`**, asserted across every shared construct and on a full document exported by the editor itself.

Full suite green on jvm, js, and wasmJs; iOS compiles. Phase 2 (the state-level `importMarkdown` API and any paste behavior) stays open on #142 pending the product questions there.
