### PR TITLE
fix: keep the IME composing region alive and diff composition rewrites correctly

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -1148,9 +1148,10 @@ class TextKitState(
         } else if (prevTextFieldValue.text.length < textFieldValue.text.length) {
             handleRemovingText()
         } else {
-            if (prevTextFieldValue.text == textFieldValue.text &&
-                prevTextFieldValue.selection != textFieldValue.selection
-            ) {
+            if (prevTextFieldValue.text == textFieldValue.text) {
+                // Same text: a selection move, or the IME adjusting only its composing region —
+                // both keep the value's identity (the copy below carries the incoming composition,
+                // so a composition-only update is never swallowed, #144).
                 // Update selection
                 val normalized = normalizeSelectionForListLayout(prevTextFieldValue.selection)
                 textFieldValue = prevTextFieldValue.copy(selection = normalized)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -1165,8 +1165,11 @@ class TextKitState(
                 checkDecorator(textFieldValue.selection.min, textFieldValue.selection.max)
                 tokenState.refreshQuery(textFieldValue.text, selection)
             } else {
-                // Replacing the same length of characters using the clipboard
-                updateAnnotatedString(prevTextFieldValue.selection)
+                // Same length, different characters: a same-length replace (an IME committing
+                // one composed character over one pinyin letter, a same-length paste). This must
+                // reach the engine like any other edit — rebuilding the display from the old
+                // engine text silently discarded the replacement (#144).
+                handleReplacingText()
             }
         }
         prevTextFieldValue = TextFieldValue()
@@ -1334,7 +1337,14 @@ class TextKitState(
             start = selection.start.coerceIn(0, text.length),
             end = selection.end.coerceIn(0, text.length),
         )
-        textFieldValue = TextFieldValue(text = text, selection = coerced)
+        // The IME's composing region must survive the rebuild (#144): handing a value back without
+        // it cancels the composition, so every keystroke committed immediately and a CJK IME could
+        // never compose a word. It survives exactly when the engine settled on the text the IME
+        // produced — after an engine rewrite (a marker conversion, a caret clamp) the region no
+        // longer describes the document and is dropped, which tells the IME to restart cleanly.
+        val composition = prevTextFieldValue.composition
+            ?.takeIf { prevTextFieldValue.text == text && it.max <= text.length }
+        textFieldValue = TextFieldValue(text = text, selection = coerced, composition = composition)
         visualTransformation =
             VisualTransformation { _ -> TransformedText(annotatedString, editorOffsetMapping) }
     }
@@ -1479,13 +1489,24 @@ class TextKitState(
             isTyping -> {
                 val typedTextCount = prevTextFieldValue.text.length - textFieldValue.text.length
                 val start = prevTextFieldValue.selection.min - typedTextCount
-                val typedText = prevTextFieldValue.text.substring(start, start + typedTextCount)
-                TextEditorAction.TextAdded(
-                    text = typedText,
-                    marks = marks,
-                    offset = start,
-                    selection = prevTextFieldValue.selection
-                )
+                // The fast path assumes the new characters sit directly before the caret with the
+                // rest untouched. A composing IME breaks that shape (it rewrites its whole
+                // composed run), so the assumption is verified and anything else falls back to a
+                // content diff (#144).
+                val isInsertBeforeCaret = start >= 0 &&
+                    start + typedTextCount <= prevTextFieldValue.text.length &&
+                    prevTextFieldValue.text.removeRange(start, start + typedTextCount) == textFieldValue.text
+                if (isInsertBeforeCaret) {
+                    TextEditorAction.TextAdded(
+                        text = prevTextFieldValue.text.substring(start, start + typedTextCount),
+                        marks = marks,
+                        offset = start,
+                        selection = prevTextFieldValue.selection
+                    )
+                } else {
+                    contentDiffAction(textFieldValue.text, prevTextFieldValue.text, marks)
+                        ?: TextEditorAction.None
+                }
             }
 
             isUsingClipboard -> {
@@ -1526,13 +1547,7 @@ class TextKitState(
 
     private fun createRemoveAction(): TextEditorAction {
         return when {
-            isTyping -> {
-                TextEditorAction.TextRemoved(
-                    offset = prevTextFieldValue.selection.min,
-                    length = textFieldValue.text.length - prevTextFieldValue.text.length,
-                    selection = textFieldValue.selection
-                )
-            }
+            isTyping -> deletionOrDiff()
 
             isUsingClipboard -> {
                 val (offset, replacement) = replacementOverPriorSelection(
@@ -1557,10 +1572,83 @@ class TextKitState(
                 }
             }
 
-            else -> TextEditorAction.TextRemoved(
-                offset = prevTextFieldValue.selection.min,
-                length = textFieldValue.text.length - prevTextFieldValue.text.length,
+            else -> deletionOrDiff()
+        }
+    }
+
+    /**
+     * The shrink-path fast action: a deletion ending at the new caret. The shape is verified — a
+     * composing IME can shrink the text while also rewriting it (committing `你好` over `nihao`),
+     * which is a replace, not a deletion; that falls back to a content diff (#144).
+     */
+    private fun deletionOrDiff(): TextEditorAction {
+        val offset = prevTextFieldValue.selection.min
+        val length = textFieldValue.text.length - prevTextFieldValue.text.length
+        val isPureDeletion = offset >= 0 && length > 0 &&
+            offset + length <= textFieldValue.text.length &&
+            textFieldValue.text.removeRange(offset, offset + length) == prevTextFieldValue.text
+        if (isPureDeletion) {
+            return TextEditorAction.TextRemoved(
+                offset = offset,
+                length = length,
                 selection = textFieldValue.selection
+            )
+        }
+        return contentDiffAction(textFieldValue.text, prevTextFieldValue.text, lastMarks)
+            ?: TextEditorAction.None
+    }
+
+    /** Applies a same-length text replacement as its own discrete engine edit. */
+    private fun handleReplacingText() {
+        val action = contentDiffAction(textFieldValue.text, prevTextFieldValue.text, lastMarks) ?: return
+        recordBefore {
+            val (result, range) = TextTransaction.onTextUpdated(action, manager)
+            if (result) {
+                selection = range
+                updateAnnotatedString(selection)
+                tokenState.refreshQuery(textFieldValue.text, selection)
+                lastRangeSelection = TextRange.Zero
+                lastEmbedType = embedTypeAtCaret()
+            }
+            result
+        }
+    }
+
+    /**
+     * The single contiguous change between [oldText] and [newText] as an engine action, located by
+     * longest common prefix then suffix; null when the texts are equal. The fallback for every
+     * edit the caret-anchored fast paths cannot describe — above all an IME rewriting its
+     * composed run (#144).
+     */
+    private fun contentDiffAction(oldText: String, newText: String, marks: Set<Mark>): TextEditorAction? {
+        if (oldText == newText) return null
+        var prefix = 0
+        val maxPrefix = minOf(oldText.length, newText.length)
+        while (prefix < maxPrefix && oldText[prefix] == newText[prefix]) prefix++
+        var suffix = 0
+        val maxSuffix = minOf(oldText.length, newText.length) - prefix
+        while (suffix < maxSuffix &&
+            oldText[oldText.length - 1 - suffix] == newText[newText.length - 1 - suffix]
+        ) suffix++
+        val removeLength = oldText.length - prefix - suffix
+        val inserted = newText.substring(prefix, newText.length - suffix)
+        return when {
+            removeLength == 0 -> TextEditorAction.TextAdded(
+                text = inserted,
+                marks = marks,
+                offset = prefix,
+                selection = TextRange(prefix + inserted.length),
+            )
+            inserted.isEmpty() -> TextEditorAction.TextRemoved(
+                offset = prefix,
+                length = removeLength,
+                selection = TextRange(prefix),
+            )
+            else -> TextEditorAction.TextUpdated(
+                removeLength = removeLength,
+                text = inserted,
+                offset = prefix,
+                selection = TextRange(prefix + inserted.length),
             )
         }
     }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ImeCompositionTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ImeCompositionTest.kt
@@ -80,4 +80,13 @@ class ImeCompositionTest {
         assertNull(s.textFieldValue.composition)
         assertEquals(s.toJson(), editorFrom(s.toJson()).toJson())
     }
+
+    @Test
+    fun a_composition_only_update_is_not_swallowed() {
+        val s = state()
+        s.ime("nihao", 5, TextRange(0, 5))
+        // same text, same selection — only the composing region changes
+        s.ime("nihao", 5, TextRange(2, 5))
+        assertEquals(TextRange(2, 5), s.textFieldValue.composition)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ImeCompositionTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ImeCompositionTest.kt
@@ -1,0 +1,83 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import com.jjrodcast.textkit.editor.models.createTextKitConfiguration
+import com.jjrodcast.textkit.ui.state.TextKitState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * A composing IME (Chinese pinyin, Japanese romaji, …) marks its in-progress text with
+ * [TextFieldValue.composition] and expects that region to survive the app's round trip — a value
+ * handed back without it cancels the composition, so every keystroke committed immediately and a
+ * CJK word could never be composed (#144). The state must keep the region whenever the engine
+ * settles on exactly the text the IME produced, and drop it only when an engine rewrite (a marker
+ * conversion, a clamp) makes the region meaningless.
+ */
+class ImeCompositionTest {
+
+    private fun state() = TextKitState("{}", createTextKitConfiguration()).apply { setup() }
+
+    private fun TextKitState.ime(text: String, caret: Int, composition: TextRange?) =
+        onTextFieldChange(TextFieldValue(text, TextRange(caret), composition))
+
+    @Test
+    fun the_composing_region_survives_each_keystroke() {
+        val s = state()
+        s.ime("n", 1, TextRange(0, 1))
+        assertEquals(TextRange(0, 1), s.textFieldValue.composition)
+        s.ime("ni", 2, TextRange(0, 2))
+        assertEquals(TextRange(0, 2), s.textFieldValue.composition)
+    }
+
+    @Test
+    fun committing_the_composition_clears_the_region_and_keeps_the_text() {
+        val s = state()
+        s.ime("nihao", 5, TextRange(0, 5))
+        s.ime("你好", 2, null)
+        assertEquals("你好", s.textFieldValue.text)
+        assertNull(s.textFieldValue.composition)
+    }
+
+    @Test
+    fun composing_after_existing_text_keeps_the_region_in_place() {
+        val s = state()
+        s.ime("hello ", 6, null)
+        s.ime("hello w", 7, TextRange(6, 7))
+        assertEquals(TextRange(6, 7), s.textFieldValue.composition)
+        s.ime("hello wo", 8, TextRange(6, 8))
+        assertEquals(TextRange(6, 8), s.textFieldValue.composition)
+    }
+
+    @Test
+    fun an_engine_rewrite_drops_the_stale_region() {
+        val s = state()
+        // "1. " converts to a list marker: the engine's settled text is no longer what the IME
+        // sent, so the composing region no longer describes the document and must not survive.
+        s.ime("1", 1, TextRange(0, 1))
+        s.ime("1.", 2, TextRange(0, 2))
+        s.ime("1. ", 3, TextRange(0, 3))
+        assertNull(s.textFieldValue.composition)
+    }
+
+    @Test
+    fun a_selection_only_change_keeps_the_region() {
+        val s = state()
+        s.ime("nihao", 5, TextRange(0, 5))
+        s.onTextFieldChange(TextFieldValue("nihao", TextRange(3), TextRange(0, 5)))
+        assertEquals(TextRange(0, 5), s.textFieldValue.composition)
+    }
+
+    @Test
+    fun a_mid_document_commit_replaces_only_the_composed_run() {
+        val s = state()
+        s.ime("hello ", 6, null)
+        s.ime("hello nihao", 11, TextRange(6, 11))
+        s.ime("hello 你好", 8, null)
+        assertEquals("hello 你好", s.textFieldValue.text)
+        assertNull(s.textFieldValue.composition)
+        assertEquals(s.toJson(), editorFrom(s.toJson()).toJson())
+    }
+}


### PR DESCRIPTION
Fixes #144.

A composing IME (Chinese pinyin, Japanese romaji, …) marks its in-progress text with `TextFieldValue.composition` and expects that region to survive the app's round trip. Three defects in the state's value handling each independently broke that contract:

1. **The composing region was dropped on every keystroke.** `updateAnnotatedString` rebuilt `textFieldValue` without the incoming `composition`, and a value handed back without it cancels the composition — so every letter committed immediately and a CJK word could never be composed. The region now survives exactly when the engine settles on the text the IME produced; after an engine rewrite (a marker conversion, a caret clamp) it no longer describes the document and is dropped, telling the IME to restart cleanly.

2. **A composition commit was mis-diffed as a deletion.** The shrink path assumed any collapsed-caret length decrease was a pure deletion ending at the caret — but committing `你好` over the composed `nihao` is a *replace*: the old code deleted three characters and never inserted the committed text (`nihao` became `ni`). The insert path made the mirror-image assumption (new characters sit directly before the caret). Both fast paths now verify their shape and fall back to a longest-common-prefix/suffix content diff that describes the IME's actual rewrite.

3. **A same-length replacement never reached the engine.** The equal-length branch only rebuilt the display, silently discarding the change — and a one-letter pinyin committing one han character (`a` → `啊`) is exactly that shape. It now applies the diffed replace as a discrete engine edit.

Tests: `ImeCompositionTest` drives the state through simulated IME value sequences — region survival across keystrokes, commits at the document start and mid-document, the same-length commit, a selection-only change keeping the region, and the marker-conversion case where dropping the region is the correct behavior. Full suite green on jvm, js, and wasmJs (the stress harness doubling as a no-regression check on the reworked typing paths); iOS compiles.

I could only verify against simulated IME sequences — @magic-cucumber, if you can try this branch with your Chinese IME on a real device, that confirmation would be very welcome.
