### PR TITLE
feat: code blocks as embeds with fenced Markdown on both sides

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/MarkdownSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/export/MarkdownSerializer.kt
@@ -155,6 +155,7 @@ internal class MarkdownSerializer : DocumentSerializer {
     private fun embed(block: EmbedBlock): String = when (block.embedType) {
         EmbedTypes.Table -> table(block.raw)
         EmbedTypes.Image -> image(block.raw)
+        EmbedTypes.CodeBlock -> codeFence(block.raw)
         else -> "<${Html.Div}${htmlAttr(Html.DataType, block.embedType)}${htmlAttr(Html.DataId, block.id)}></${Html.Div}>"
     }
 
@@ -185,6 +186,23 @@ internal class MarkdownSerializer : DocumentSerializer {
             .filterIsInstance<Paragraph>()
             .joinToString(separator = " ") { inline(it.content) }
             .replace("\n", " ")
+
+    /**
+     * A fenced code block. The code is emitted verbatim — no escaping, Markdown metacharacters
+     * included — because the fence suspends all inline parsing; the fence itself grows one
+     * backtick longer than the longest backtick run inside the code, so the content can never
+     * close it early. The `attrs.language` info string rides on the opening fence.
+     */
+    private fun codeFence(raw: JsonElement): String {
+        val code = raw.childNodes()
+            .mapNotNull { it.jsonObject["text"]?.jsonPrimitive?.contentOrNull }
+            .joinToString(separator = "")
+        val language = raw.jsonObject["attrs"]?.jsonObject?.get("language")?.jsonPrimitive?.contentOrNull.orEmpty()
+        val longestRun = Regex("`+").findAll(code).maxOfOrNull { it.value.length } ?: 0
+        val fence = Md.CodeFenceChar.repeat(maxOf(Md.MinCodeFence, longestRun + 1))
+        val body = if (code.isEmpty()) "" else "$code\n"
+        return "$fence$language\n$body$fence"
+    }
 
     private fun image(raw: JsonElement): String {
         val attrs = raw.jsonObject["attrs"]?.jsonObject
@@ -331,6 +349,8 @@ internal class MarkdownSerializer : DocumentSerializer {
         const val TableEdgeStart = "| "
         const val TableEdgeEnd = " |"
         const val TableDelimiter = "---"
+        const val CodeFenceChar = "`"
+        const val MinCodeFence = 3
     }
 
     /** Inline-HTML tag and attribute names used for the marks and alignment GFM cannot express. */

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/markdown/MarkdownParser.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/markdown/MarkdownParser.kt
@@ -567,7 +567,8 @@ internal class MarkdownParser {
         val ORDERED = Regex("""^(\d+)[.)] (.*)$""")
         val IMAGE_LINE = Regex("""^!\[(.*)\]\((.*)\)\s*$""")
         val DELIMITER_ROW = Regex("""^\s*\|?[\s:\-|]*-[\s:\-|]*\|?\s*$""")
-        val CODE_FENCE = Regex("""^(```+)(.*)$""")
+        // CommonMark allows up to three leading spaces before a fence.
+        val CODE_FENCE = Regex("""^ {0,3}(```+)(.*)$""")
 
         /** One nesting level of the exporter's indented item content. */
         const val NESTED_INDENT = 4

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/markdown/MarkdownParser.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/markdown/MarkdownParser.kt
@@ -66,6 +66,8 @@ internal class MarkdownParser {
 
                 isTable(lines, i) -> i = parseTable(lines, i, blocks)
 
+                CODE_FENCE.matches(line) -> i = parseCodeFence(lines, i, blocks)
+
                 HEADING.matches(line) -> {
                     val (hashes, rest) = HEADING.find(line)!!.destructured
                     val level = hashes.length.coerceIn(HeadingLevels.H1, HeadingLevels.H6)
@@ -95,7 +97,7 @@ internal class MarkdownParser {
         while (i < lines.size) {
             val line = lines[i]
             if (line.isBlank() || HEADING.matches(line) || isQuote(line) ||
-                listMarker(line, indent = 0) != null || isTable(lines, i)
+                listMarker(line, indent = 0) != null || isTable(lines, i) || CODE_FENCE.matches(line)
             ) break
             run += line.trim()
             i++
@@ -276,6 +278,42 @@ internal class MarkdownParser {
         }
         cells += sb.toString().trim()
         return cells
+    }
+
+    /**
+     * A fenced code block: everything between the opening fence and a closing run of at least as
+     * many backticks is the code, verbatim — no inline parsing, no escapes, blank lines included.
+     * The info string on the opening fence becomes `attrs.language`. An unterminated fence runs to
+     * the end of the input (the CommonMark behavior).
+     */
+    private fun parseCodeFence(lines: List<String>, start: Int, blocks: MutableList<BaseParagraph>): Int {
+        val (fence, language) = CODE_FENCE.find(lines[start])!!.destructured
+        var i = start + 1
+        val code = mutableListOf<String>()
+        while (i < lines.size) {
+            val line = lines[i]
+            val close = CODE_FENCE.find(line)
+            if (close != null && close.groupValues[1].length >= fence.length && close.groupValues[2].isBlank()) {
+                i++
+                break
+            }
+            code += line
+            i++
+        }
+        val raw = buildJsonObject {
+            put("type", EmbedTypes.CodeBlock)
+            put("attrs", buildJsonObject { put("language", language.trim()) })
+            put("content", buildJsonArray {
+                if (code.isNotEmpty()) {
+                    add(buildJsonObject {
+                        put("type", "text")
+                        put("text", code.joinToString(separator = "\n"))
+                    })
+                }
+            })
+        }
+        blocks += EmbedBlock(embedType = EmbedTypes.CodeBlock, id = EmbedTypes.CodeBlock, raw = raw)
+        return i
     }
 
     // ── Embeds ───────────────────────────────────────────────────────────────
@@ -529,6 +567,7 @@ internal class MarkdownParser {
         val ORDERED = Regex("""^(\d+)[.)] (.*)$""")
         val IMAGE_LINE = Regex("""^!\[(.*)\]\((.*)\)\s*$""")
         val DELIMITER_ROW = Regex("""^\s*\|?[\s:\-|]*-[\s:\-|]*\|?\s*$""")
+        val CODE_FENCE = Regex("""^(```+)(.*)$""")
 
         /** One nesting level of the exporter's indented item content. */
         const val NESTED_INDENT = 4

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/EmbedBlock.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/EmbedBlock.kt
@@ -71,8 +71,9 @@ internal fun embedNameOf(payload: String): String? = embedAttrOf(payload, "name"
 internal fun embedLanguageOf(payload: String): String? = embedAttrOf(payload, "language")
 
 /**
- * The verbatim code of a `codeBlock` embed: its content text nodes joined as-is. Null for a
- * payload that is not valid JSON; empty content yields an empty string.
+ * The verbatim code of a `codeBlock` embed: its content text nodes joined as-is. Null when the
+ * payload is not a JSON object of the expected shape (invalid JSON, or a top-level array or
+ * primitive); an object with empty or missing content yields an empty string.
  */
 internal fun embedCodeTextOf(payload: String): String? = runCatching {
     (TEXT_EDITOR_JSON.parseToJsonElement(payload).jsonObject["content"] as? kotlinx.serialization.json.JsonArray)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/EmbedBlock.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/parser/EmbedBlock.kt
@@ -36,8 +36,9 @@ internal object EmbedTypes {
     const val Table = "table"
     const val Image = "image"
     const val Document = "document"
+    const val CodeBlock = "codeBlock"
 
-    val ALL: Set<String> = setOf(Table, Image, Document)
+    val ALL: Set<String> = setOf(Table, Image, Document, CodeBlock)
 
     fun isEmbed(type: String?): Boolean = type != null && type in ALL
 }
@@ -66,6 +67,20 @@ internal fun embedUrlOf(payload: String): String? = embedAttrOf(payload, "url")
 /** Reads `attrs.name` from an embed's raw JSON — a `document` node's display name. */
 internal fun embedNameOf(payload: String): String? = embedAttrOf(payload, "name")
 
+/** Reads `attrs.language` from an embed's raw JSON — a `codeBlock` node's info string. */
+internal fun embedLanguageOf(payload: String): String? = embedAttrOf(payload, "language")
+
+/**
+ * The verbatim code of a `codeBlock` embed: its content text nodes joined as-is. Null for a
+ * payload that is not valid JSON; empty content yields an empty string.
+ */
+internal fun embedCodeTextOf(payload: String): String? = runCatching {
+    (TEXT_EDITOR_JSON.parseToJsonElement(payload).jsonObject["content"] as? kotlinx.serialization.json.JsonArray)
+        .orEmpty()
+        .mapNotNull { it.jsonObject["text"]?.jsonPrimitive?.contentOrNull }
+        .joinToString(separator = "")
+}.getOrNull()
+
 /**
  * Reads one string attribute from an embed's raw JSON, or null when the payload has no attrs, no
  * such key, a blank value, or is not valid JSON at all — embeds are an opaque passthrough, so a
@@ -86,6 +101,7 @@ internal object EmbedLabels {
         EmbedTypes.Table -> "📊 Tabla $indexByType"
         EmbedTypes.Image -> "🖼 Imagen $indexByType"
         EmbedTypes.Document -> "📄 Documento $indexByType"
+        EmbedTypes.CodeBlock -> "⌨ Código $indexByType"
         else -> "⧉ $embedType $indexByType"
     }
 }

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/TextKitEmbedPopup.kt
@@ -53,6 +53,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import coil3.compose.SubcomposeAsyncImage
 import com.jjrodcast.textkit.editor.core.TextKitEditorManager
 import com.jjrodcast.textkit.editor.core.parser.EmbedTypes
+import com.jjrodcast.textkit.editor.core.parser.embedCodeTextOf
+import com.jjrodcast.textkit.editor.core.parser.embedLanguageOf
 import com.jjrodcast.textkit.editor.core.parser.embedNameOf
 import com.jjrodcast.textkit.editor.core.parser.embedUrlOf
 import com.jjrodcast.textkit.theme.TextKitTheme
@@ -286,6 +288,31 @@ private fun EmbedPopupContent(
                                 TextButton(onClick = { onOpenDocument(url) }) {
                                     Text(stringResource(Res.string.open_label))
                                 }
+                            }
+                        }
+                    }
+
+                    EmbedTypes.CodeBlock -> {
+                        val code = remember(embed.rawJson) { embedCodeTextOf(embed.rawJson).orEmpty() }
+                        val language = remember(embed.rawJson) { embedLanguageOf(embed.rawJson) }
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            if (language != null) {
+                                Text(
+                                    text = language,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = TextKitTheme.colors.onSurfaceVariant,
+                                )
+                            }
+                            Box(
+                                modifier = Modifier.fillMaxWidth()
+                                    .verticalScroll(rememberScrollState())
+                            ) {
+                                Text(
+                                    text = code,
+                                    style = MaterialTheme.typography.bodySmall.copy(
+                                        fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
+                                    ),
+                                )
                             }
                         }
                     }

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/CodeBlockTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/CodeBlockTest.kt
@@ -33,6 +33,14 @@ class CodeBlockTest {
     }
 
     @Test
+    fun an_indented_fence_still_opens_a_code_block() {
+        val doc = parse("  ```py\n  indented code\n  ```")
+        val embed = assertIs<EmbedBlock>(doc.content.single())
+        assertEquals("py", embedLanguageOf(embed.raw.toString()))
+        assertEquals("  indented code", embedCodeTextOf(embed.raw.toString()))
+    }
+
+    @Test
     fun an_unterminated_fence_runs_to_the_end() {
         val doc = parse("```\nno closer\nstill code")
         val embed = assertIs<EmbedBlock>(doc.content.single())

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/CodeBlockTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/CodeBlockTest.kt
@@ -1,0 +1,76 @@
+package com.jjrodcast.textkit
+
+import com.jjrodcast.textkit.editor.core.export.MarkdownSerializer
+import com.jjrodcast.textkit.editor.core.markdown.MarkdownParser
+import com.jjrodcast.textkit.editor.core.markdown.markdownToJson
+import com.jjrodcast.textkit.editor.core.parser.EmbedBlock
+import com.jjrodcast.textkit.editor.core.parser.embedCodeTextOf
+import com.jjrodcast.textkit.editor.core.parser.embedLanguageOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The `codeBlock` node (#142): an opaque embed like tables and images, so it survives the editor
+ * losslessly, plus fenced-block support on both Markdown sides. Inside a fence nothing is parsed —
+ * the code is verbatim, blank lines and metacharacters included — and the exported fence always
+ * outgrows the longest backtick run in the code so the content can never close it early.
+ */
+class CodeBlockTest {
+
+    private fun parse(md: String) = MarkdownParser().parse(md)
+
+    @Test
+    fun a_fence_imports_verbatim_with_its_language() {
+        val doc = parse("```kotlin\nval x = \"**not bold**\"\n\nprintln(x)\n```")
+        val embed = assertIs<EmbedBlock>(doc.content.single())
+        assertEquals("codeBlock", embed.embedType)
+        val payload = embed.raw.toString()
+        assertEquals("kotlin", embedLanguageOf(payload))
+        assertEquals("val x = \"**not bold**\"\n\nprintln(x)", embedCodeTextOf(payload))
+    }
+
+    @Test
+    fun an_unterminated_fence_runs_to_the_end() {
+        val doc = parse("```\nno closer\nstill code")
+        val embed = assertIs<EmbedBlock>(doc.content.single())
+        assertEquals("no closer\nstill code", embedCodeTextOf(embed.raw.toString()))
+    }
+
+    @Test
+    fun a_longer_fence_carries_backticks_in_the_code() {
+        val doc = parse("````\na ``` inside\n````")
+        val embed = assertIs<EmbedBlock>(doc.content.single())
+        assertEquals("a ``` inside", embedCodeTextOf(embed.raw.toString()))
+    }
+
+    @Test
+    fun canonical_fences_are_a_fixed_point_of_parse_then_export() {
+        for (md in listOf(
+            "```kotlin\nval x = 1\n```",
+            "```\nplain\n```",
+            "```\n```",
+            "````\ncode with ``` run\n````",
+            "before\n\n```js\nlet a = 1\n```\n\nafter",
+        )) {
+            assertEquals(md, MarkdownSerializer().serialize(parse(md)), "fixed point broken for:\n$md")
+        }
+    }
+
+    @Test
+    fun a_code_block_document_loads_as_a_chip_and_round_trips() {
+        val e = editorFrom(markdownToJson("intro\n\n```kotlin\nval x = 1\n```"))
+        assertTrue(e.text.contains("Código"), e.text)
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+        // the code survives the editor verbatim: export the loaded document back to markdown
+        assertTrue(e.toMarkdown().contains("```kotlin\nval x = 1\n```"), e.toMarkdown())
+    }
+
+    @Test
+    fun the_code_helpers_degrade_on_malformed_payloads() {
+        assertNull(embedCodeTextOf("not json"))
+        assertNull(embedLanguageOf("{}"))
+    }
+}


### PR DESCRIPTION
Part of #142 — the code node you called for in the scope answers, as the first of two phase-2 PRs (the `importMarkdown` API follows).

**Where the node lives:** I put `codeBlock` in the embed registry — the same slot tables, images and documents occupy — rather than modeling it like `heading`. The heading pattern flattens on editor load and never reconstructs, so the node type would be lost on the first open; an embed is a verbatim passthrough, so a code block survives the editor byte-for-byte, renders as a placeholder chip (`⌨ Código N`), and its popup shows the code monospace with the language as a caption. The node shape is the TipTap convention: `{"type":"codeBlock","attrs":{"language":…},"content":[{"type":"text","text":…}]}`. Happy to rework toward a first-class editable block later if that's where you want to take it — the Markdown sides won't change.

**Markdown, both directions:**
- `toMarkdown()` emits a fenced block: the code verbatim (a fence suspends all inline parsing, so nothing is escaped), `attrs.language` as the info string, and the fence grown one backtick longer than the longest backtick run inside the code so the content can never close it early.
- The importer parses fences: everything to the closing run (at least as long as the opener) is code, verbatim — blank lines and metacharacters included; the info string becomes the language; an unterminated fence runs to the end of the input, the CommonMark behavior.

Tests: fence import (language, verbatim content, unterminated, longer fences), the parse→export fixed point across the fence shapes, editor load round trip (chip renders, `toJson` idempotent, re-export reproduces the fence), and the helper degrades on malformed payloads. Full suite green on jvm, js, and wasmJs; iOS compiles.
