### PR TITLE
feat: importMarkdown replaces the document from GitHub Flavored Markdown

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -5,6 +5,7 @@ import com.jjrodcast.textkit.editor.core.history.EditorHistoryManager
 import com.jjrodcast.textkit.editor.core.history.HistorySnapshot
 import com.jjrodcast.textkit.editor.core.export.HtmlSerializer
 import com.jjrodcast.textkit.editor.core.export.MarkdownSerializer
+import com.jjrodcast.textkit.editor.core.markdown.markdownToJson
 import com.jjrodcast.textkit.editor.core.models.TextEditorModel
 import com.jjrodcast.textkit.editor.core.parser.EmbedTokenType
 import com.jjrodcast.textkit.editor.core.parser.Mark
@@ -107,6 +108,9 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
      * lossless format.
      */
     fun toMarkdown(): String = MarkdownSerializer().serialize(transaction.document)
+
+    /** Loads [markdown] as the document, converted through the same GFM subset [toMarkdown] emits. */
+    fun loadMarkdown(markdown: String, isViewer: Boolean = false) = load(markdownToJson(markdown), isViewer)
 
     val isViewer get() = transaction.isViewer
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.em
 import com.jjrodcast.textkit.editor.components.TextEditorDecoratorItem
 import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.core.TextKitEditorManager
+import com.jjrodcast.textkit.editor.core.markdown.markdownToJson
 import com.jjrodcast.textkit.editor.core.history.EditKind
 import com.jjrodcast.textkit.editor.core.parser.BoldMark
 import com.jjrodcast.textkit.editor.core.parser.HeadingLevels
@@ -481,6 +482,23 @@ class TextKitState(
      * [rememberTextKitState] accepts as `json`). Use it to persist the editor's contents.
      */
     fun toJson() = manager.toJson()
+
+    /**
+     * Replaces the whole document with [markdown], converted through the same GitHub Flavored
+     * Markdown subset [toMarkdown] emits (#142). Like loading a new document, the replacement
+     * resets the undo history — the snapshots undo restores are tied to the replaced document
+     * and are meaningless across a swap (the same rule `load` documents). The caret lands at the
+     * document start.
+     */
+    fun importMarkdown(markdown: String) {
+        manager.load(markdownToJson(markdown), configuration.viewerMode)
+        tokenState.dismiss()
+        selection = TextRange.Zero
+        updateAnnotatedString(selection)
+        lastRangeSelection = TextRange.Zero
+        lastEmbedType = embedTypeAtCaret()
+        syncHistoryAvailability()
+    }
 
     /**
      * Exports the current document as semantic HTML. Export only: the editor is still loaded from,

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -492,11 +492,16 @@ class TextKitState(
      */
     fun importMarkdown(markdown: String) {
         manager.load(markdownToJson(markdown), configuration.viewerMode)
+        // Everything anchored to the replaced document is reset: open popups, the pending token
+        // query, and the selection-derived formatting-bar state re-read at the new caret.
         tokenState.dismiss()
+        dismissLinkPopup()
+        dismissEmbedPopup()
         selection = TextRange.Zero
         updateAnnotatedString(selection)
         lastRangeSelection = TextRange.Zero
         lastEmbedType = embedTypeAtCaret()
+        readSelectionContext()
         syncHistoryAvailability()
     }
 

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ImportMarkdownApiTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ImportMarkdownApiTest.kt
@@ -1,0 +1,56 @@
+package com.jjrodcast.textkit
+
+import androidx.compose.ui.text.TextRange
+import com.jjrodcast.textkit.editor.models.createTextKitConfiguration
+import com.jjrodcast.textkit.ui.state.TextKitState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The explicit import API (#142, phase 2): [TextKitState.importMarkdown] replaces the whole
+ * document — the scope the proposal settled on — as a single undoable step.
+ */
+class ImportMarkdownApiTest {
+
+    private fun state(json: String = "{}") =
+        TextKitState(json, createTextKitConfiguration()).apply { setup() }
+
+    @Test
+    fun import_replaces_the_document() {
+        val s = state("""{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"old content"}]}]}""")
+        s.importMarkdown("# Title\n\n- item one\n- item two")
+        assertTrue(!s.textFieldValue.text.contains("old content"))
+        assertTrue(s.textFieldValue.text.contains("Title"))
+        assertTrue(s.textFieldValue.text.contains("item two"))
+        assertEquals(TextRange.Zero, s.textFieldValue.selection)
+        assertEquals(s.toJson(), editorFrom(s.toJson()).toJson())
+    }
+
+    @Test
+    fun import_resets_the_undo_history_like_load() {
+        val s = state("""{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"keep me"}]}]}""")
+        s.importMarkdown("replacement\n\n> quoted")
+        // A document swap invalidates the piece-table snapshots undo restores, so the history is
+        // reset — the same contract as loading a new document.
+        assertTrue(!s.canUndo)
+        assertTrue(!s.undo())
+        assertTrue(s.textFieldValue.text.contains("replacement"))
+    }
+
+    @Test
+    fun importing_empty_markdown_clears_the_document() {
+        val s = state("""{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"gone"}]}]}""")
+        s.importMarkdown("")
+        assertEquals("", s.textFieldValue.text)
+    }
+
+    @Test
+    fun the_manager_level_convenience_loads_markdown() {
+        val e = com.jjrodcast.textkit.editor.core.TextKitEditorManager()
+        e.loadMarkdown("**bold** text\n\n- [x] done")
+        assertTrue(e.text.contains("bold"))
+        assertTrue(e.toJson().contains("taskItem"))
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ImportMarkdownApiTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/ImportMarkdownApiTest.kt
@@ -9,7 +9,8 @@ import kotlin.test.assertTrue
 
 /**
  * The explicit import API (#142, phase 2): [TextKitState.importMarkdown] replaces the whole
- * document — the scope the proposal settled on — as a single undoable step.
+ * document — the scope the proposal settled on. Like `load`, the swap resets the undo history:
+ * the snapshots undo restores are tied to the replaced document.
  */
 class ImportMarkdownApiTest {
 


### PR DESCRIPTION
Closes #142 — the second phase-2 PR, wiring the converter to the explicit API per the scope answers: explicit-API-only, replace-the-document.

- **`TextKitState.importMarkdown(markdown)`** replaces the whole document with the converted Markdown, dismisses any open token popup, re-renders, and drops the caret at the document start.
- **`TextKitEditorManager.loadMarkdown(markdown, isViewer)`** is the manager-level equivalent, symmetric with `toMarkdown()`.

One semantic worth calling out: the replacement **resets the undo history, exactly like `load`** — undo restores are piece-table snapshots tied to the replaced document, so they are meaningless across a swap (the same rule `load` already documents; my first cut tried to make the import one undoable step and the browser targets faithfully demonstrated why that cannot work with snapshot-based history). If undo-across-import ever becomes worth having, it needs a JSON-level history entry — happy to explore that separately if you want it.

Tests: replacement (content swapped, caret at start, round-trip stable), the history-reset contract, empty-Markdown clearing the document, and the manager-level convenience. Full suite green on jvm, js, and wasmJs; iOS compiles.

With this and #148, everything from the proposal's scope answers is in: explicit API, code node, replace semantics.
