### PR TITLE
feat: import HTML as document JSON with inbound sanitization

### DIFF
--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/TextKitEditorManager.kt
@@ -6,6 +6,7 @@ import com.jjrodcast.textkit.editor.core.history.HistorySnapshot
 import com.jjrodcast.textkit.editor.core.export.HtmlSerializer
 import com.jjrodcast.textkit.editor.core.export.MarkdownSerializer
 import com.jjrodcast.textkit.editor.core.markdown.markdownToJson
+import com.jjrodcast.textkit.editor.core.html.htmlToJson
 import com.jjrodcast.textkit.editor.core.models.TextEditorModel
 import com.jjrodcast.textkit.editor.core.parser.EmbedTokenType
 import com.jjrodcast.textkit.editor.core.parser.Mark
@@ -111,6 +112,9 @@ class TextKitEditorManager(val configuration: TextKitConfiguration = createTextK
 
     /** Loads [markdown] as the document, converted through the same GFM subset [toMarkdown] emits. */
     fun loadMarkdown(markdown: String, isViewer: Boolean = false) = load(markdownToJson(markdown), isViewer)
+
+    /** Loads [html] as the document, converted through the same HTML subset [toHtml] emits (#44). */
+    fun loadHtml(html: String, isViewer: Boolean = false) = load(htmlToJson(html), isViewer)
 
     val isViewer get() = transaction.isViewer
 

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/html/HtmlParser.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/html/HtmlParser.kt
@@ -1,0 +1,583 @@
+package com.jjrodcast.textkit.editor.core.html
+
+import com.jjrodcast.textkit.editor.core.export.ExportHtml
+import com.jjrodcast.textkit.editor.core.parser.BaseParagraph
+import com.jjrodcast.textkit.editor.core.parser.BaseText
+import com.jjrodcast.textkit.editor.core.parser.Blockquote
+import com.jjrodcast.textkit.editor.core.parser.BoldMark
+import com.jjrodcast.textkit.editor.core.parser.BulletedList
+import com.jjrodcast.textkit.editor.core.parser.EmbedBlock
+import com.jjrodcast.textkit.editor.core.parser.EmbedTypes
+import com.jjrodcast.textkit.editor.core.parser.HardBreak
+import com.jjrodcast.textkit.editor.core.parser.Hashtag
+import com.jjrodcast.textkit.editor.core.parser.HashtagType
+import com.jjrodcast.textkit.editor.core.parser.Heading
+import com.jjrodcast.textkit.editor.core.parser.HeadingAttrs
+import com.jjrodcast.textkit.editor.core.parser.HeadingLevels
+import com.jjrodcast.textkit.editor.core.parser.HighlightMark
+import com.jjrodcast.textkit.editor.core.parser.ItalicMark
+import com.jjrodcast.textkit.editor.core.parser.LinkAttrs
+import com.jjrodcast.textkit.editor.core.parser.LinkMark
+import com.jjrodcast.textkit.editor.core.parser.ListAttrs
+import com.jjrodcast.textkit.editor.core.parser.ListItem
+import com.jjrodcast.textkit.editor.core.parser.Mark
+import com.jjrodcast.textkit.editor.core.parser.Mention
+import com.jjrodcast.textkit.editor.core.parser.MentionType
+import com.jjrodcast.textkit.editor.core.parser.OrderedList
+import com.jjrodcast.textkit.editor.core.parser.Paragraph
+import com.jjrodcast.textkit.editor.core.parser.ParagraphAttrs
+import com.jjrodcast.textkit.editor.core.parser.StrikeMark
+import com.jjrodcast.textkit.editor.core.parser.TEXT_EDITOR_JSON
+import com.jjrodcast.textkit.editor.core.parser.TaskList
+import com.jjrodcast.textkit.editor.core.parser.TaskListAttrs
+import com.jjrodcast.textkit.editor.core.parser.TaskListItem
+import com.jjrodcast.textkit.editor.core.parser.Text
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
+import com.jjrodcast.textkit.editor.core.parser.TextEditorDocument
+import com.jjrodcast.textkit.editor.core.parser.TextStyleAttrs
+import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
+import com.jjrodcast.textkit.editor.core.parser.TokenAttrs
+import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Converts HTML to the editor's document JSON — the inverse of `HtmlSerializer`, targeting the
+ * subset that exporter emits so its output round-trips, plus the synonyms and looseness real-world
+ * HTML brings (`<b>`/`<i>`/`<del>`, unclosed `<p>`/`<li>`, tag soup, loose inline content).
+ *
+ * The import is **lossy but text-safe**: content is never dropped, only demoted. An unknown tag is
+ * unwrapped around its content; loose inline content becomes a paragraph. And it is a sanitizer by
+ * construction (issue #44): the output is typed nodes, so markup can never pass through verbatim —
+ * `<script>`/`<style>` bodies are discarded wholesale, event handlers have nowhere to live, an
+ * unsafe-scheme `href` drops its link (the text stays, `ExportHtml.safeHref`'s rule inbound), an
+ * unsafe `<img src>` degrades to the alt text, and `style` values are re-parsed into validated
+ * attributes rather than carried as CSS.
+ */
+fun htmlToJson(html: String): String =
+    TEXT_EDITOR_JSON.encodeToString(TextEditorDocument.serializer(), HtmlParser().parse(html))
+
+internal class HtmlParser {
+
+    fun parse(html: String): TextEditorDocument {
+        val root = buildTree(tokenize(html))
+        return TextEditorDocument(mapBlocks(root.children))
+    }
+
+    // ── DOM-lite ─────────────────────────────────────────────────────────────
+
+    internal sealed class Node
+
+    internal class Element(
+        val name: String,
+        val attrs: Map<String, String>,
+        val children: MutableList<Node> = mutableListOf(),
+    ) : Node()
+
+    internal class TextNode(val text: String) : Node()
+
+    private sealed class Token {
+        data class Open(val name: String, val attrs: Map<String, String>, val selfClosing: Boolean) : Token()
+        data class Close(val name: String) : Token()
+        data class Chars(val text: String) : Token()
+    }
+
+    // ── Tokenizer ────────────────────────────────────────────────────────────
+
+    private fun tokenize(html: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var i = 0
+        val text = StringBuilder()
+        fun flushText() {
+            if (text.isNotEmpty()) {
+                tokens += Token.Chars(decodeEntities(text.toString()))
+                text.clear()
+            }
+        }
+        while (i < html.length) {
+            val ch = html[i]
+            if (ch != '<') {
+                text.append(ch)
+                i++
+                continue
+            }
+            when {
+                html.startsWith("<!--", i) -> {
+                    flushText()
+                    val end = html.indexOf("-->", i + 4)
+                    i = if (end < 0) html.length else end + 3
+                }
+
+                html.startsWith("<!", i) || html.startsWith("<?", i) -> {
+                    flushText()
+                    val end = html.indexOf('>', i)
+                    i = if (end < 0) html.length else end + 1
+                }
+
+                i + 1 < html.length && (html[i + 1].isLetter() || html[i + 1] == '/') -> {
+                    val end = html.indexOf('>', i)
+                    if (end < 0) {
+                        // an unterminated tag at the end of input is not a tag; keep it as text
+                        text.append(ch)
+                        i++
+                        continue
+                    }
+                    flushText()
+                    val inner = html.substring(i + 1, end)
+                    if (inner.startsWith("/")) {
+                        tokens += Token.Close(inner.substring(1).trim().lowercase())
+                    } else {
+                        val selfClosing = inner.endsWith("/")
+                        val content = if (selfClosing) inner.dropLast(1) else inner
+                        val name = content.takeWhile { !it.isWhitespace() }.lowercase()
+                        tokens += Token.Open(name, parseAttrs(content.drop(name.length)), selfClosing)
+                        // A raw-text element's body is discarded wholesale, markup and all.
+                        if (name in RAW_TEXT_ELEMENTS && !selfClosing) {
+                            val close = html.indexOf("</$name", end + 1, ignoreCase = true)
+                            i = if (close < 0) {
+                                html.length
+                            } else {
+                                val closeEnd = html.indexOf('>', close)
+                                if (closeEnd < 0) html.length else closeEnd + 1
+                            }
+                            tokens += Token.Close(name)
+                            continue
+                        }
+                    }
+                    i = end + 1
+                }
+
+                else -> {
+                    text.append(ch)
+                    i++
+                }
+            }
+        }
+        flushText()
+        return tokens
+    }
+
+    private fun parseAttrs(raw: String): Map<String, String> {
+        val attrs = mutableMapOf<String, String>()
+        var i = 0
+        while (i < raw.length) {
+            while (i < raw.length && raw[i].isWhitespace()) i++
+            if (i >= raw.length) break
+            val nameStart = i
+            while (i < raw.length && !raw[i].isWhitespace() && raw[i] != '=') i++
+            val name = raw.substring(nameStart, i).lowercase()
+            if (name.isEmpty()) { i++; continue }
+            while (i < raw.length && raw[i].isWhitespace()) i++
+            if (i >= raw.length || raw[i] != '=') {
+                attrs[name] = ""
+                continue
+            }
+            i++
+            while (i < raw.length && raw[i].isWhitespace()) i++
+            val value = when {
+                i < raw.length && (raw[i] == '"' || raw[i] == '\'') -> {
+                    val quote = raw[i]
+                    val end = raw.indexOf(quote, i + 1)
+                    if (end < 0) raw.substring(i + 1).also { i = raw.length }
+                    else raw.substring(i + 1, end).also { i = end + 1 }
+                }
+                else -> {
+                    val start = i
+                    while (i < raw.length && !raw[i].isWhitespace()) i++
+                    raw.substring(start, i)
+                }
+            }
+            attrs[name] = decodeEntities(value)
+        }
+        return attrs
+    }
+
+    private fun decodeEntities(text: String): String {
+        if ('&' !in text) return text
+        return buildString {
+            var i = 0
+            while (i < text.length) {
+                if (text[i] != '&') {
+                    append(text[i]); i++
+                    continue
+                }
+                val semi = text.indexOf(';', i + 1)
+                if (semi < 0 || semi - i > MAX_ENTITY_LENGTH) {
+                    append(text[i]); i++
+                    continue
+                }
+                val entity = text.substring(i + 1, semi)
+                val decoded = when {
+                    NAMED_ENTITIES.containsKey(entity) -> NAMED_ENTITIES.getValue(entity)
+                    entity.startsWith("#x") || entity.startsWith("#X") ->
+                        entity.drop(2).toIntOrNull(16)?.takeIf { it in 1..0x10FFFF }
+                            ?.let { runCatching { it.toChar().toString() }.getOrNull() }
+                    entity.startsWith("#") ->
+                        entity.drop(1).toIntOrNull()?.takeIf { it in 1..0x10FFFF }
+                            ?.let { runCatching { it.toChar().toString() }.getOrNull() }
+                    else -> null
+                }
+                if (decoded != null) {
+                    append(decoded)
+                    i = semi + 1
+                } else {
+                    append(text[i]); i++
+                }
+            }
+        }
+    }
+
+    // ── Tree builder ─────────────────────────────────────────────────────────
+
+    /** Builds the element tree with browser-style recovery: void elements never open, `<p>`/`<li>`
+     *  and table cells auto-close their predecessors, and a stray close tag is ignored. */
+    private fun buildTree(tokens: List<Token>): Element {
+        val root = Element(ROOT, emptyMap())
+        val stack = ArrayDeque<Element>().apply { addLast(root) }
+        fun closeUpTo(name: String) {
+            if (stack.none { it.name == name }) return
+            while (stack.size > 1) {
+                val closed = stack.removeLast()
+                if (closed.name == name) break
+            }
+        }
+        fun autoClose(opening: String) {
+            when {
+                opening in BLOCK_TAGS && stack.last().name == "p" -> closeUpTo("p")
+                opening == "li" && stack.any { it.name == "li" } &&
+                    stack.last().name !in LIST_CONTAINER_TAGS -> closeUpTo("li")
+                (opening == "td" || opening == "th") && stack.last().name in CELL_TAGS ->
+                    closeUpTo(stack.last().name)
+                opening == "tr" && stack.last().name in CELL_TAGS + "tr" -> closeUpTo("tr")
+            }
+        }
+        tokens.forEach { token ->
+            when (token) {
+                is Token.Chars -> stack.last().children += TextNode(token.text)
+                is Token.Open -> {
+                    autoClose(token.name)
+                    val element = Element(token.name, token.attrs)
+                    stack.last().children += element
+                    if (!token.selfClosing && token.name !in VOID_ELEMENTS && token.name !in RAW_TEXT_ELEMENTS) {
+                        stack.addLast(element)
+                    }
+                }
+                is Token.Close -> closeUpTo(token.name)
+            }
+        }
+        return root
+    }
+
+    // ── Block mapping ────────────────────────────────────────────────────────
+
+    private fun mapBlocks(nodes: List<Node>): List<BaseParagraph> {
+        val blocks = mutableListOf<BaseParagraph>()
+        val looseInline = mutableListOf<Node>()
+        fun flushLoose() {
+            val content = mapInline(looseInline, emptySet())
+            looseInline.clear()
+            if (content.isNotEmpty()) blocks += Paragraph(content = content)
+        }
+        nodes.forEach { node ->
+            when {
+                node is TextNode && node.text.isBlank() && looseInline.isEmpty() -> Unit
+                node is Element && node.name in DROPPED_ELEMENTS -> Unit
+                node is Element && node.name in BLOCK_TAGS -> {
+                    flushLoose()
+                    blocks += mapBlock(node)
+                }
+                // anything else — text, marks, unknown inline tags — is loose inline content that
+                // browsers wrap into an implicit paragraph
+                else -> looseInline += node
+            }
+        }
+        flushLoose()
+        return blocks
+    }
+
+    private fun mapBlock(element: Element): List<BaseParagraph> = when (element.name) {
+        "p" -> listOf(Paragraph(attrs = ParagraphAttrs(textAlign = alignOf(element)), content = mapInline(element.children, emptySet())))
+
+        "h1", "h2", "h3", "h4", "h5", "h6" -> {
+            val level = element.name.drop(1).toInt().coerceIn(HeadingLevels.H1, HeadingLevels.H6)
+            listOf(Heading(attrs = HeadingAttrs(level = level, textAlign = alignOf(element)), content = mapInline(element.children, emptySet())))
+        }
+
+        "blockquote" -> listOf(Blockquote(content = mapBlocks(element.children)))
+
+        "ul" ->
+            if (element.attrs[DATA_TYPE] == TASK_LIST_TYPE) listOf(taskList(element))
+            else listOf(BulletedList(content = listItems(element)))
+
+        "ol" -> {
+            val start = element.attrs["start"]?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+            listOf(OrderedList(attrs = ListAttrs(start = start), content = listItems(element)))
+        }
+
+        "table" -> listOf(tableEmbed(element))
+
+        "img" -> imageBlock(element)
+
+        "pre" -> listOf(codeEmbed(element))
+
+        "div" -> {
+            val dataType = element.attrs[DATA_TYPE]
+            if (dataType != null) {
+                // the export's placeholder for an embed it could not render; keep type and id so
+                // the shape survives a round trip
+                listOf(
+                    EmbedBlock(
+                        embedType = dataType,
+                        id = element.attrs[DATA_ID] ?: dataType,
+                        raw = buildJsonObject {
+                            put("type", dataType)
+                            put("attrs", buildJsonObject { put("id", element.attrs[DATA_ID] ?: dataType) })
+                        },
+                    )
+                )
+            } else {
+                // a plain div is a transparent container
+                mapBlocks(element.children)
+            }
+        }
+
+        else -> mapBlocks(element.children)
+    }
+
+    private fun listItems(list: Element): List<BaseText> =
+        list.children.filterIsInstance<Element>().filter { it.name == "li" }.map { li ->
+            ListItem(content = mapBlocks(li.children))
+        }
+
+    private fun taskList(list: Element): TaskList {
+        val items = list.children.filterIsInstance<Element>().filter { it.name == "li" }.map { li ->
+            val checkbox = li.children.filterIsInstance<Element>().firstOrNull { it.name == "input" }
+            val checked = li.attrs[DATA_CHECKED] == "true" || checkbox?.attrs?.containsKey("checked") == true
+            val content = li.children.filterNot { it is Element && it.name == "input" }
+            TaskListItem(attrs = TaskListAttrs(checked = checked), content = mapBlocks(content))
+        }
+        return TaskList(content = items)
+    }
+
+    // ── Embeds ───────────────────────────────────────────────────────────────
+
+    private fun tableEmbed(table: Element): EmbedBlock {
+        // tr rows can sit directly in <table> or inside thead/tbody/tfoot sections
+        val rows = table.children.filterIsInstance<Element>()
+            .flatMap { if (it.name in TABLE_SECTION_TAGS) it.children.filterIsInstance<Element>() else listOf(it) }
+            .filter { it.name == "tr" }
+        val raw = buildJsonObject {
+            put("type", EmbedTypes.Table)
+            put("content", buildJsonArray {
+                rows.forEach { row ->
+                    add(buildJsonObject {
+                        put("type", "tableRow")
+                        put("content", buildJsonArray {
+                            row.children.filterIsInstance<Element>()
+                                .filter { it.name in CELL_TAGS }
+                                .forEach { cell ->
+                                    add(buildJsonObject {
+                                        put("type", if (cell.name == "th") "tableHeader" else "tableCell")
+                                        put("attrs", buildJsonObject {
+                                            put("colspan", cell.attrs["colspan"]?.toIntOrNull()?.coerceAtLeast(1) ?: 1)
+                                            put("rowspan", cell.attrs["rowspan"]?.toIntOrNull()?.coerceAtLeast(1) ?: 1)
+                                            put("colwidth", JsonNull)
+                                        })
+                                        put("content", buildJsonArray {
+                                            cellBlocks(cell).forEach {
+                                                add(TEXT_EDITOR_JSON.encodeToJsonElement(BaseParagraph.serializer(), it))
+                                            }
+                                        })
+                                    })
+                                }
+                        })
+                    })
+                }
+            })
+        }
+        return EmbedBlock(embedType = EmbedTypes.Table, id = EmbedTypes.Table, raw = raw)
+    }
+
+    /** A cell's blocks; a cell holding only inline content still yields one paragraph. */
+    private fun cellBlocks(cell: Element): List<BaseParagraph> {
+        val blocks = mapBlocks(cell.children)
+        return blocks.ifEmpty { listOf(Paragraph()) }
+    }
+
+    /** An `<img>`: a safe `src` becomes the image embed; an unsafe one degrades to the alt text. */
+    private fun imageBlock(img: Element): List<BaseParagraph> {
+        val src = img.attrs["src"]?.let { ExportHtml.safeHref(it) }
+        if (src == null) {
+            val alt = img.attrs["alt"].orEmpty()
+            return if (alt.isBlank()) emptyList()
+            else listOf(Paragraph(content = listOf(Text(text = alt))))
+        }
+        val raw = buildJsonObject {
+            put("type", EmbedTypes.Image)
+            put("attrs", buildJsonObject {
+                put("src", src)
+                put("alt", img.attrs["alt"].orEmpty())
+            })
+        }
+        return listOf(EmbedBlock(embedType = EmbedTypes.Image, id = EmbedTypes.Image, raw = raw))
+    }
+
+    /** `<pre>`(`<code>`) → the `codeBlock` embed; a `language-*` class becomes the language. */
+    private fun codeEmbed(pre: Element): EmbedBlock {
+        val code = pre.children.filterIsInstance<Element>().firstOrNull { it.name == "code" }
+        val source = code ?: pre
+        val language = (code?.attrs?.get("class") ?: pre.attrs["class"]).orEmpty()
+            .split(' ').firstOrNull { it.startsWith(LANGUAGE_CLASS_PREFIX) }
+            ?.removePrefix(LANGUAGE_CLASS_PREFIX).orEmpty()
+        val text = rawText(source).removeSuffix("\n")
+        val raw = buildJsonObject {
+            put("type", EmbedTypes.CodeBlock)
+            put("attrs", buildJsonObject { put("language", language) })
+            put("content", buildJsonArray {
+                if (text.isNotEmpty()) {
+                    add(buildJsonObject {
+                        put("type", "text")
+                        put("text", text)
+                    })
+                }
+            })
+        }
+        return EmbedBlock(embedType = EmbedTypes.CodeBlock, id = EmbedTypes.CodeBlock, raw = raw)
+    }
+
+    /** All text under [node], tags stripped, whitespace preserved (pre content is verbatim). */
+    private fun rawText(node: Node): String = when (node) {
+        is TextNode -> node.text
+        is Element -> if (node.name == "br") "\n" else node.children.joinToString(separator = "") { rawText(it) }
+    }
+
+    // ── Inline mapping ───────────────────────────────────────────────────────
+
+    private fun mapInline(nodes: List<Node>, marks: Set<Mark>): List<BaseText> {
+        val out = mutableListOf<BaseText>()
+        nodes.forEach { node ->
+            when (node) {
+                is TextNode -> {
+                    val collapsed = collapseWhitespace(node.text)
+                    if (collapsed.isNotEmpty()) out += Text(text = collapsed, marks = marks)
+                }
+                is Element -> when (node.name) {
+                    in DROPPED_ELEMENTS -> Unit
+                    "br" -> out += HardBreak(marks = marks)
+                    "strong", "b" -> out += mapInline(node.children, marks + BoldMark())
+                    "em", "i" -> out += mapInline(node.children, marks + ItalicMark())
+                    "u", "ins" -> out += mapInline(node.children, marks + UnderlineMark())
+                    "s", "del", "strike" -> out += mapInline(node.children, marks + StrikeMark())
+                    "mark" -> out += mapInline(node.children, marks + HighlightMark())
+                    "a" -> {
+                        // an unsafe scheme drops the link and keeps the text — safeHref inbound
+                        val href = node.attrs["href"]?.let { ExportHtml.safeHref(it) }
+                        val linked = if (href != null) marks + LinkMark(LinkAttrs(href = href)) else marks
+                        out += mapInline(node.children, linked)
+                    }
+                    "span" -> out += span(node, marks)
+                    else -> out += mapInline(node.children, marks)
+                }
+            }
+        }
+        return mergeAdjacent(out)
+    }
+
+    private fun span(node: Element, marks: Set<Mark>): List<BaseText> {
+        val dataType = node.attrs[DATA_TYPE]
+        if (dataType == MentionType.Mention || dataType == HashtagType.Hashtag) {
+            val trigger = if (dataType == MentionType.Mention) MentionType.DEFAULT_MENTION_CHAR else HashtagType.DEFAULT_HASHTAG_CHAR
+            val label = rawText(node).trim().removePrefix(trigger.toString())
+            val attrs = TokenAttrs(id = node.attrs[DATA_ID].orEmpty(), label = label)
+            return listOf(
+                if (dataType == MentionType.Mention) Mention(attrs = attrs, marks = marks)
+                else Hashtag(attrs = attrs, marks = marks)
+            )
+        }
+        val styled = node.attrs["style"]?.let { textStyleFrom(it) }
+        return mapInline(node.children, if (styled != null) marks + styled else marks)
+    }
+
+    /** Re-parses a `style` attribute's `color`/`font-size` into a validated [TextStyleMark] —
+     *  values go through the same rules the export applies, so nothing unvetted is carried. */
+    private fun textStyleFrom(style: String): TextStyleMark? {
+        var color: String? = null
+        var fontSize = TextStyleAttrs.UNSET_FONT_SIZE
+        style.split(';').forEach { declaration ->
+            val key = declaration.substringBefore(':').trim().lowercase()
+            val value = declaration.substringAfter(':', "").trim()
+            when (key) {
+                ExportHtml.COLOR -> color = ExportHtml.safeColor(value)
+                ExportHtml.FONT_SIZE -> fontSize = value.removeSuffix("px").trim().toIntOrNull()
+                    ?.takeIf { it in 1..MAX_FONT_SIZE } ?: fontSize
+            }
+        }
+        if (color == null && fontSize == TextStyleAttrs.UNSET_FONT_SIZE) return null
+        return TextStyleMark(TextStyleAttrs(color = color ?: "", fontSize = fontSize))
+    }
+
+    private fun alignOf(element: Element): TextAlign {
+        val style = element.attrs["style"] ?: return TextAlign.Left
+        val value = style.split(';')
+            .firstOrNull { it.substringBefore(':').trim().lowercase() == ExportHtml.TEXT_ALIGN }
+            ?.substringAfter(':')?.trim()?.lowercase()
+        return when (value) {
+            "center" -> TextAlign.Center
+            "right" -> TextAlign.Right
+            "justify" -> TextAlign.Justify
+            else -> TextAlign.Left
+        }
+    }
+
+    /** HTML collapses whitespace runs to one space outside `pre`. */
+    private fun collapseWhitespace(text: String): String =
+        text.replace(WHITESPACE_RUN, " ")
+
+    /** Adjacent text nodes with identical marks merge, so tag boundaries leave no seams. */
+    private fun mergeAdjacent(nodes: List<BaseText>): List<BaseText> {
+        val merged = mutableListOf<BaseText>()
+        nodes.forEach { node ->
+            val last = merged.lastOrNull()
+            if (node is Text && last is Text && last.marks == node.marks) {
+                merged[merged.size - 1] = last.copy(text = last.text + node.text)
+            } else {
+                merged += node
+            }
+        }
+        return merged
+    }
+
+    private companion object {
+        const val ROOT = "#root"
+        const val DATA_TYPE = "data-type"
+        const val DATA_ID = "data-id"
+        const val DATA_CHECKED = "data-checked"
+        const val TASK_LIST_TYPE = "taskList"
+        const val LANGUAGE_CLASS_PREFIX = "language-"
+        const val MAX_ENTITY_LENGTH = 12
+        const val MAX_FONT_SIZE = 512
+
+        val NAMED_ENTITIES = mapOf(
+            "amp" to "&",
+            "lt" to "<",
+            "gt" to ">",
+            "quot" to "\"",
+            "apos" to "'",
+            "nbsp" to " ",
+        )
+
+        val RAW_TEXT_ELEMENTS = setOf("script", "style")
+        val DROPPED_ELEMENTS = setOf("script", "style", "head", "title", "template")
+        val VOID_ELEMENTS = setOf("br", "img", "input", "hr", "meta", "link", "col", "area", "base", "embed", "source", "track", "wbr")
+        val BLOCK_TAGS = setOf(
+            "p", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "blockquote",
+            "table", "img", "pre", "div",
+        )
+        val LIST_CONTAINER_TAGS = setOf("ul", "ol")
+        val CELL_TAGS = setOf("td", "th")
+        val TABLE_SECTION_TAGS = setOf("thead", "tbody", "tfoot")
+        val WHITESPACE_RUN = Regex("""\s+""")
+    }
+}

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/html/HtmlParser.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/editor/core/html/HtmlParser.kt
@@ -48,8 +48,11 @@ import kotlinx.serialization.json.put
  * subset that exporter emits so its output round-trips, plus the synonyms and looseness real-world
  * HTML brings (`<b>`/`<i>`/`<del>`, unclosed `<p>`/`<li>`, tag soup, loose inline content).
  *
- * The import is **lossy but text-safe**: content is never dropped, only demoted. An unknown tag is
- * unwrapped around its content; loose inline content becomes a paragraph. And it is a sanitizer by
+ * The import is **lossy but text-safe**: rendered content is never dropped, only demoted. An
+ * unknown tag is unwrapped around its content; loose inline content becomes a paragraph. The
+ * deliberate exceptions are the elements whose content a browser never renders — `<script>`,
+ * `<style>` and inert `<template>` bodies — which are discarded whole, so the import matches what
+ * the user actually saw on the page. And it is a sanitizer by
  * construction (issue #44): the output is typed nodes, so markup can never pass through verbatim —
  * `<script>`/`<style>` bodies are discarded wholesale, event handlers have nowhere to live, an
  * unsafe-scheme `href` drops its link (the text stays, `ExportHtml.safeHref`'s rule inbound), an
@@ -212,11 +215,9 @@ internal class HtmlParser {
                 val decoded = when {
                     NAMED_ENTITIES.containsKey(entity) -> NAMED_ENTITIES.getValue(entity)
                     entity.startsWith("#x") || entity.startsWith("#X") ->
-                        entity.drop(2).toIntOrNull(16)?.takeIf { it in 1..0x10FFFF }
-                            ?.let { runCatching { it.toChar().toString() }.getOrNull() }
+                        entity.drop(2).toIntOrNull(16)?.let(::codePointToString)
                     entity.startsWith("#") ->
-                        entity.drop(1).toIntOrNull()?.takeIf { it in 1..0x10FFFF }
-                            ?.let { runCatching { it.toChar().toString() }.getOrNull() }
+                        entity.drop(1).toIntOrNull()?.let(::codePointToString)
                     else -> null
                 }
                 if (decoded != null) {
@@ -227,6 +228,22 @@ internal class HtmlParser {
                 }
             }
         }
+    }
+
+    /**
+     * The string for one Unicode code point — a surrogate pair for the supplementary planes,
+     * which `Int.toChar()` would truncate. Lone-surrogate and out-of-range values yield null.
+     */
+    private fun codePointToString(codePoint: Int): String? = when (codePoint) {
+        in 1..0xD7FF, in 0xE000..0xFFFF -> codePoint.toChar().toString()
+        in 0x10000..0x10FFFF -> {
+            val value = codePoint - 0x10000
+            charArrayOf(
+                ((value shr 10) + 0xD800).toChar(),
+                ((value and 0x3FF) + 0xDC00).toChar(),
+            ).concatToString()
+        }
+        else -> null
     }
 
     // ── Tree builder ─────────────────────────────────────────────────────────
@@ -487,10 +504,13 @@ internal class HtmlParser {
 
     private fun span(node: Element, marks: Set<Mark>): List<BaseText> {
         val dataType = node.attrs[DATA_TYPE]
-        if (dataType == MentionType.Mention || dataType == HashtagType.Hashtag) {
+        // A token needs an identity: without a non-blank data-id the span degrades to its plain
+        // text (the visible label, trigger char and all) instead of minting an id-less token.
+        val tokenId = node.attrs[DATA_ID]?.takeIf { it.isNotBlank() }
+        if ((dataType == MentionType.Mention || dataType == HashtagType.Hashtag) && tokenId != null) {
             val trigger = if (dataType == MentionType.Mention) MentionType.DEFAULT_MENTION_CHAR else HashtagType.DEFAULT_HASHTAG_CHAR
             val label = rawText(node).trim().removePrefix(trigger.toString())
-            val attrs = TokenAttrs(id = node.attrs[DATA_ID].orEmpty(), label = label)
+            val attrs = TokenAttrs(id = tokenId, label = label)
             return listOf(
                 if (dataType == MentionType.Mention) Mention(attrs = attrs, marks = marks)
                 else Hashtag(attrs = attrs, marks = marks)

--- a/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
+++ b/shared/src/commonMain/kotlin/com/jjrodcast/textkit/ui/state/TextKitState.kt
@@ -45,6 +45,7 @@ import com.jjrodcast.textkit.editor.components.TextEditorDecoratorItem
 import com.jjrodcast.textkit.editor.components.TextEditorListItem
 import com.jjrodcast.textkit.editor.core.TextKitEditorManager
 import com.jjrodcast.textkit.editor.core.markdown.markdownToJson
+import com.jjrodcast.textkit.editor.core.html.htmlToJson
 import com.jjrodcast.textkit.editor.core.history.EditKind
 import com.jjrodcast.textkit.editor.core.parser.BoldMark
 import com.jjrodcast.textkit.editor.core.parser.HeadingLevels
@@ -491,7 +492,21 @@ class TextKitState(
      * document start.
      */
     fun importMarkdown(markdown: String) {
-        manager.load(markdownToJson(markdown), configuration.viewerMode)
+        importDocumentJson(markdownToJson(markdown))
+    }
+
+    /**
+     * Replaces the whole document with [html], converted through the same HTML subset [toHtml]
+     * emits (#44) — sanitized on the way in: scripts and styles are discarded, unsafe link and
+     * image schemes are dropped. Same contract as [importMarkdown]: like `load`, the swap resets
+     * the undo history, and the caret lands at the document start.
+     */
+    fun importHtml(html: String) {
+        importDocumentJson(htmlToJson(html))
+    }
+
+    private fun importDocumentJson(json: String) {
+        manager.load(json, configuration.viewerMode)
         // Everything anchored to the replaced document is reset: open popups, the pending token
         // query, and the selection-derived formatting-bar state re-read at the new caret.
         tokenState.dismiss()

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlImportTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlImportTest.kt
@@ -1,0 +1,237 @@
+package com.jjrodcast.textkit
+
+import com.jjrodcast.textkit.editor.core.export.HtmlSerializer
+import com.jjrodcast.textkit.editor.core.html.HtmlParser
+import com.jjrodcast.textkit.editor.core.html.htmlToJson
+import com.jjrodcast.textkit.editor.core.parser.Blockquote
+import com.jjrodcast.textkit.editor.core.parser.BoldMark
+import com.jjrodcast.textkit.editor.core.parser.BulletedList
+import com.jjrodcast.textkit.editor.core.parser.EmbedBlock
+import com.jjrodcast.textkit.editor.core.parser.HardBreak
+import com.jjrodcast.textkit.editor.core.parser.Heading
+import com.jjrodcast.textkit.editor.core.parser.HighlightMark
+import com.jjrodcast.textkit.editor.core.parser.ItalicMark
+import com.jjrodcast.textkit.editor.core.parser.LinkMark
+import com.jjrodcast.textkit.editor.core.parser.ListItem
+import com.jjrodcast.textkit.editor.core.parser.Mark
+import com.jjrodcast.textkit.editor.core.parser.Mention
+import com.jjrodcast.textkit.editor.core.parser.OrderedList
+import com.jjrodcast.textkit.editor.core.parser.Paragraph
+import com.jjrodcast.textkit.editor.core.parser.StrikeMark
+import com.jjrodcast.textkit.editor.core.parser.TaskList
+import com.jjrodcast.textkit.editor.core.parser.Text
+import com.jjrodcast.textkit.editor.core.parser.TextAlign
+import com.jjrodcast.textkit.editor.core.parser.TextStyleMark
+import com.jjrodcast.textkit.editor.core.parser.UnderlineMark
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The HTML importer (#44): the exporter's subset inverted, plus real-world synonyms and tag-soup
+ * recovery, sanitizing on the way in. The fixed-point tests assert that for exporter-canonical
+ * HTML, `export(parse(H)) == H` — every structure the two sides share survives a full round trip.
+ */
+class HtmlImportTest {
+
+    private fun parse(html: String) = HtmlParser().parse(html)
+
+    private fun firstParagraph(html: String): Paragraph =
+        assertIs<Paragraph>(parse(html).content.first())
+
+    // ── Blocks ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun block_tags_map_to_their_nodes() {
+        val doc = parse("<h2>Title</h2><p>body</p><blockquote><p>quoted</p></blockquote>")
+        assertEquals(2, assertIs<Heading>(doc.content[0]).attrs.level)
+        assertIs<Paragraph>(doc.content[1])
+        assertIs<Paragraph>(assertIs<Blockquote>(doc.content[2]).content.single())
+    }
+
+    @Test
+    fun lists_map_with_start_and_task_state() {
+        val doc = parse(
+            "<ul><li>a</li><li>b</li></ul>" +
+                "<ol start=\"3\"><li>c</li></ol>" +
+                "<ul data-type=\"taskList\">" +
+                "<li data-type=\"taskItem\" data-checked=\"true\"><input type=\"checkbox\" checked><p>done</p></li>" +
+                "<li data-type=\"taskItem\" data-checked=\"false\"><input type=\"checkbox\"><p>open</p></li>" +
+                "</ul>"
+        )
+        assertEquals(2, assertIs<BulletedList>(doc.content[0]).content.size)
+        assertEquals(3, assertIs<OrderedList>(doc.content[1]).attrs.start)
+        val tasks = assertIs<TaskList>(doc.content[2])
+        assertTrue(tasks.items[0].attrs.checked)
+        assertTrue(!tasks.items[1].attrs.checked)
+    }
+
+    @Test
+    fun unclosed_p_and_li_recover_like_a_browser() {
+        val doc = parse("<p>one<p>two<ul><li>a<li>b</ul>")
+        assertEquals("one", (assertIs<Paragraph>(doc.content[0]).content.single() as Text).text)
+        assertEquals("two", (assertIs<Paragraph>(doc.content[1]).content.single() as Text).text)
+        assertEquals(2, assertIs<BulletedList>(doc.content[2]).content.size)
+    }
+
+    @Test
+    fun loose_inline_content_becomes_a_paragraph() {
+        val doc = parse("just <b>text</b> at the root")
+        val p = assertIs<Paragraph>(doc.content.single())
+        assertEquals(setOf<Mark>(BoldMark()), (p.content[1] as Text).marks)
+    }
+
+    @Test
+    fun a_table_becomes_the_editor_table_embed() {
+        val doc = parse("<table><thead><tr><th>Name</th></tr></thead><tbody><tr><td colspan=\"2\">Juan</td></tr></tbody></table>")
+        val embed = assertIs<EmbedBlock>(doc.content.single())
+        assertEquals("table", embed.embedType)
+        val raw = embed.raw.toString()
+        assertTrue(raw.contains("tableHeader") && raw.contains("tableCell"))
+        assertTrue(raw.contains("\"colspan\":2"))
+    }
+
+    @Test
+    fun pre_code_becomes_the_code_embed_with_language() {
+        val doc = parse("<pre><code class=\"language-kotlin\">val x = 1\nval y = 2</code></pre>")
+        val embed = assertIs<EmbedBlock>(doc.content.single())
+        assertEquals("codeBlock", embed.embedType)
+        assertTrue(embed.raw.toString().contains("language-kotlin").not())
+        assertTrue(embed.raw.toString().contains("\"language\":\"kotlin\""))
+        assertTrue(embed.raw.toString().contains("val x = 1\\nval y = 2"))
+    }
+
+    @Test
+    fun alignment_round_trips_from_the_style_attribute() {
+        val p = firstParagraph("<p style=\"text-align:center\">centered</p>")
+        assertEquals(TextAlign.Center, p.attrs.textAlign)
+    }
+
+    // ── Inline ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun mark_tags_and_their_synonyms_map_and_adjacent_runs_merge() {
+        // the synonym pairs produce identical marks, so their runs merge seamlessly
+        val p = firstParagraph("<p><strong>s</strong><b>b</b><em>e</em><i>i</i><u>u</u><s>st</s><del>d</del><mark>m</mark></p>")
+        assertEquals(
+            listOf("sb" to BoldMark() as Mark, "ei" to ItalicMark(), "u" to UnderlineMark(), "std" to StrikeMark(), "m" to HighlightMark()),
+            p.content.map { (it as Text).text to it.marks.single() },
+        )
+    }
+
+    @Test
+    fun links_spans_and_breaks_map() {
+        val p = firstParagraph("<p><a href=\"https://example.com\">go</a><br><span style=\"color:#ff0000;font-size:18px\">red</span></p>")
+        assertEquals("https://example.com", ((p.content[0] as Text).marks.single() as LinkMark).attrs.href)
+        assertIs<HardBreak>(p.content[1])
+        val style = (p.content[2] as Text).marks.single() as TextStyleMark
+        assertEquals("#ff0000", style.attrs.color)
+        assertEquals(18, style.attrs.fontSize)
+    }
+
+    @Test
+    fun tokens_keep_their_identity() {
+        val p = firstParagraph("<p><span data-type=\"mention\" data-id=\"u1\">@ana</span></p>")
+        val mention = assertIs<Mention>(p.content.single())
+        assertEquals("u1", mention.attrs.id)
+        assertEquals("ana", mention.attrs.label)
+    }
+
+    @Test
+    fun entities_decode_and_adjacent_runs_merge() {
+        val p = firstParagraph("<p>a &amp; b &lt;c&gt; &#233; &#x41;</p>")
+        assertEquals("a & b <c> é A", (p.content.single() as Text).text)
+    }
+
+    // ── Sanitization ─────────────────────────────────────────────────────────
+
+    @Test
+    fun scripts_styles_and_unsafe_schemes_are_neutralized() {
+        val doc = parse(
+            "<script>alert('x')</script><style>p{}</style>" +
+                "<p onclick=\"evil()\"><a href=\"javascript:alert(1)\">still text</a></p>" +
+                "<img src=\"javascript:bad()\" alt=\"the alt\">"
+        )
+        assertEquals(2, doc.content.size)
+        val linkless = assertIs<Paragraph>(doc.content[0]).content.single() as Text
+        assertEquals("still text", linkless.text)
+        assertTrue(linkless.marks.isEmpty(), "unsafe link must drop, keeping the text")
+        assertEquals("the alt", (assertIs<Paragraph>(doc.content[1]).content.single() as Text).text)
+        assertTrue(!htmlToJson("<script>alert('x')</script>").contains("alert"))
+    }
+
+    // ── Integration ──────────────────────────────────────────────────────────
+
+    @Test
+    fun the_imported_json_loads_into_the_editor() {
+        val e = editorFrom(htmlToJson("<h1>Title</h1><p><b>bold</b> body</p><ul><li>item</li></ul>"))
+        assertTrue(e.text.contains("Title"))
+        assertTrue(e.text.contains("bold"))
+        assertTrue(e.text.contains("item"))
+        assertEquals(e.toJson(), editorFrom(e.toJson()).toJson())
+    }
+
+    // ── Round trip ───────────────────────────────────────────────────────────
+
+    /** For exporter-canonical HTML, parse → export must be the identity. */
+    private fun assertFixedPoint(html: String) {
+        assertEquals(html, HtmlSerializer().serialize(parse(html)), "fixed point broken for:\n$html")
+    }
+
+    @Test
+    fun canonical_html_is_a_fixed_point_of_parse_then_export() {
+        assertFixedPoint("<p>plain</p>")
+        assertFixedPoint("<h3>Heading</h3>")
+        assertFixedPoint("<p style=\"text-align:center\">centered</p>")
+        assertFixedPoint("<p><strong>b</strong><em>i</em><u>u</u><s>s</s><mark>m</mark></p>")
+        assertFixedPoint("<p><a href=\"https://example.com\">link</a></p>")
+        assertFixedPoint("<p><span style=\"color:#ff0000;font-size:18px\">styled</span></p>")
+        assertFixedPoint("<ul><li><p>one</p></li><li><p>two</p></li></ul>")
+        assertFixedPoint("<ol start=\"3\"><li><p>c</p></li></ol>")
+        assertFixedPoint("<ul data-type=\"taskList\"><li data-type=\"taskItem\" data-checked=\"true\"><input type=\"checkbox\" checked><p>do</p></li></ul>")
+        assertFixedPoint("<blockquote><p>quoted</p></blockquote>")
+        assertFixedPoint("<p>a<br>b</p>")
+        assertFixedPoint("<img src=\"https://example.com/a.png\" alt=\"alt\">")
+        assertFixedPoint("<p><span data-type=\"mention\" data-id=\"u1\">@ana</span></p>")
+        assertFixedPoint("<div data-type=\"document\" data-id=\"doc-1\"></div>")
+    }
+
+    @Test
+    fun an_exported_document_survives_import_and_re_export() {
+        val e = editorFrom(
+            """{"type":"doc","content":[
+              {"type":"paragraph","content":[{"type":"text","text":"intro "},{"type":"text","text":"bold","marks":[{"type":"bold"}]}]},
+              {"type":"blockquote","content":[{"type":"paragraph","content":[{"type":"text","text":"quoted"}]}]},
+              {"type":"orderedList","attrs":{"start":1},"content":[
+                {"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"first"}]}]}
+              ]},
+              {"type":"taskList","content":[
+                {"type":"taskItem","attrs":{"checked":true},"content":[{"type":"paragraph","content":[{"type":"text","text":"do"}]}]}
+              ]}
+            ]}"""
+        )
+        val html = e.toHtml()
+        assertEquals(html, HtmlSerializer().serialize(parse(html)))
+    }
+
+    /** The importer is a boundary: anything in, no throw, output always loads. */
+    @Test
+    fun hostile_input_never_throws_and_always_loads() {
+        val alphabet = "ab <>/=\"'&;#pulih123!-\n\t"
+        for (seed in 0 until 500) {
+            val rng = kotlin.random.Random(seed)
+            val garbage = buildString { repeat(rng.nextInt(100)) { append(alphabet[rng.nextInt(alphabet.length)]) } }
+            val json = try {
+                htmlToJson(garbage)
+            } catch (t: Throwable) {
+                throw AssertionError("parser threw at seed=$seed input='${garbage.replace("\n", "\\n")}'", t)
+            }
+            try {
+                editorFrom(json)
+            } catch (t: Throwable) {
+                throw AssertionError("import output failed to load at seed=$seed input='${garbage.replace("\n", "\\n")}'", t)
+            }
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlImportTest.kt
+++ b/shared/src/commonTest/kotlin/com/jjrodcast/textkit/HtmlImportTest.kt
@@ -142,6 +142,16 @@ class HtmlImportTest {
     fun entities_decode_and_adjacent_runs_merge() {
         val p = firstParagraph("<p>a &amp; b &lt;c&gt; &#233; &#x41;</p>")
         assertEquals("a & b <c> é A", (p.content.single() as Text).text)
+        // supplementary-plane references need a surrogate pair, not a truncated char
+        assertEquals("😀", (firstParagraph("<p>&#x1F600;</p>").content.single() as Text).text)
+        // a lone surrogate reference is invalid and stays literal
+        assertEquals("&#xD800;", (firstParagraph("<p>&#xD800;</p>").content.single() as Text).text)
+    }
+
+    @Test
+    fun a_token_span_without_an_id_degrades_to_its_text() {
+        val p = firstParagraph("<p><span data-type=\"mention\">@ana</span></p>")
+        assertEquals("@ana", (p.content.single() as Text).text)
     }
 
     // ── Sanitization ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #44, built on the two decisions you made there: a hand-rolled parser for our supported subset (no external libraries), and `ExportHtml`'s rules governing inbound sanitization.

**The parser** (`HtmlParser`, zero dependencies) is a tolerant tag-soup parser with browser-style recovery: void elements, auto-closing `<p>`/`<li>`/table cells, stray close tags ignored, comments and doctypes skipped, entities decoded (named + numeric). `<script>`/`<style>` bodies are discarded wholesale at the tokenizer level. `htmlToJson(html)` is the entry point; `TextKitEditorManager.loadHtml` and `TextKitState.importHtml` mirror the Markdown APIs (same contract: replace the document, history resets like `load`).

**The mapping** is the issue's table, inverted from `HtmlSerializer`, plus what the schema grew since July: `p`/`h1–h6` (with `text-align`), `blockquote`, `ul`/`ol[start]`/`li`, `ul[data-type=taskList]` with `data-checked` or a checked `<input>`, `table` (including `thead`/`tbody` sections, `colspan`/`rowspan`) → the table embed, `img` → the image embed, `pre>code[class=language-*]` → the `codeBlock` embed, mark tags with their real-world synonyms (`strong`/`b`, `em`/`i`, `s`/`del`/`strike`, `u`/`ins`, `mark`), `a[href]`, `span[style]` re-parsed into a validated `textStyle`, and `span[data-type=mention|hashtag][data-id]` restoring token identity. Everything else is lossy-but-text-safe: unknown tags unwrap around their content, loose inline content becomes a paragraph, adjacent same-mark runs merge seamlessly.

**Sanitization, per your second answer:** the output is typed nodes, so markup can never pass through verbatim — event handlers have nowhere to live. `ExportHtml.safeHref` applies inbound: an unsafe-scheme link drops its mark but keeps the text, an unsafe `img src` degrades to the alt text, and `style` values are re-parsed through `safeColor`/font-size validation rather than carried as CSS.

**Tests** (16): per-construct mappings, browser-recovery cases, the sanitizer suite (script/style/`javascript:`/`onclick`), an editor-load integration check, a seeded 500-case fuzz (never throws, output always loads), and the anchoring property — **for exporter-canonical HTML, `export(parse(H)) == H`**, asserted across every shared construct and on a full document exported by the editor itself. Full suite green on jvm, js, and wasmJs; iOS compiles.
